### PR TITLE
Treat extra bytes in a packet as an error

### DIFF
--- a/dns_test.go
+++ b/dns_test.go
@@ -332,3 +332,37 @@ func TestNoRdataUnpack(t *testing.T) {
 		t.Logf("%s\n", rr)
 	}
 }
+
+func TestUnpackExtraData(t *testing.T) {
+	m := new(Msg)
+	m.Answer = make([]RR, 1)
+	rr := new(A)
+	rr.Hdr = RR_Header{Name: "miek.nl.", Rrtype: TypeA, Class: ClassINET, Ttl: 0}
+	rr.A = net.IPv4(127, 0, 0, 1)
+	m.Answer[0] = rr
+
+	buf, err := m.Pack()
+	if err != nil {
+		t.Log("Packing failed")
+		t.Fail()
+		return
+	}
+
+	err = m.Unpack(buf)
+	if err != nil {
+		t.Log("Unpacking failed")
+		t.Fail()
+		return
+	}
+	err = m.Unpack(append(buf, 'X'))
+	if err == nil {
+		t.Log("Unpacking not failed")
+		t.Fail()
+		return
+	} else {
+		if err.(*Error).err != "extra bytes found in the dns packet" {
+			t.Logf("Wrong error message %#v", err)
+			t.Fail()
+		}
+	}
+}

--- a/msg.go
+++ b/msg.go
@@ -1420,9 +1420,7 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 		}
 	}
 	if off != len(msg) {
-		// TODO(miek) make this an error?
-		// use PackOpt to let people tell how detailed the error reporting should be?
-		// println("dns: extra bytes in dns packet", off, "<", len(msg))
+		return &Error{err: "extra bytes found in the dns packet"}
 	}
 	return nil
 }


### PR DESCRIPTION
It's better to be safe than sorry. A valid packet never has any extra
bytes. A dns packet with extra bytes is clearly malformed and it's
okay to be dropped.
