### PR TITLE
Correct the DNSKEY flag values

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -70,8 +70,8 @@ const (
 // DNSKEY flag values.
 const (
 	SEP    = 1
-	ZONE   = 1 << 7
-	REVOKE = 1 << 8
+	REVOKE = 1 << 7
+	ZONE   = 1 << 8
 )
 
 // The RRSIG needs to be converted to wireformat with some of


### PR DESCRIPTION
See https://www.iana.org/assignments/dnskey-flags/dnskey-flags.xhtml

Elsewhere in the code 256 (1 << 8) is used numerically for ZONE, so nothing breaks for now.
