### PR TITLE
Add support for extended RCODEs and detect bad RCODEs

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -122,6 +122,16 @@ func (rr *OPT) SetVersion(v uint8) {
 	rr.Hdr.Ttl = rr.Hdr.Ttl&0xFF00FFFF | (uint32(v) << 16)
 }
 
+// ExtRcode returns the EDNS extended RCODE field (the upper 8 bits of the RCODE).
+func (rr *OPT) ExtRcode() uint8 {
+	return uint8((rr.Hdr.Ttl & 0xFF000000) >> 24)
+}
+
+// SetExtRcode sets the EDNS extended RCODE field.
+func (rr *OPT) SetExtRcode(v uint8) {
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | (uint32(v) << 24)
+}
+
 // UDPSize returns the UDP buffer size.
 func (rr *OPT) UDPSize() uint16 {
 	return rr.Hdr.Class

--- a/edns_test.go
+++ b/edns_test.go
@@ -31,4 +31,18 @@ func TestOPTTtl(t *testing.T) {
 	if e.Hdr.Ttl != oldTtl {
 		t.Fail()
 	}
+
+	if e.ExtRcode() != 0 {
+		t.Fail()
+	}
+
+	e.SetExtRcode(42)
+	if e.ExtRcode() != 42 {
+		t.Fail()
+	}
+
+	e.SetExtRcode(0)
+	if e.Hdr.Ttl != oldTtl {
+		t.Fail()
+	}
 }


### PR DESCRIPTION
A too high RCODE previously would have simply corrupted the packet.

Logic put in PackBuffer because Rcode is public and can be changed anytime
