### PR TITLE
Fix for typo in message in zscan_rr

### DIFF
--- a/zscan_rr.go
+++ b/zscan_rr.go
@@ -1360,7 +1360,7 @@ func setWKS(h RR_Header, c chan lex, f string) (RR, *ParseError, string) {
 	l := <-c
 	rr.Address = net.ParseIP(l.token)
 	if rr.Address == nil {
-		return nil, &ParseError{f, "bad WKS Adress", l}, ""
+		return nil, &ParseError{f, "bad WKS Address", l}, ""
 	}
 
 	<-c // _BLANK


### PR DESCRIPTION
Adress is spelled with an insufficient number of ds.
