### PR TITLE
Reduce memory allocations in msg.Copy()

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -1706,20 +1706,31 @@ func (dns *Msg) Copy() *Msg {
 	r1.MsgHdr = dns.MsgHdr
 	r1.Compress = dns.Compress
 
-	r1.Question = make([]Question, len(dns.Question))
-	copy(r1.Question, dns.Question) // TODO(miek): Question is an immutable value, ok to do a shallow-copy
+	if len(dns.Question) > 0 {
+		r1.Question = make([]Question, len(dns.Question))
+		copy(r1.Question, dns.Question) // TODO(miek): Question is an immutable value, ok to do a shallow-copy
+	}
 
-	r1.Answer = make([]RR, len(dns.Answer))
-	for i := 0; i < len(dns.Answer); i++ {
-		r1.Answer[i] = dns.Answer[i].copy()
+	if len(dns.Answer) > 0 {
+		r1.Answer = make([]RR, len(dns.Answer))
+		for i := 0; i < len(dns.Answer); i++ {
+			r1.Answer[i] = dns.Answer[i].copy()
+		}
 	}
-	r1.Ns = make([]RR, len(dns.Ns))
-	for i := 0; i < len(dns.Ns); i++ {
-		r1.Ns[i] = dns.Ns[i].copy()
+
+	if len(dns.Ns) > 0 {
+		r1.Ns = make([]RR, len(dns.Ns))
+		for i := 0; i < len(dns.Ns); i++ {
+			r1.Ns[i] = dns.Ns[i].copy()
+		}
 	}
-	r1.Extra = make([]RR, len(dns.Extra))
-	for i := 0; i < len(dns.Extra); i++ {
-		r1.Extra[i] = dns.Extra[i].copy()
+
+	if len(dns.Extra) > 0 {
+		r1.Extra = make([]RR, len(dns.Extra))
+		for i := 0; i < len(dns.Extra); i++ {
+			r1.Extra[i] = dns.Extra[i].copy()
+		}
 	}
+
 	return r1
 }


### PR DESCRIPTION
Right now we do three memory allocations for RR slices. In theory we can just allocate a single slice. Of course the question is what happens when user does: `msg.Answer = append(msg.Answer, )`.

Alternatively we could set the slices to nil if the length is zero.
