### PR TITLE
It now compiles with latest go release

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,7 +149,7 @@ func (q *Query) Query() os.Error {
 	if handler == nil {
 		handler = DefaultQueryMux
 	}
-forever:
+//forever:
 	for {
 		select {
 		case in := <-q.ChannelQuery:
@@ -314,7 +314,7 @@ func (w *reply) Send(m *Msg) os.Error {
 			return ErrNoSig
 		}
 		m, _ = TsigGenerate(m, w.Client().TsigSecret[secret], w.tsigRequestMAC, w.tsigTimersOnly)
-                w.tsigRequestMAC = m.Extra[len(m.Extra)-1].(*RR_TSIG).MAC        // Safe the requestMAC
+		w.tsigRequestMAC = m.Extra[len(m.Extra)-1].(*RR_TSIG).MAC // Safe the requestMAC
 	}
 	out, ok := m.Pack()
 	if !ok {
@@ -336,7 +336,7 @@ func (w *reply) writeClient(p []byte) (n int, err os.Error) {
 		panic("c.Net empty")
 	}
 
-	conn, err := net.Dial(c.Net, "", w.addr)
+	conn, err := net.Dial(c.Net, w.addr)
 	if err != nil {
 		return 0, err
 	}

--- a/clientconfig.go
+++ b/clientconfig.go
@@ -17,24 +17,24 @@ import (
 
 // Wrap the contents of the /etc/resolv.conf.
 type ClientConfig struct {
-        Servers  []string            // servers to use
-        Search   []string            // suffixes to append to local name
-        Port     string              // what port to use
-        Ndots    int                 // number of dots in name to trigger absolute lookup
-        Timeout  int                 // seconds before giving up on packet
-        Attempts int                 // lost packets before giving up on server
+	Servers  []string // servers to use
+	Search   []string // suffixes to append to local name
+	Port     string   // what port to use
+	Ndots    int      // number of dots in name to trigger absolute lookup
+	Timeout  int      // seconds before giving up on packet
+	Attempts int      // lost packets before giving up on server
 }
 
 // See resolv.conf(5) on a Linux machine.
 // Parse a /etc/resolv.conf like file and return a filled out ClientConfig. Note
 // that all nameservers will have the port number appendend (:53)
 func ClientConfigFromFile(conf string) (*ClientConfig, os.Error) {
-	file, err := os.Open(conf, os.O_RDONLY, 0)
+	file, err := os.Open(conf)
 	defer file.Close()
 	if err != nil {
 		return nil, err
 	}
-        c := new(ClientConfig)
+	c := new(ClientConfig)
 	b := bufio.NewReader(file)
 	c.Servers = make([]string, 3)[0:0] // small, but the standard limit
 	c.Search = make([]string, 0)

--- a/server.go
+++ b/server.go
@@ -190,7 +190,7 @@ func (srv *Server) ListenAndServe() os.Error {
 	}
 	switch srv.Net {
 	case "tcp":
-		a, e := net.ResolveTCPAddr(addr)
+		a, e := net.ResolveTCPAddr("tcp",addr)
 		if e != nil {
 			return e
 		}
@@ -200,7 +200,7 @@ func (srv *Server) ListenAndServe() os.Error {
 		}
 		return srv.ServeTCP(l)
 	case "udp":
-		a, e := net.ResolveUDPAddr(addr)
+		a, e := net.ResolveUDPAddr("udp",addr)
 		if e != nil {
 			return e
 		}


### PR DESCRIPTION
I'm not entirely sure it works, I didn't fix the tests yet, but it's better than nothing.

1) Ran gofix on all files.
2) Added "tcp" and "udp" to Resolve\* functions in server.go
3) Generated primes to the primes array and not to two predefined
   struct members (P and Q), since now rsa support multi-factor primes.
