### PR TITLE
must lowercase ownername when computing hash for DS

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -166,7 +166,7 @@ func (k *DNSKEY) ToDS(h int) *DS {
 	wire = wire[:n]
 
 	owner := make([]byte, 255)
-	off, err1 := PackDomainName(k.Hdr.Name, owner, 0, nil, false)
+	off, err1 := PackDomainName(strings.ToLower(k.Hdr.Name), owner, 0, nil, false)
 	if err1 != nil {
 		return nil
 	}


### PR DESCRIPTION
If a resolver returns key with uppercase owner name, then key.ToDS is ran, it will generate an invalid ds record.  Not sure if we should just coerce k.Hdr.Name to lowercase from the getgo, but in the interest of not confusing ways people use things, just lowercase the name prior to hashing for now.
