### PR TITLE
Do not fail AXFR if first anwser is just SOA

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -69,6 +69,12 @@ func (w *reply) axfrIn(q *Msg, c chan *Envelope) {
 				return
 			}
 			first = !first
+			// only one answer that is SOA, receive more
+			if (len(in.Answer) == 1) {
+				w.tsigTimersOnly = true
+				c <- &Envelope{in.Answer, nil}
+				continue
+			}
 		}
 
 		if !first {


### PR DESCRIPTION
I have a case where first axfr reply has only one record (SOA), current logic terminates rest of the transfer
 since `checkXfrSOA(in, false)` returns true for just 1 SOA record in the answer.
