### PR TITLE
Reduce amount of work done when unpacking unprintable characters.

### DIFF
--- a/dns_test.go
+++ b/dns_test.go
@@ -426,6 +426,16 @@ func BenchmarkUnpackDomainName(b *testing.B) {
 	}
 }
 
+func BenchmarkUnpackDomainNameUnprintable(b *testing.B) {
+	name1 := "\x02\x02\x02\x025\x02\x02\x02\x02.12345678.123."
+	buf := make([]byte, len(name1)+1)
+	_, _ = PackDomainName(name1, buf, 0, nil, false)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = UnpackDomainName(buf, 0)
+	}
+}
+
 func TestToRFC3597(t *testing.T) {
 	a, _ := NewRR("miek.nl. IN A 10.0.1.1")
 	x := new(RFC3597)

--- a/msg.go
+++ b/msg.go
@@ -422,7 +422,15 @@ Loop:
 					s = append(s, '\\', 'r')
 				default:
 					if b < 32 || b >= 127 { // unprintable use \DDD
-						s = append(s, fmt.Sprintf("\\%03d", b)...)
+						var buf [3]byte
+						bufs := strconv.AppendInt(buf[:0], int64(b), 10)
+						s = append(s, '\\')
+						for i := 0; i < 3-len(bufs); i++ {
+							s = append(s, '0')
+						}
+						for _, r := range bufs {
+							s = append(s, r)
+						}
 					} else {
 						s = append(s, b)
 					}


### PR DESCRIPTION
Instead of going through the fmt package, we can use append int,
which saves an allocation.

benchmark                                old ns/op     new ns/op     delta
BenchmarkUnpackDomainNameUnprintable     2147          506           -76.43%
