### PR TITLE
RRsetDeleteRR must set TTL to 0 otherwise BIND rejects with "FORMERR"

### DIFF
--- a/update.go
+++ b/update.go
@@ -176,5 +176,6 @@ func (u *Update) RRsetDeleteRR(rr []RR) {
 	for i, r := range rr {
 		u.Ns[i] = r
 		u.Ns[i].Header().Class = ClassNONE
+		u.Ns[i].Header().Ttl = 0
 	}
 }


### PR DESCRIPTION
The file named/update.c.html in the BIND project tests the TTL immediately after seeing that "update_class == dns_rdataclass_none".  See also http://www.fiveanddime.net/bind-9/bind-9.3.1/bin/named/update.c.html and search for the above conditional.
