### PR TITLE
Add support for ResponseWriter.LocalAddr()

### DIFF
--- a/server.go
+++ b/server.go
@@ -489,9 +489,8 @@ func (w *response) Write(m []byte) (int, error) {
 func (w *response) LocalAddr() net.Addr { 
 	if w.tcp != nil {
 		return w.tcp.LocalAddr()
-	} else {
-		return w.udp.LocalAddr()
 	}
+	return w.udp.LocalAddr()
 }
 
 // RemoteAddr implements the ResponseWriter.RemoteAddr method.


### PR DESCRIPTION
This pull request adds the ability to retrieve the local address that the server is bound to from a handler. 

My use case for this is that I have a single ServeMux handling multiple server instances (bound to different IPs/Ports), and I need to identify which IP the request came from.
