### PR TITLE
Use SourceNetmask to truncate IP addresses in EDNS-CLIENT-SUBNET packets

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -227,6 +227,11 @@ func (e *EDNS0_SUBNET) pack() ([]byte, error) {
 			}
 			ip[i] = a[i]
 		}
+		needLength := e.SourceNetmask / 8
+		if e.SourceNetmask%8 > 0 {
+			needLength++
+		}
+		ip = ip[:needLength]
 		b = append(b, ip...)
 	case 2:
 		if e.SourceNetmask > net.IPv6len*8 {
@@ -240,7 +245,11 @@ func (e *EDNS0_SUBNET) pack() ([]byte, error) {
 			}
 			ip[i] = a[i]
 		}
-		// chop off ip a SourceNetmask/8: ip = ip[:e.SourceNetmask/8] ?
+		needLength := e.SourceNetmask / 8
+		if e.SourceNetmask%8 > 0 {
+			needLength++
+		}
+		ip = ip[:needLength]
 		b = append(b, ip...)
 	default:
 		return nil, errors.New("dns: bad address family")


### PR DESCRIPTION
OpenDNS returns SERVFAIL to the client if the address in the EDNS packet
is too long. The spec says to truncate it to the shortest possible address
when the SourceNetmask is applied.
