### PR TITLE
client: c.exchange: receive multiple messages and combine into one

### DIFF
--- a/client.go
+++ b/client.go
@@ -154,7 +154,18 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 		return nil, 0, err
 	}
 	r, err = co.ReadMsg()
-	return r, co.rtt, err
+	rtt = co.rtt
+	for {
+		p, err := co.ReadMsg()
+		if err != nil {
+			break
+		}
+		r.Answer = append(r.Answer, p.Answer...)
+		r.Ns = append(r.Ns, p.Ns...)
+		r.Extra = append(r.Extra, p.Extra...)
+		rtt += co.rtt
+	}
+	return r, rtt, err
 }
 
 // ReadMsg reads a message from the connection co.


### PR DESCRIPTION
We combine the answers into a single *Msg because `c.Exchange` API returns a single *Msg. For exactness with the server, it would be better if we could return the list of *Msg received.

Alternatively `*Client` could expose the underlying `*Conn` and the caller could call `co.ReadMsg` itself if it wants more than the first message replied by `c.Exchange`. Unfortunately, `c.exchange` [closes](https://github.com/miekg/dns/blob/master/client.go#L142) the conn after use, so we can't.

I did not modify the other `Exchange` functions, I don't know if you wish to do so. This can be done in a separate change anyway.

Fixes #167