### PR TITLE
Fix NewPrivateKey ECDSA parsing, and add test

### DIFF
--- a/dnssec_rfc_test.go
+++ b/dnssec_rfc_test.go
@@ -1,0 +1,161 @@
+// Copyright 2014 CloudFlare. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dns
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Here the test vectors from the relevant RFCs are checked.
+
+// rfc6605 6.1
+func TestRFC6605P256(t *testing.T) {
+	exDNSKEY := `example.net. 3600 IN DNSKEY 257 3 13 (
+                 GojIhhXUN/u4v54ZQqGSnyhWJwaubCvTmeexv7bR6edb
+                 krSqQpF64cYbcB7wNcP+e+MAnLr+Wi9xMWyQLc8NAA== )`
+	exPriv := `Private-key-format: v1.2
+Algorithm: 13 (ECDSAP256SHA256)
+PrivateKey: GU6SnQ/Ou+xC5RumuIUIuJZteXT2z0O/ok1s38Et6mQ=`
+	rrDNSKEY, err := NewRR(exDNSKEY)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	exDS := `example.net. 3600 IN DS 55648 13 2 (
+             b4c8c1fe2e7477127b27115656ad6256f424625bf5c1
+             e2770ce6d6e37df61d17 )`
+	rrDS, err := NewRR(exDS)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA256)
+	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
+		t.Errorf("DS record differs:\n%v\n%v\n", ourDS, rrDS.(*DS))
+	}
+
+	exA := `www.example.net. 3600 IN A 192.0.2.1`
+	exRRSIG := `www.example.net. 3600 IN RRSIG A 13 3 3600 (
+                20100909100439 20100812100439 55648 example.net.
+                qx6wLYqmh+l9oCKTN6qIc+bw6ya+KJ8oMz0YP107epXA
+                yGmt+3SNruPFKG7tZoLBLlUzGGus7ZwmwWep666VCw== )`
+	rrA, err := NewRR(exA)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	rrRRSIG, err := NewRR(exRRSIG)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
+		t.Errorf("Failure to validate the spec RRSIG: %v", err)
+	}
+
+	ourRRSIG := &RRSIG{
+		Hdr: RR_Header{
+			Ttl: rrA.Header().Ttl,
+		},
+		KeyTag:     rrDNSKEY.(*DNSKEY).KeyTag(),
+		SignerName: rrDNSKEY.(*DNSKEY).Hdr.Name,
+		Algorithm:  rrDNSKEY.(*DNSKEY).Algorithm,
+	}
+	ourRRSIG.Expiration, _ = StringToTime("20100909100439")
+	ourRRSIG.Inception, _ = StringToTime("20100812100439")
+	err = ourRRSIG.Sign(priv, []RR{rrA})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err = ourRRSIG.Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
+		t.Errorf("Failure to validate our RRSIG: %v", err)
+	}
+
+	// Signatures are randomized
+	rrRRSIG.(*RRSIG).Signature = ""
+	ourRRSIG.Signature = ""
+	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
+		t.Fatalf("RRSIG record differs:\n%v\n%v\n", ourRRSIG, rrRRSIG.(*RRSIG))
+	}
+}
+
+// rfc6605 6.2
+func TestRFC6605P384(t *testing.T) {
+	exDNSKEY := `example.net. 3600 IN DNSKEY 257 3 14 (
+                 xKYaNhWdGOfJ+nPrL8/arkwf2EY3MDJ+SErKivBVSum1
+                 w/egsXvSADtNJhyem5RCOpgQ6K8X1DRSEkrbYQ+OB+v8
+                 /uX45NBwY8rp65F6Glur8I/mlVNgF6W/qTI37m40 )`
+	exPriv := `Private-key-format: v1.2
+Algorithm: 14 (ECDSAP384SHA384)
+PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
+	rrDNSKEY, err := NewRR(exDNSKEY)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	exDS := `example.net. 3600 IN DS 10771 14 4 (
+           72d7b62976ce06438e9c0bf319013cf801f09ecc84b8
+           d7e9495f27e305c6a9b0563a9b5f4d288405c3008a94
+           6df983d6 )`
+	rrDS, err := NewRR(exDS)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA384)
+	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
+		t.Fatalf("DS record differs:\n%v\n%v\n", ourDS, rrDS.(*DS))
+	}
+
+	exA := `www.example.net. 3600 IN A 192.0.2.1`
+	exRRSIG := `www.example.net. 3600 IN RRSIG A 14 3 3600 (
+           20100909102025 20100812102025 10771 example.net.
+           /L5hDKIvGDyI1fcARX3z65qrmPsVz73QD1Mr5CEqOiLP
+           95hxQouuroGCeZOvzFaxsT8Glr74hbavRKayJNuydCuz
+           WTSSPdz7wnqXL5bdcJzusdnI0RSMROxxwGipWcJm )`
+	rrA, err := NewRR(exA)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	rrRRSIG, err := NewRR(exRRSIG)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
+		t.Errorf("Failure to validate the spec RRSIG: %v", err)
+	}
+
+	ourRRSIG := &RRSIG{
+		Hdr: RR_Header{
+			Ttl: rrA.Header().Ttl,
+		},
+		KeyTag:     rrDNSKEY.(*DNSKEY).KeyTag(),
+		SignerName: rrDNSKEY.(*DNSKEY).Hdr.Name,
+		Algorithm:  rrDNSKEY.(*DNSKEY).Algorithm,
+	}
+	ourRRSIG.Expiration, _ = StringToTime("20100909102025")
+	ourRRSIG.Inception, _ = StringToTime("20100812102025")
+	err = ourRRSIG.Sign(priv, []RR{rrA})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if err = ourRRSIG.Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
+		t.Errorf("Failure to validate our RRSIG: %v", err)
+	}
+
+	// Signatures are randomized
+	rrRRSIG.(*RRSIG).Signature = ""
+	ourRRSIG.Signature = ""
+	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
+		t.Fatalf("RRSIG record differs:\n%v\n%v\n", ourRRSIG, rrRRSIG.(*RRSIG))
+	}
+}

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -6,7 +6,6 @@ package dns
 
 import (
 	"crypto/rsa"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -413,7 +412,7 @@ Activate: 20110302104537`
 	}
 }
 
-func testSignVerifyECDSA(t *testing.T) {
+func TestSignVerifyECDSA(t *testing.T) {
 	pub := `example.net. 3600 IN DNSKEY 257 3 14 (
 	xKYaNhWdGOfJ+nPrL8/arkwf2EY3MDJ+SErKivBVSum1
 	w/egsXvSADtNJhyem5RCOpgQ6K8X1DRSEkrbYQ+OB+v8
@@ -430,14 +429,14 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	//	// Create seperate test for this
-	//	ds := eckey.(*DNSKEY).ToDS(SHA384)
-	//	if ds.KeyTag != 10771 {
-	//		t.Fatal("wrong keytag on DS")
-	//	}
-	//	if ds.Digest != "72d7b62976ce06438e9c0bf319013cf801f09ecc84b8d7e9495f27e305c6a9b0563a9b5f4d288405c3008a946df983d6" {
-	//		t.Fatal("wrong DS Digest")
-	//	}
+	// TODO: Create seperate test for this
+	ds := eckey.(*DNSKEY).ToDS(SHA384)
+	if ds.KeyTag != 10771 {
+		t.Fatal("wrong keytag on DS")
+	}
+	if ds.Digest != "72d7b62976ce06438e9c0bf319013cf801f09ecc84b8d7e9495f27e305c6a9b0563a9b5f4d288405c3008a946df983d6" {
+		t.Fatal("wrong DS Digest")
+	}
 	a, _ := NewRR("www.example.net. 3600 IN A 192.0.2.1")
 	sig := new(RRSIG)
 	sig.Hdr = RR_Header{"example.net.", TypeRRSIG, ClassINET, 14400, 0}
@@ -492,156 +491,9 @@ func TestSignVerifyECDSA2(t *testing.T) {
 	if sig.Sign(privkey, []RR{srv}) != nil {
 		t.Fatal("failure to sign the record")
 	}
-	if sig.Verify(key, []RR{srv}) != nil {
-		t.Fatal("failure to validate")
-	}
-}
 
-// rfc6605 6.1
-func testRFC6605P256(t *testing.T) {
-	exDNSKEY := `example.net. 3600 IN DNSKEY 257 3 13 (
-                 GojIhhXUN/u4v54ZQqGSnyhWJwaubCvTmeexv7bR6edb
-                 krSqQpF64cYbcB7wNcP+e+MAnLr+Wi9xMWyQLc8NAA== )`
-	exPriv := `Private-key-format: v1.2
-Algorithm: 13 (ECDSAP256SHA256)
-PrivateKey: GU6SnQ/Ou+xC5RumuIUIuJZteXT2z0O/ok1s38Et6mQ=`
-	rrDNSKEY, err := NewRR(exDNSKEY)
+	err = sig.Verify(key, []RR{srv})
 	if err != nil {
-		t.Fatal(err.Error())
-	}
-	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	exDS := `example.net. 3600 IN DS 55648 13 2 (
-             b4c8c1fe2e7477127b27115656ad6256f424625bf5c1
-             e2770ce6d6e37df61d17 )`
-	rrDS, err := NewRR(exDS)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA256)
-	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
-		t.Errorf("DS record differs:\n%v\n%v\n", ourDS, rrDS.(*DS))
-	}
-
-	exA := `www.example.net. 3600 IN A 192.0.2.1`
-	exRRSIG := `www.example.net. 3600 IN RRSIG A 13 3 3600 (
-                20100909100439 20100812100439 55648 example.net.
-                qx6wLYqmh+l9oCKTN6qIc+bw6ya+KJ8oMz0YP107epXA
-                yGmt+3SNruPFKG7tZoLBLlUzGGus7ZwmwWep666VCw== )`
-	rrA, err := NewRR(exA)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	rrRRSIG, err := NewRR(exRRSIG)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
-		t.Errorf("Failure to validate the spec RRSIG: %v", err)
-	}
-
-	ourRRSIG := &RRSIG{
-		Hdr: RR_Header{
-			Ttl: rrA.Header().Ttl,
-		},
-		KeyTag:     rrDNSKEY.(*DNSKEY).KeyTag(),
-		SignerName: rrDNSKEY.(*DNSKEY).Hdr.Name,
-		Algorithm:  rrDNSKEY.(*DNSKEY).Algorithm,
-	}
-	ourRRSIG.Expiration, _ = StringToTime("20100909100439")
-	ourRRSIG.Inception, _ = StringToTime("20100812100439")
-	err = ourRRSIG.Sign(priv, []RR{rrA})
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	if err = ourRRSIG.Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
-		t.Errorf("Failure to validate our RRSIG: %v", err)
-	}
-
-	// Signatures are randomized
-	rrRRSIG.(*RRSIG).Signature = ""
-	ourRRSIG.Signature = ""
-	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
-		t.Fatalf("RRSIG record differs:\n%v\n%v\n", ourRRSIG, rrRRSIG.(*RRSIG))
-	}
-}
-
-// rfc6605 6.2
-func testRFC6605P384(t *testing.T) {
-	exDNSKEY := `example.net. 3600 IN DNSKEY 257 3 14 (
-                 xKYaNhWdGOfJ+nPrL8/arkwf2EY3MDJ+SErKivBVSum1
-                 w/egsXvSADtNJhyem5RCOpgQ6K8X1DRSEkrbYQ+OB+v8
-                 /uX45NBwY8rp65F6Glur8I/mlVNgF6W/qTI37m40 )`
-	exPriv := `Private-key-format: v1.2
-Algorithm: 14 (ECDSAP384SHA384)
-PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
-	rrDNSKEY, err := NewRR(exDNSKEY)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	exDS := `example.net. 3600 IN DS 10771 14 4 (
-           72d7b62976ce06438e9c0bf319013cf801f09ecc84b8
-           d7e9495f27e305c6a9b0563a9b5f4d288405c3008a94
-           6df983d6 )`
-	rrDS, err := NewRR(exDS)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA384)
-	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
-		t.Fatalf("DS record differs:\n%v\n%v\n", ourDS, rrDS.(*DS))
-	}
-
-	exA := `www.example.net. 3600 IN A 192.0.2.1`
-	exRRSIG := `www.example.net. 3600 IN RRSIG A 14 3 3600 (
-           20100909102025 20100812102025 10771 example.net.
-           /L5hDKIvGDyI1fcARX3z65qrmPsVz73QD1Mr5CEqOiLP
-           95hxQouuroGCeZOvzFaxsT8Glr74hbavRKayJNuydCuz
-           WTSSPdz7wnqXL5bdcJzusdnI0RSMROxxwGipWcJm )`
-	rrA, err := NewRR(exA)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	rrRRSIG, err := NewRR(exRRSIG)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
-		t.Errorf("Failure to validate the spec RRSIG: %v", err)
-	}
-
-	ourRRSIG := &RRSIG{
-		Hdr: RR_Header{
-			Ttl: rrA.Header().Ttl,
-		},
-		KeyTag:     rrDNSKEY.(*DNSKEY).KeyTag(),
-		SignerName: rrDNSKEY.(*DNSKEY).Hdr.Name,
-		Algorithm:  rrDNSKEY.(*DNSKEY).Algorithm,
-	}
-	ourRRSIG.Expiration, _ = StringToTime("20100909102025")
-	ourRRSIG.Inception, _ = StringToTime("20100812102025")
-	err = ourRRSIG.Sign(priv, []RR{rrA})
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	if err = ourRRSIG.Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
-		t.Errorf("Failure to validate our RRSIG: %v", err)
-	}
-
-	// Signatures are randomized
-	rrRRSIG.(*RRSIG).Signature = ""
-	ourRRSIG.Signature = ""
-	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
-		t.Fatalf("RRSIG record differs:\n%v\n%v\n", ourRRSIG, rrRRSIG.(*RRSIG))
+		t.Fatal("Failure to validate:", err)
 	}
 }

--- a/kscan.go
+++ b/kscan.go
@@ -128,13 +128,13 @@ func readPrivateKeyDSA(m map[string]string) (PrivateKey, error) {
 	p.X = big.NewInt(0)
 	for k, v := range m {
 		switch k {
-		case "private_value(x):":
+		case "private_value(x)":
 			v1, err := packBase64([]byte(v))
 			if err != nil {
 				return nil, err
 			}
 			p.X.SetBytes(v1)
-		case "created:", "publish:", "activate:":
+		case "created", "publish", "activate":
 			/* not used in Go (yet) */
 		}
 	}
@@ -144,16 +144,16 @@ func readPrivateKeyDSA(m map[string]string) (PrivateKey, error) {
 func readPrivateKeyECDSA(m map[string]string) (PrivateKey, error) {
 	p := new(ecdsa.PrivateKey)
 	p.D = big.NewInt(0)
-	// Need to check if we have everything
+	// TODO: validate that the required flags are present
 	for k, v := range m {
 		switch k {
-		case "privatekey:":
+		case "privatekey":
 			v1, err := packBase64([]byte(v))
 			if err != nil {
 				return nil, err
 			}
 			p.D.SetBytes(v1)
-		case "created:", "publish:", "activate:":
+		case "created", "publish", "activate":
 			/* not used in Go (yet) */
 		}
 	}

--- a/kscan_test.go
+++ b/kscan_test.go
@@ -1,0 +1,55 @@
+// Copyright 2014 CloudFlare. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dns
+
+import (
+	"crypto/rsa"
+	"reflect"
+	"testing"
+)
+
+type algorithm struct {
+	name uint8
+	bits int
+}
+
+func TestNewPrivateKeyECDSA(t *testing.T) {
+	algorithms := []algorithm{
+		algorithm{ECDSAP256SHA256, 256},
+		algorithm{ECDSAP384SHA384, 384},
+		algorithm{RSASHA1, 1024},
+		algorithm{RSASHA256, 2048},
+		// algorithm{DSA, 1024},  // TODO: STILL BROKEN!
+	}
+
+	for _, algo := range algorithms {
+		key := new(DNSKEY)
+		key.Hdr.Rrtype = TypeDNSKEY
+		key.Hdr.Name = "miek.nl."
+		key.Hdr.Class = ClassINET
+		key.Hdr.Ttl = 14400
+		key.Flags = 256
+		key.Protocol = 3
+		key.Algorithm = algo.name
+		privkey, err := key.Generate(algo.bits)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		newPrivKey, err := key.NewPrivateKey(key.PrivateKeyString(privkey))
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+
+		switch newPrivKey := newPrivKey.(type) {
+		case *rsa.PrivateKey:
+			newPrivKey.Precompute()
+		}
+
+		if !reflect.DeepEqual(privkey, newPrivKey) {
+			t.Errorf("[%v] Private keys differ:\n%#v\n%#v\n", AlgorithmToString[algo.name], privkey, newPrivKey)
+		}
+	}
+}


### PR DESCRIPTION
The only common denominator of the failing tests was reading a ECDSA PrivateKey from a string.

Turns out the private D wasn't being read at all, due to a `:`. One more one-byte fix ;)

Closes #121 
