### PR TITLE
Support the new RFC6891 EDNS0 SUBNET option code

### DIFF
--- a/ex/q/q.go
+++ b/ex/q/q.go
@@ -44,6 +44,7 @@ func main() {
 	tcp := flag.Bool("tcp", false, "TCP mode")
 	nsid := flag.Bool("nsid", false, "set edns nsid option")
 	client := flag.String("client", "", "set edns client-subnet option")
+	clientdraftcode := flag.Bool("clientdraft", false, "set edns client-subnet option using the draft option code")
 	//serial := flag.Int("serial", 0, "perform an IXFR with this serial")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options] [@server] [qtype] [qclass] [name ...]\n", os.Args[0])
@@ -177,6 +178,9 @@ Flags:
 		if *client != "" {
 			e := new(dns.EDNS0_SUBNET)
 			e.Code = dns.EDNS0SUBNET
+			if *clientdraftcode {
+				e.DraftOption = true
+			}
 			e.SourceScope = 0
 			e.Address = net.ParseIP(*client)
 			if e.Address == nil {

--- a/msg.go
+++ b/msg.go
@@ -786,11 +786,14 @@ func unpackStructValue(val reflect.Value, msg []byte, off int) (off1 int, err er
 					e.unpack(msg[off1 : off1+int(optlen)])
 					edns = append(edns, e)
 					off = off1 + int(optlen)
-				case EDNS0SUBNET:
+				case EDNS0SUBNET, EDNS0SUBNETDRAFT:
 					e := new(EDNS0_SUBNET)
 					e.unpack(msg[off1 : off1+int(optlen)])
 					edns = append(edns, e)
 					off = off1 + int(optlen)
+					if code == EDNS0SUBNETDRAFT {
+						e.DraftOption = true
+					}
 				case EDNS0UL:
 					e := new(EDNS0_UL)
 					e.unpack(msg[off1 : off1+int(optlen)])


### PR DESCRIPTION
I tried a few variations of keeping support for the draft code. While it feels a little hacky, this version by far gave me the smallest diff and the least changes in my server implementation.
