### PR TITLE
Remove extraneous spaces in String() methods

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -652,7 +652,7 @@ moutamassey             NS      ns01.yahoodomains.jp.
 }
 
 func ExampleHIP() {
-	h := `www.example.com      IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
+	h := `www.example.com     IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
                 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p
 9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQ
 b1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D
@@ -661,7 +661,7 @@ b1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D
 		fmt.Printf("%s\n", hip.String())
 	}
 	// Output:
-	// www.example.com.	3600	IN	HIP	 2 200100107B1A74DF365639CC39F1D578 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQb1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D rvs.example.com.
+	// www.example.com.	3600	IN	HIP	2 200100107B1A74DF365639CC39F1D578 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQb1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D rvs.example.com.
 }
 
 func TestHIP(t *testing.T) {

--- a/types.go
+++ b/types.go
@@ -308,7 +308,7 @@ func (rr *MF) copy() RR           { return &MF{*rr.Hdr.copyHeader(), rr.Mf} }
 func (rr *MF) len() int           { return rr.Hdr.len() + len(rr.Mf) + 1 }
 
 func (rr *MF) String() string {
-	return rr.Hdr.String() + " " + sprintName(rr.Mf)
+	return rr.Hdr.String() + sprintName(rr.Mf)
 }
 
 type MD struct {
@@ -321,7 +321,7 @@ func (rr *MD) copy() RR           { return &MD{*rr.Hdr.copyHeader(), rr.Md} }
 func (rr *MD) len() int           { return rr.Hdr.len() + len(rr.Md) + 1 }
 
 func (rr *MD) String() string {
-	return rr.Hdr.String() + " " + sprintName(rr.Md)
+	return rr.Hdr.String() + sprintName(rr.Md)
 }
 
 type MX struct {
@@ -981,7 +981,7 @@ func (rr *TALINK) len() int           { return rr.Hdr.len() + len(rr.PreviousNam
 
 func (rr *TALINK) String() string {
 	return rr.Hdr.String() +
-		" " + sprintName(rr.PreviousName) + " " + sprintName(rr.NextName)
+		sprintName(rr.PreviousName) + " " + sprintName(rr.NextName)
 }
 
 type SSHFP struct {
@@ -1282,7 +1282,7 @@ func (rr *TLSA) copy() RR {
 
 func (rr *TLSA) String() string {
 	return rr.Hdr.String() +
-		" " + strconv.Itoa(int(rr.Usage)) +
+		strconv.Itoa(int(rr.Usage)) +
 		" " + strconv.Itoa(int(rr.Selector)) +
 		" " + strconv.Itoa(int(rr.MatchingType)) +
 		" " + rr.Certificate
@@ -1307,7 +1307,7 @@ func (rr *HIP) copy() RR {
 
 func (rr *HIP) String() string {
 	s := rr.Hdr.String() +
-		" " + strconv.Itoa(int(rr.PublicKeyAlgorithm)) +
+		strconv.Itoa(int(rr.PublicKeyAlgorithm)) +
 		" " + rr.Hit +
 		" " + rr.PublicKey
 	for _, d := range rr.RendezvousServers {


### PR DESCRIPTION
Some types append a space after Hdr.String(). However, since Hdr.String() appends its own space, this leads to the output of two spaces.
