### PR TITLE
Use true random (crypto/rand) for Id

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -49,6 +49,8 @@ var (
 	ErrAuth      error = &Error{err: "bad authentication"}
 	ErrSoa       error = &Error{err: "no SOA"}
 	ErrRRset     error = &Error{err: "bad rrset"}
+
+	maxId = big.NewInt(0xFFFF)
 )
 
 // A manually-unpacked version of (id, bits).
@@ -1456,7 +1458,7 @@ func compressionHelper(c map[string]int, s string) {
 // Id return a 16 bits true random number to be used as a
 // message id.
 func Id() uint16 {
-	id, err := rand.Int(rand.Reader, big.NewInt(0xFFFF))
+	id, err := rand.Int(rand.Reader, maxId)
 	if err != nil {
 		panic(fmt.Sprintf("Cannot generate random id: %s", err))
 	}


### PR DESCRIPTION
Using math/rand for this seems to be insecure. See http://tools.ietf.org/html/rfc5452
It might also make sense to revisit the source port generation if it's random enough. I've added a similar patch to https://code.google.com/p/go/issues/detail?id=5767
