### PR TITLE
add checks to prevent panic when parsing zone text.

### DIFF
--- a/zscan.go
+++ b/zscan.go
@@ -102,12 +102,13 @@ type Token struct {
 	Comment string      // a potential comment positioned after the RR and on the same line
 }
 
-// NewRR reads the RR contained in the string s. Only the first RR is returned.
-// The class defaults to IN and TTL defaults to 3600. The full zone file
-// syntax like $TTL, $ORIGIN, etc. is supported.
-// All fields of the returned RR are set, except RR.Header().Rdlength which is set to 0.
+// NewRR reads the RR contained in the string s. Only the first RR is
+// returned. If s contains no RR, return nil with no error. The class
+// defaults to IN and TTL defaults to 3600. The full zone file syntax
+// like $TTL, $ORIGIN, etc. is supported. All fields of the returned
+// RR are set, except RR.Header().Rdlength which is set to 0.
 func NewRR(s string) (RR, error) {
-	if s[len(s)-1] != '\n' { // We need a closing newline
+	if len(s) > 0 && s[len(s)-1] != '\n' { // We need a closing newline
 		return ReadRR(strings.NewReader(s+"\n"), "")
 	}
 	return ReadRR(strings.NewReader(s), "")
@@ -117,6 +118,10 @@ func NewRR(s string) (RR, error) {
 // See NewRR for more documentation.
 func ReadRR(q io.Reader, filename string) (RR, error) {
 	r := <-parseZoneHelper(q, ".", filename, 1)
+	if r == nil {
+		return nil, nil
+	}
+
 	if r.Error != nil {
 		return nil, r.Error
 	}

--- a/zscan_test.go
+++ b/zscan_test.go
@@ -1,0 +1,66 @@
+package dns
+
+import "testing"
+
+// special input test
+func TestNewRRSpecial(t *testing.T) {
+	var (
+		rr     RR
+		err    error
+		expect string
+	)
+
+	rr, err = NewRR("; comment")
+	expect = ""
+	if err != nil {
+		t.Errorf("unexpect err: %s", err)
+	}
+	if rr != nil {
+		t.Errorf("unexpect result: [%s] != [%s]", rr, expect)
+	}
+
+	rr, err = NewRR("")
+	expect = ""
+	if err != nil {
+		t.Errorf("unexpect err: %s", err)
+	}
+	if rr != nil {
+		t.Errorf("unexpect result: [%s] != [%s]", rr, expect)
+	}
+
+	rr, err = NewRR("$ORIGIN foo.")
+	expect = ""
+	if err != nil {
+		t.Errorf("unexpect err: %s", err)
+	}
+	if rr != nil {
+		t.Errorf("unexpect result: [%s] != [%s]", rr, expect)
+	}
+
+	rr, err = NewRR(" ")
+	expect = ""
+	if err != nil {
+		t.Errorf("unexpect err: %s", err)
+	}
+	if rr != nil {
+		t.Errorf("unexpect result: [%s] != [%s]", rr, expect)
+	}
+
+	rr, err = NewRR("\n")
+	expect = ""
+	if err != nil {
+		t.Errorf("unexpect err: %s", err)
+	}
+	if rr != nil {
+		t.Errorf("unexpect result: [%s] != [%s]", rr, expect)
+	}
+
+	rr, err = NewRR("foo. A 1.1.1.1\nbar. A 2.2.2.2")
+	expect = "foo.\t3600\tIN\tA\t1.1.1.1"
+	if err != nil {
+		t.Errorf("unexpect err: %s", err)
+	}
+	if rr == nil || rr.String() != expect {
+		t.Errorf("unexpect result: [%s] != [%s]", rr, expect)
+	}
+}


### PR DESCRIPTION
Empty text or comments in zone format will cause panics. Also add a description.