### PR TITLE
initial stab at edns update lease http://files.dns-sd.org/draft-sekar-dn...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -87,6 +87,7 @@ be build with: `make -C ex`, or also with the `go` tool.
 * 5936 - AXFR
 * 6605 - ECDSA
 * xxxx - URI record (draft)
+* xxxx - Dns Update Lease (draft)
 
 ## Loosely based upon
 

--- a/msg.go
+++ b/msg.go
@@ -699,6 +699,11 @@ func unpackStructValue(val reflect.Value, msg []byte, off int) (off1 int, err er
 					e.unpack(msg[off1 : off1+int(optlen)])
 					edns = append(edns, e)
 					off = off1 + int(optlen)
+				case EDNS0UPDATELEASE:
+					e := new(EDNS0_UPDATE_LEASE)
+					e.unpack(msg[off1 : off1+int(optlen)])
+					edns = append(edns, e)
+					off = off1 + int(optlen)
 				}
 				fv.Set(reflect.ValueOf(edns))
 				// multiple EDNS codes?


### PR DESCRIPTION
Initial pass for supporting edns update leases http://files.dns-sd.org/draft-sekar-dns-ul.txt

Includes an example how to use it in the test case, but the test case does not actually do anything -- because it would need a server to test against. 
