### PR TITLE
Convert tests from being t.Log(..) then t.Fail() to just t.Error(...)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -21,24 +21,20 @@ func TestClientSync(t *testing.T) {
 	c := new(Client)
 	r, _, e := c.Exchange(m, addrstr)
 	if e != nil {
-		t.Logf("failed to exchange: %s", e.Error())
-		t.Fail()
+		t.Errorf("failed to exchange: %s", e.Error())
 	}
 	if r != nil && r.Rcode != RcodeSuccess {
-		t.Log("failed to get an valid answer")
-		t.Fail()
-		t.Logf("%v\n", r)
+		t.Error("failed to get an valid answer")
+		t.Errorf("%v\n", r)
 	}
 	// And now with plain Exchange().
 	r, e = Exchange(m, addrstr)
 	if e != nil {
-		t.Logf("failed to exchange: %s", e.Error())
-		t.Fail()
+		t.Errorf("failed to exchange: %s", e.Error())
 	}
 	if r != nil && r.Rcode != RcodeSuccess {
-		t.Log("failed to get an valid answer")
-		t.Fail()
-		t.Logf("%v\n", r)
+		t.Error("failed to get an valid answer")
+		t.Errorf("%v\n", r)
 	}
 }
 
@@ -60,14 +56,12 @@ func TestClientEDNS0(t *testing.T) {
 	c := new(Client)
 	r, _, e := c.Exchange(m, addrstr)
 	if e != nil {
-		t.Logf("failed to exchange: %s", e.Error())
-		t.Fail()
+		t.Errorf("failed to exchange: %s", e.Error())
 	}
 
 	if r != nil && r.Rcode != RcodeSuccess {
-		t.Log("failed to get an valid answer")
-		t.Fail()
-		t.Logf("%v\n", r)
+		t.Error("failed to get an valid answer")
+		t.Errorf("%v\n", r)
 	}
 }
 
@@ -106,8 +100,7 @@ Loop:
 				first = rtt
 			} else {
 				if first != rtt {
-					t.Log("all rtts should be equal")
-					t.Fail()
+					t.Error("all rtts should be equal")
 				}
 			}
 			i++
@@ -142,7 +135,6 @@ func ExampleUpdateLeaseTSIG(t *testing.T) {
 
 	_, _, err := c.Exchange(m, "127.0.0.1:53")
 	if err != nil {
-		t.Log(err.Error())
-		t.Fail()
+		t.Error(err.Error())
 	}
 }

--- a/dns_test.go
+++ b/dns_test.go
@@ -17,13 +17,11 @@ func TestPackUnpack(t *testing.T) {
 	out.Answer[0] = key
 	msg, err := out.Pack()
 	if err != nil {
-		t.Log("failed to pack msg with DNSKEY")
-		t.Fail()
+		t.Error("failed to pack msg with DNSKEY")
 	}
 	in := new(Msg)
 	if in.Unpack(msg) != nil {
-		t.Log("failed to unpack msg with DNSKEY")
-		t.Fail()
+		t.Error("failed to unpack msg with DNSKEY")
 	}
 
 	sig := new(RRSIG)
@@ -35,13 +33,11 @@ func TestPackUnpack(t *testing.T) {
 	out.Answer[0] = sig
 	msg, err = out.Pack()
 	if err != nil {
-		t.Log("failed to pack msg with RRSIG")
-		t.Fail()
+		t.Error("failed to pack msg with RRSIG")
 	}
 
 	if in.Unpack(msg) != nil {
-		t.Log("failed to unpack msg with RRSIG")
-		t.Fail()
+		t.Error("failed to unpack msg with RRSIG")
 	}
 }
 
@@ -62,8 +58,7 @@ func TestPackUnpack2(t *testing.T) {
 	m.Answer[0] = rr
 	_, err := m.Pack()
 	if err != nil {
-		t.Log("Packing failed: " + err.Error())
-		t.Fail()
+		t.Error("Packing failed: ", err.Error())
 		return
 	}
 }
@@ -90,16 +85,14 @@ func TestPackUnpack3(t *testing.T) {
 	m.Answer[0] = rr
 	b, err := m.Pack()
 	if err != nil {
-		t.Log("packing failed: " + err.Error())
-		t.Fail()
+		t.Error("packing failed: " + err.Error())
 		return
 	}
 
 	var unpackMsg Msg
 	err = unpackMsg.Unpack(b)
 	if err != nil {
-		t.Log("unpacking failed")
-		t.Fail()
+		t.Error("unpacking failed")
 		return
 	}
 }
@@ -111,10 +104,9 @@ func TestBailiwick(t *testing.T) {
 	}
 	for parent, child := range yes {
 		if !IsSubDomain(parent, child) {
-			t.Logf("%s should be child of %s\n", child, parent)
-			t.Logf("comparelabels %d", CompareDomainName(parent, child))
-			t.Logf("lenlabels %d %d", CountLabel(parent), CountLabel(child))
-			t.Fail()
+			t.Errorf("%s should be child of %s\n", child, parent)
+			t.Errorf("comparelabels %d", CompareDomainName(parent, child))
+			t.Errorf("lenlabels %d %d", CountLabel(parent), CountLabel(child))
 		}
 	}
 	no := map[string]string{
@@ -126,10 +118,9 @@ func TestBailiwick(t *testing.T) {
 	}
 	for parent, child := range no {
 		if IsSubDomain(parent, child) {
-			t.Logf("%s should not be child of %s\n", child, parent)
-			t.Logf("comparelabels %d", CompareDomainName(parent, child))
-			t.Logf("lenlabels %d %d", CountLabel(parent), CountLabel(child))
-			t.Fail()
+			t.Errorf("%s should not be child of %s\n", child, parent)
+			t.Errorf("comparelabels %d", CompareDomainName(parent, child))
+			t.Errorf("lenlabels %d %d", CountLabel(parent), CountLabel(child))
 		}
 	}
 }
@@ -142,13 +133,11 @@ func TestPack(t *testing.T) {
 	for _, r := range rr {
 		m.Answer[0], err = NewRR(r)
 		if err != nil {
-			t.Logf("failed to create RR: %s\n", err.Error())
-			t.Fail()
+			t.Errorf("failed to create RR: %s\n", err.Error())
 			continue
 		}
 		if _, err := m.Pack(); err != nil {
-			t.Logf("packing failed: %s\n", err.Error())
-			t.Fail()
+			t.Errorf("packing failed: %s\n", err.Error())
 		}
 	}
 	x := new(Msg)
@@ -160,20 +149,17 @@ func TestPack(t *testing.T) {
 	// This crashes due to the fact the a.ntpns.org isn't a FQDN
 	// How to recover() from a remove panic()?
 	if _, err := x.Pack(); err == nil {
-		t.Log("packing should fail")
-		t.Fail()
+		t.Error("packing should fail")
 	}
 	x.Answer = make([]RR, 1)
 	x.Answer[0], err = NewRR(rr[0])
 	if _, err := x.Pack(); err == nil {
-		t.Log("packing should fail")
-		t.Fail()
+		t.Error("packing should fail")
 	}
 	x.Question = make([]Question, 1)
 	x.Question[0] = Question{";sd#eddddséâèµâââ¥âxzztsestxssweewwsssstx@s@Zåµe@cn.pool.ntp.org.", TypeA, ClassINET}
 	if _, err := x.Pack(); err == nil {
-		t.Log("packing should fail")
-		t.Fail()
+		t.Error("packing should fail")
 	}
 }
 
@@ -186,9 +172,8 @@ func TestPackNAPTR(t *testing.T) {
 		rr, _ := NewRR(n)
 		msg := make([]byte, rr.len())
 		if off, err := PackRR(rr, msg, 0, nil, false); err != nil {
-			t.Logf("packing failed: %s", err.Error())
-			t.Logf("length %d, need more than %d\n", rr.len(), off)
-			t.Fail()
+			t.Errorf("packing failed: %s", err.Error())
+			t.Errorf("length %d, need more than %d\n", rr.len(), off)
 		} else {
 			t.Logf("buf size needed: %d\n", off)
 		}
@@ -229,12 +214,10 @@ func TestMsgCompressLength(t *testing.T) {
 		buf, err := msg.Pack()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		if predicted < len(buf) {
 			t.Errorf("predicted compressed length is wrong: predicted %s (len=%d) %d, actual %d\n",
 				msg.Question[0].Name, len(msg.Answer), predicted, len(buf))
-			t.Fail()
 		}
 	}
 }
@@ -261,12 +244,10 @@ func TestMsgLength(t *testing.T) {
 		buf, err := msg.Pack()
 		if err != nil {
 			t.Error(err)
-			t.Fail()
 		}
 		if predicted < len(buf) {
 			t.Errorf("predicted length is wrong: predicted %s (len=%d), actual %d\n",
 				msg.Question[0].Name, predicted, len(buf))
-			t.Fail()
 		}
 	}
 }
@@ -441,7 +422,7 @@ func TestToRFC3597(t *testing.T) {
 	x := new(RFC3597)
 	x.ToRFC3597(a)
 	if x.String() != `miek.nl.	3600	CLASS1	TYPE1	\# 4 0a000101` {
-		t.Fail()
+		t.Error("string mismatch")
 	}
 }
 
@@ -455,8 +436,7 @@ func TestNoRdataPack(t *testing.T) {
 		*r.Header() = RR_Header{Name: "miek.nl.", Rrtype: typ, Class: ClassINET, Ttl: 3600}
 		_, e := PackRR(r, data, 0, nil, false)
 		if e != nil {
-			t.Logf("failed to pack RR with zero rdata: %s: %s\n", TypeToString[typ], e.Error())
-			t.Fail()
+			t.Errorf("failed to pack RR with zero rdata: %s: %s\n", TypeToString[typ], e.Error())
 		}
 	}
 }
@@ -479,8 +459,7 @@ func TestNoRdataUnpack(t *testing.T) {
 		}
 		rr, _, e := UnpackRR(data[:off], 0)
 		if e != nil {
-			t.Logf("failed to unpack RR with zero rdata: %s: %s\n", TypeToString[typ], e.Error())
-			t.Fail()
+			t.Errorf("failed to unpack RR with zero rdata: %s: %s\n", TypeToString[typ], e.Error())
 		}
 		t.Logf("%s\n", rr)
 	}
@@ -565,15 +544,13 @@ func TestPackIPSECKEY(t *testing.T) {
 		rr, _ := NewRR(t1)
 		off, e := PackRR(rr, buf, 0, nil, false)
 		if e != nil {
-			t.Logf("failed to pack IPSECKEY %s: %s\n", e, t1)
-			t.Fail()
+			t.Errorf("failed to pack IPSECKEY %s: %s\n", e, t1)
 			continue
 		}
 
 		rr, _, e = UnpackRR(buf[:off], 0)
 		if e != nil {
-			t.Logf("failed to unpack IPSECKEY %s: %s\n", e, t1)
-			t.Fail()
+			t.Errorf("failed to unpack IPSECKEY %s: %s\n", e, t1)
 		}
 		t.Logf("%s\n", rr)
 	}
@@ -595,8 +572,7 @@ func TestMsgPackBuffer(t *testing.T) {
 		input, _ := hex.DecodeString(hexData)
 		m := new(Msg)
 		if e := m.Unpack(input); e != nil {
-			t.Logf("packet %d failed to unpack", i)
-			t.Fail()
+			t.Errorf("packet %d failed to unpack", i)
 			continue
 		}
 		t.Logf("packet %d %s\n", i, m.String())

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -109,8 +109,7 @@ func TestSecure(t *testing.T) {
 
 	// It should validate. Period is checked separately, so this will keep on working
 	if sig.Verify(key, []RR{soa}) != nil {
-		t.Log("failure to validate")
-		t.Fail()
+		t.Error("failure to validate")
 	}
 }
 
@@ -131,15 +130,13 @@ func TestSignature(t *testing.T) {
 
 	// Should not be valid
 	if sig.ValidityPeriod(time.Now()) {
-		t.Log("should not be valid")
-		t.Fail()
+		t.Error("should not be valid")
 	}
 
 	sig.Inception = 315565800   //Tue Jan  1 10:10:00 CET 1980
 	sig.Expiration = 4102477800 //Fri Jan  1 10:10:00 CET 2100
 	if !sig.ValidityPeriod(time.Now()) {
-		t.Log("should be valid")
-		t.Fail()
+		t.Error("should be valid")
 	}
 }
 
@@ -196,13 +193,11 @@ func TestSignVerify(t *testing.T) {
 
 	for _, r := range []RR{soa, soa1, srv} {
 		if sig.Sign(privkey, []RR{r}) != nil {
-			t.Log("failure to sign the record")
-			t.Fail()
+			t.Error("failure to sign the record")
 			continue
 		}
 		if sig.Verify(key, []RR{r}) != nil {
-			t.Log("failure to validate")
-			t.Fail()
+			t.Error("failure to validate")
 			continue
 		}
 		t.Logf("validated: %s\n", r.Header().Name)
@@ -234,14 +229,12 @@ func Test65534(t *testing.T) {
 	sig.SignerName = key.Hdr.Name
 	sig.Algorithm = RSASHA256
 	if err := sig.Sign(privkey, []RR{t6}); err != nil {
-		t.Log(err)
-		t.Log("failure to sign the TYPE65534 record")
-		t.Fail()
+		t.Error(err)
+		t.Error("failure to sign the TYPE65534 record")
 	}
 	if err := sig.Verify(key, []RR{t6}); err != nil {
-		t.Log(err)
-		t.Log("failure to validate")
-		t.Fail()
+		t.Error(err)
+		t.Error("failure to validate")
 	} else {
 		t.Logf("validated: %s\n", t6.Header().Name)
 	}
@@ -271,13 +264,11 @@ Coefficient: UuRoNqe7YHnKmQzE6iDWKTMIWTuoqqrFAmXPmKQnC+Y+BQzOVEHUo9bXdDnoI9hzXP1
 		t.Fatal(err)
 	}
 	if pubkey.(*DNSKEY).PublicKey != "AwEAAZuMCu2FdugHkTrXYgl5qixvcDw1aDDlvL46/xJKbHBAHY16fNUb2b65cwko2Js/aJxUYJbZk5dwCDZxYfrfbZVtDPQuc3o8QaChVxC7/JYz2AHc9qHvqQ1j4VrH71RWINlQo6VYjzN/BGpMhOZoZOEwzp1HfsOE3lNYcoWU1smL" {
-		t.Log("pubkey is not what we've read")
-		t.Fail()
+		t.Error("pubkey is not what we've read")
 	}
 	if pubkey.(*DNSKEY).PrivateKeyString(privkey) != privStr {
-		t.Log("privkey is not what we've read")
-		t.Logf("%v", pubkey.(*DNSKEY).PrivateKeyString(privkey))
-		t.Fail()
+		t.Error("privkey is not what we've read")
+		t.Errorf("%v", pubkey.(*DNSKEY).PrivateKeyString(privkey))
 	}
 }
 
@@ -294,8 +285,7 @@ func TestTag(t *testing.T) {
 
 	tag := key.KeyTag()
 	if tag != 12051 {
-		t.Logf("wrong key tag: %d for key %v\n", tag, key)
-		t.Fail()
+		t.Errorf("wrong key tag: %d for key %v\n", tag, key)
 	}
 }
 
@@ -335,13 +325,11 @@ func TestKeyRSA(t *testing.T) {
 	sig.SignerName = key.Hdr.Name
 
 	if err := sig.Sign(priv, []RR{soa}); err != nil {
-		t.Logf("failed to sign")
-		t.Fail()
+		t.Error("failed to sign")
 		return
 	}
 	if err := sig.Verify(key, []RR{soa}); err != nil {
-		t.Logf("failed to verify")
-		t.Fail()
+		t.Error("failed to verify")
 	}
 }
 
@@ -358,8 +346,7 @@ func TestKeyToDS(t *testing.T) {
 
 	ds := key.ToDS(SHA1)
 	if strings.ToUpper(ds.Digest) != "B5121BDB5B8D86D0CC5FFAFBAAABE26C3E20BAC1" {
-		t.Logf("wrong DS digest for SHA1\n%v\n", ds)
-		t.Fail()
+		t.Errorf("wrong DS digest for SHA1\n%v\n", ds)
 	}
 }
 
@@ -384,23 +371,19 @@ Activate: 20110302104537`
 	k := xk.(*DNSKEY)
 	p, err := k.NewPrivateKey(priv)
 	if err != nil {
-		t.Logf("%v\n", err)
-		t.Fail()
+		t.Errorf("%v\n", err)
 	}
 	switch priv := p.(type) {
 	case *RSAPrivateKey:
 		if 65537 != priv.PublicKey.E {
-			t.Log("exponenent should be 65537")
-			t.Fail()
+			t.Error("exponenent should be 65537")
 		}
 	default:
-		t.Logf("we should have read an RSA key: %v", priv)
-		t.Fail()
+		t.Errorf("we should have read an RSA key: %v", priv)
 	}
 	if k.KeyTag() != 37350 {
-		t.Logf("%d %v\n", k.KeyTag(), k)
-		t.Log("keytag should be 37350")
-		t.Fail()
+		t.Errorf("%d %v\n", k.KeyTag(), k)
+		t.Error("keytag should be 37350")
 	}
 
 	soa := new(SOA)
@@ -423,9 +406,8 @@ Activate: 20110302104537`
 
 	sig.Sign(p, []RR{soa})
 	if sig.Signature != "D5zsobpQcmMmYsUMLxCVEtgAdCvTu8V/IEeP4EyLBjqPJmjt96bwM9kqihsccofA5LIJ7DN91qkCORjWSTwNhzCv7bMyr2o5vBZElrlpnRzlvsFIoAZCD9xg6ZY7ZyzUJmU6IcTwG4v3xEYajcpbJJiyaw/RqR90MuRdKPiBzSo=" {
-		t.Log("signature is not correct")
-		t.Logf("%v\n", sig)
-		t.Fail()
+		t.Error("signature is not correct")
+		t.Errorf("%v\n", sig)
 	}
 }
 

--- a/labels_test.go
+++ b/labels_test.go
@@ -13,34 +13,27 @@ func TestCompareDomainName(t *testing.T) {
 	s6 := "miek.nl"
 
 	if CompareDomainName(s1, s2) != 2 {
-		t.Logf("%s with %s should be %d", s1, s2, 2)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", s1, s2, 2)
 	}
 	if CompareDomainName(s1, s3) != 1 {
-		t.Logf("%s with %s should be %d", s1, s3, 1)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", s1, s3, 1)
 	}
 	if CompareDomainName(s3, s4) != 0 {
-		t.Logf("%s with %s should be %d", s3, s4, 0)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", s3, s4, 0)
 	}
 	// Non qualified tests
 	if CompareDomainName(s1, s5) != 1 {
-		t.Logf("%s with %s should be %d", s1, s5, 1)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", s1, s5, 1)
 	}
 	if CompareDomainName(s1, s6) != 2 {
-		t.Logf("%s with %s should be %d", s1, s5, 2)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", s1, s5, 2)
 	}
 
 	if CompareDomainName(s1, ".") != 0 {
-		t.Logf("%s with %s should be %d", s1, s5, 0)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", s1, s5, 0)
 	}
 	if CompareDomainName(".", ".") != 0 {
-		t.Logf("%s with %s should be %d", ".", ".", 0)
-		t.Fail()
+		t.Errorf("%s with %s should be %d", ".", ".", 0)
 	}
 }
 
@@ -59,8 +52,7 @@ func TestSplit(t *testing.T) {
 	}
 	for s, i := range splitter {
 		if x := len(Split(s)); x != i {
-			t.Logf("labels should be %d, got %d: %s %v\n", i, x, s, Split(s))
-			t.Fail()
+			t.Errorf("labels should be %d, got %d: %s %v\n", i, x, s, Split(s))
 		} else {
 			t.Logf("%s %v\n", s, Split(s))
 		}
@@ -78,13 +70,11 @@ func TestSplit2(t *testing.T) {
 		switch len(i) {
 		case 1:
 			if x[0] != i[0] {
-				t.Logf("labels should be %v, got %v: %s\n", i, x, s)
-				t.Fail()
+				t.Errorf("labels should be %v, got %v: %s\n", i, x, s)
 			}
 		default:
 			if x[0] != i[0] || x[1] != i[1] || x[2] != i[2] {
-				t.Logf("labels should be %v, got %v: %s\n", i, x, s)
-				t.Fail()
+				t.Errorf("labels should be %v, got %v: %s\n", i, x, s)
 			}
 		}
 	}
@@ -113,8 +103,7 @@ func TestPrevLabel(t *testing.T) {
 	for s, i := range prever {
 		x, ok := PrevLabel(s.string, s.int)
 		if i != x {
-			t.Logf("label should be %d, got %d, %t: preving %d, %s\n", i, x, ok, s.int, s.string)
-			t.Fail()
+			t.Errorf("label should be %d, got %d, %t: preving %d, %s\n", i, x, ok, s.int, s.string)
 		}
 	}
 }
@@ -129,8 +118,7 @@ func TestCountLabel(t *testing.T) {
 	for s, i := range splitter {
 		x := CountLabel(s)
 		if x != i {
-			t.Logf("CountLabel should have %d, got %d\n", i, x)
-			t.Fail()
+			t.Errorf("CountLabel should have %d, got %d\n", i, x)
 		}
 	}
 }
@@ -149,14 +137,12 @@ domainLoop:
 	for domain, splits := range labels {
 		parts := SplitDomainName(domain)
 		if len(parts) != len(splits) {
-			t.Logf("SplitDomainName returned %v for %s, expected %v", parts, domain, splits)
-			t.Fail()
+			t.Errorf("SplitDomainName returned %v for %s, expected %v", parts, domain, splits)
 			continue domainLoop
 		}
 		for i := range parts {
 			if parts[i] != splits[i] {
-				t.Logf("SplitDomainName returned %v for %s, expected %v", parts, domain, splits)
-				t.Fail()
+				t.Errorf("SplitDomainName returned %v for %s, expected %v", parts, domain, splits)
 				continue domainLoop
 			}
 		}
@@ -180,9 +166,8 @@ func TestIsDomainName(t *testing.T) {
 	for d, ok := range names {
 		l, k := IsDomainName(d)
 		if ok.ok != k || ok.lab != l {
-			t.Logf(" got %v %d for %s ", k, l, d)
-			t.Logf("have %v %d for %s ", ok.ok, ok.lab, d)
-			t.Fail()
+			t.Errorf(" got %v %d for %s ", k, l, d)
+			t.Errorf("have %v %d for %s ", ok.ok, ok.lab, d)
 		}
 	}
 }

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -7,14 +7,12 @@ import (
 func TestPackNsec3(t *testing.T) {
 	nsec3 := HashName("dnsex.nl.", SHA1, 0, "DEAD")
 	if nsec3 != "ROCCJAE8BJJU7HN6T7NG3TNM8ACRS87J" {
-		t.Logf("%v\n", nsec3)
-		t.Fail()
+		t.Errorf("%v\n", nsec3)
 	}
 
 	nsec3 = HashName("a.b.c.example.org.", SHA1, 2, "DEAD")
 	if nsec3 != "6LQ07OAHBTOOEU2R9ANI2AT70K5O0RCG" {
-		t.Logf("%v\n", nsec3)
-		t.Fail()
+		t.Errorf("%v\n", nsec3)
 	}
 }
 
@@ -22,12 +20,10 @@ func TestNsec3(t *testing.T) {
 	// examples taken from .nl
 	nsec3, _ := NewRR("39p91242oslggest5e6a7cci4iaeqvnk.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 39P99DCGG0MDLARTCRMCF6OFLLUL7PR6 NS DS RRSIG")
 	if !nsec3.(*NSEC3).Cover("snasajsksasasa.nl.") { // 39p94jrinub66hnpem8qdpstrec86pg3
-		t.Logf("39p94jrinub66hnpem8qdpstrec86pg3. should be covered by 39p91242oslggest5e6a7cci4iaeqvnk.nl. - 39P99DCGG0MDLARTCRMCF6OFLLUL7PR6")
-		t.Fail()
+		t.Error("39p94jrinub66hnpem8qdpstrec86pg3. should be covered by 39p91242oslggest5e6a7cci4iaeqvnk.nl. - 39P99DCGG0MDLARTCRMCF6OFLLUL7PR6")
 	}
 	nsec3, _ = NewRR("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
 	if !nsec3.(*NSEC3).Match("nl.") { // sk4e8fj94u78smusb40o1n0oltbblu2r.nl.
-		t.Logf("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
-		t.Fail()
+		t.Error("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -20,19 +20,16 @@ func TestDotInName(t *testing.T) {
 	PackDomainName("aa\\.bb.nl.", buf, 0, nil, false)
 	// index 3 must be a real dot
 	if buf[3] != '.' {
-		t.Log("dot should be a real dot")
-		t.Fail()
+		t.Error("dot should be a real dot")
 	}
 
 	if buf[6] != 2 {
-		t.Log("this must have the value 2")
-		t.Fail()
+		t.Error("this must have the value 2")
 	}
 	dom, _, _ := UnpackDomainName(buf, 0)
 	// printing it should yield the backspace again
 	if dom != "aa\\.bb.nl." {
-		t.Log("dot should have been escaped: " + dom)
-		t.Fail()
+		t.Error("dot should have been escaped: ", dom)
 	}
 }
 
@@ -54,15 +51,13 @@ func TestTooLongDomainName(t *testing.T) {
 	dom := l + l + l + l + l + l + l
 	_, e := NewRR(dom + " IN A 127.0.0.1")
 	if e == nil {
-		t.Log("should be too long")
-		t.Fail()
+		t.Error("should be too long")
 	} else {
 		t.Logf("error is %s", e.Error())
 	}
 	_, e = NewRR("..com. IN A 127.0.0.1")
 	if e == nil {
-		t.Log("should fail")
-		t.Fail()
+		t.Error("should fail")
 	} else {
 		t.Logf("error is %s", e.Error())
 	}
@@ -76,19 +71,16 @@ func TestDomainName(t *testing.T) {
 
 	for _, ts := range tests {
 		if _, err := PackDomainName(ts, dbuff, 0, nil, false); err != nil {
-			t.Log("not a valid domain name")
-			t.Fail()
+			t.Error("not a valid domain name")
 			continue
 		}
 		n, _, err := UnpackDomainName(dbuff, 0)
 		if err != nil {
-			t.Log("failed to unpack packed domain name")
-			t.Fail()
+			t.Error("failed to unpack packed domain name")
 			continue
 		}
 		if ts != n {
-			t.Logf("must be equal: in: %s, out: %s\n", ts, n)
-			t.Fail()
+			t.Errorf("must be equal: in: %s, out: %s\n", ts, n)
 		}
 	}
 }
@@ -110,26 +102,23 @@ func TestDomainNameAndTXTEscapes(t *testing.T) {
 		s := rr1.String()
 		rr2, err := NewRR(s)
 		if err != nil {
-			t.Logf("Error parsing unpacked RR's string: %v", err)
-			t.Logf(" Bytes: %v\n", rrbytes)
-			t.Logf("String: %v\n", s)
-			t.Fail()
+			t.Errorf("Error parsing unpacked RR's string: %v", err)
+			t.Errorf(" Bytes: %v\n", rrbytes)
+			t.Errorf("String: %v\n", s)
 		}
 		repacked := make([]byte, len(rrbytes))
 		if _, err := PackRR(rr2, repacked, 0, nil, false); err != nil {
-			t.Logf("error packing parsed RR: %v", err)
-			t.Logf(" original Bytes: %v\n", rrbytes)
-			t.Logf("unpacked Struct: %V\n", rr1)
-			t.Logf("  parsed Struct: %V\n", rr2)
-			t.Fail()
+			t.Errorf("error packing parsed RR: %v", err)
+			t.Errorf(" original Bytes: %v\n", rrbytes)
+			t.Errorf("unpacked Struct: %V\n", rr1)
+			t.Errorf("  parsed Struct: %V\n", rr2)
 		}
 		if !bytes.Equal(repacked, rrbytes) {
-			t.Log("packed bytes don't match original bytes")
-			t.Logf(" original bytes: %v", rrbytes)
-			t.Logf("   packed bytes: %v", repacked)
-			t.Logf("unpacked struct: %V", rr1)
-			t.Logf("  parsed struct: %V", rr2)
-			t.Fail()
+			t.Error("packed bytes don't match original bytes")
+			t.Errorf(" original bytes: %v", rrbytes)
+			t.Errorf("   packed bytes: %v", repacked)
+			t.Errorf("unpacked struct: %V", rr1)
+			t.Errorf("  parsed struct: %V", rr2)
 		}
 	}
 }
@@ -206,16 +195,16 @@ func TestDomainQuick(t *testing.T) {
 		buf := make([]byte, 255)
 		off, err := PackDomainName(ds, buf, 0, nil, false)
 		if err != nil {
-			t.Logf("error packing domain: %s", err.Error())
-			t.Logf(" bytes: %v\n", db)
-			t.Logf("string: %v\n", ds)
+			t.Errorf("error packing domain: %s", err.Error())
+			t.Errorf(" bytes: %v\n", db)
+			t.Errorf("string: %v\n", ds)
 			return false
 		}
 		if !bytes.Equal(db, buf[:off]) {
-			t.Logf("repacked domain doesn't match original:")
-			t.Logf("src bytes: %v", db)
-			t.Logf("   string: %v", ds)
-			t.Logf("out bytes: %v", buf[:off])
+			t.Errorf("repacked domain doesn't match original:")
+			t.Errorf("src bytes: %v", db)
+			t.Errorf("   string: %v", ds)
+			t.Errorf("out bytes: %v", buf[:off])
 			return false
 		}
 		return true
@@ -272,15 +261,15 @@ func TestTXTRRQuick(t *testing.T) {
 		buf := make([]byte, len(rrbytes)*3)
 		off, err := PackRR(rr, buf, 0, nil, false)
 		if err != nil {
-			t.Logf("pack Error: %s\nRR: %V", err.Error(), rr)
+			t.Errorf("pack Error: %s\nRR: %V", err.Error(), rr)
 			return false
 		}
 		buf = buf[:off]
 		if !bytes.Equal(buf, rrbytes) {
-			t.Logf("packed bytes don't match original bytes")
-			t.Logf("src bytes: %v", rrbytes)
-			t.Logf("   struct: %V", rr)
-			t.Logf("oUt bytes: %v", buf)
+			t.Errorf("packed bytes don't match original bytes")
+			t.Errorf("src bytes: %v", rrbytes)
+			t.Errorf("   struct: %V", rr)
+			t.Errorf("out bytes: %v", buf)
 			return false
 		}
 		if len(rdata) == 0 {
@@ -290,35 +279,35 @@ func TestTXTRRQuick(t *testing.T) {
 		rrString := rr.String()
 		rr2, err := NewRR(rrString)
 		if err != nil {
-			t.Logf("error parsing own output: %s", err.Error())
-			t.Logf("struct: %V", rr)
-			t.Logf("string: %v", rrString)
+			t.Errorf("error parsing own output: %s", err.Error())
+			t.Errorf("struct: %V", rr)
+			t.Errorf("string: %v", rrString)
 			return false
 		}
 		if rr2.String() != rrString {
-			t.Logf("parsed rr.String() doesn't match original string")
-			t.Logf("original: %v", rrString)
-			t.Logf("  parsed: %v", rr2.String())
+			t.Errorf("parsed rr.String() doesn't match original string")
+			t.Errorf("original: %v", rrString)
+			t.Errorf("  parsed: %v", rr2.String())
 			return false
 		}
 
 		buf = make([]byte, len(rrbytes)*3)
 		off, err = PackRR(rr2, buf, 0, nil, false)
 		if err != nil {
-			t.Logf("error packing parsed rr: %s", err.Error())
-			t.Logf("unpacked Struct: %V", rr)
-			t.Logf("         string: %v", rrString)
-			t.Logf("  parsed Struct: %V", rr2)
+			t.Errorf("error packing parsed rr: %s", err.Error())
+			t.Errorf("unpacked Struct: %V", rr)
+			t.Errorf("         string: %v", rrString)
+			t.Errorf("  parsed Struct: %V", rr2)
 			return false
 		}
 		buf = buf[:off]
 		if !bytes.Equal(buf, rrbytes) {
-			t.Logf("parsed packed bytes don't match original bytes")
-			t.Logf("   source bytes: %v", rrbytes)
-			t.Logf("unpacked struct: %V", rr)
-			t.Logf("         string: %v", rrString)
-			t.Logf("  parsed struct: %V", rr2)
-			t.Logf(" repacked bytes: %v", buf)
+			t.Errorf("parsed packed bytes don't match original bytes")
+			t.Errorf("   source bytes: %v", rrbytes)
+			t.Errorf("unpacked struct: %V", rr)
+			t.Errorf("         string: %v", rrString)
+			t.Errorf("  parsed struct: %V", rr2)
+			t.Errorf(" repacked bytes: %v", buf)
 			return false
 		}
 		return true
@@ -347,13 +336,11 @@ func TestParseDirectiveMisc(t *testing.T) {
 	for i, o := range tests {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -371,13 +358,11 @@ func TestNSEC(t *testing.T) {
 	for i, o := range nsectests {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -392,13 +377,11 @@ func TestParseLOC(t *testing.T) {
 	for i, o := range lt {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -412,13 +395,11 @@ func TestParseDS(t *testing.T) {
 	for i, o := range dt {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -448,13 +429,11 @@ func TestQuotes(t *testing.T) {
 	for i, o := range tests {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is\n`%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is\n`%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -473,13 +452,11 @@ func TestParseClass(t *testing.T) {
 	for i, o := range tests {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is\n`%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is\n`%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -526,13 +503,11 @@ func TestBrace(t *testing.T) {
 	for i, o := range tests {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error() + "\n\t" + i)
-			t.Fail()
+			t.Errorf("failed to parse RR: %v\n\t%d", e, i)
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -555,8 +530,7 @@ func TestParseFailure(t *testing.T) {
 	for _, s := range tests {
 		_, err := NewRR(s)
 		if err == nil {
-			t.Logf("should have triggered an error: \"%s\"", s)
-			t.Fail()
+			t.Errorf("should have triggered an error: \"%s\"", s)
 		}
 	}
 }
@@ -577,8 +551,7 @@ test                          IN CNAME test.a.example.com.
 	for x := range to {
 		i++
 		if x.Error != nil {
-			t.Logf("%s\n", x.Error)
-			t.Fail()
+			t.Errorf("%s\n", x.Error)
 			continue
 		}
 		t.Logf("%s\n", x.RR)
@@ -715,8 +688,7 @@ func TestLineNumberError(t *testing.T) {
 	s := "example.com. 1000 SOA master.example.com. admin.example.com. monkey 4294967294 4294967293 4294967295 100"
 	if _, err := NewRR(s); err != nil {
 		if err.Error() != "dns: bad SOA zone parameter: \"monkey\" at line: 1:68" {
-			t.Logf("not expecting this error: " + err.Error())
-			t.Fail()
+			t.Error("not expecting this error: ", err)
 		}
 	}
 }
@@ -736,12 +708,11 @@ func TestLineNumberError2(t *testing.T) {
 	for in, err := range tests {
 		_, e := NewRR(in)
 		if e == nil {
-			t.Fail()
+			t.Error("e is nil")
 		} else {
 			if e.Error() != err {
-				t.Logf("%s\n", in)
-				t.Logf("error should be %s is %s\n", err, e.Error())
-				t.Fail()
+				t.Errorf("%s\n", in)
+				t.Errorf("error should be %s is %s\n", err, e.Error())
 			}
 		}
 	}
@@ -756,8 +727,7 @@ func TestRfc1982(t *testing.T) {
 	strtests := []string{"20120525134203", "19700101000000", "20380119031408"}
 	for _, v := range strtests {
 		if x, _ := StringToTime(v); v != TimeToString(x) {
-			t.Logf("1982 arithmetic string failure %s (%s:%d)", v, TimeToString(x), x)
-			t.Fail()
+			t.Errorf("1982 arithmetic string failure %s (%s:%d)", v, TimeToString(x), x)
 		}
 	}
 
@@ -767,8 +737,7 @@ func TestRfc1982(t *testing.T) {
 	}
 	for i, v := range inttests {
 		if TimeToString(i) != v {
-			t.Logf("1982 arithmetic int failure %d:%s (%s)", i, v, TimeToString(i))
-			t.Fail()
+			t.Errorf("1982 arithmetic int failure %d:%s (%s)", i, v, TimeToString(i))
 		}
 	}
 
@@ -785,16 +754,14 @@ func TestRfc1982(t *testing.T) {
 		x, _ := StringToTime(from)
 		y := TimeToString(x)
 		if y != to {
-			t.Logf("1982 arithmetic future failure %s:%s (%s)", from, to, y)
-			t.Fail()
+			t.Errorf("1982 arithmetic future failure %s:%s (%s)", from, to, y)
 		}
 	}
 }
 
 func TestEmpty(t *testing.T) {
 	for _ = range ParseZone(strings.NewReader(""), "", "") {
-		t.Logf("should be empty")
-		t.Fail()
+		t.Errorf("should be empty")
 	}
 }
 
@@ -887,17 +854,17 @@ func TestSRVPacking(t *testing.T) {
 
 func TestParseBackslash(t *testing.T) {
 	if r, e := NewRR("nul\\000gap.test.globnix.net. 600 IN	A 192.0.2.10"); e != nil {
-		t.Fatalf("could not create RR with \\000 in it")
+		t.Errorf("could not create RR with \\000 in it")
 	} else {
 		t.Logf("parsed %s\n", r.String())
 	}
 	if r, e := NewRR(`nul\000gap.test.globnix.net. 600 IN TXT "Hello\123"`); e != nil {
-		t.Fatalf("could not create RR with \\000 in it")
+		t.Errorf("could not create RR with \\000 in it")
 	} else {
 		t.Logf("parsed %s\n", r.String())
 	}
 	if r, e := NewRR(`m\ @\ iek.nl. IN 3600 A 127.0.0.1`); e != nil {
-		t.Fatalf("could not create RR with \\ and \\@ in it")
+		t.Errorf("could not create RR with \\ and \\@ in it")
 	} else {
 		t.Logf("parsed %s\n", r.String())
 	}
@@ -943,13 +910,11 @@ func TestNsapGposEidNimloc(t *testing.T) {
 	for i, o := range dt {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e.Error())
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -964,13 +929,11 @@ func TestPX(t *testing.T) {
 	for i, o := range dt {
 		rr, e := NewRR(i)
 		if e != nil {
-			t.Log("failed to parse RR: " + e.Error())
-			t.Fail()
+			t.Error("failed to parse RR: ", e.Error())
 			continue
 		}
 		if rr.String() != o {
-			t.Logf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
-			t.Fail()
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'\n", i, o, rr.String())
 		} else {
 			t.Logf("RR is OK: `%s'", rr.String())
 		}
@@ -1004,8 +967,7 @@ foo. IN TXT "THIS IS TEXT MAN"; this is comment 8
 		if x.Error == nil {
 			if x.Comment != "" {
 				if _, ok := comments[x.Comment]; !ok {
-					t.Logf("wrong comment %s", x.Comment)
-					t.Fail()
+					t.Errorf("wrong comment %s", x.Comment)
 				}
 			}
 		}
@@ -1020,12 +982,10 @@ func TestEUIxx(t *testing.T) {
 	for i, o := range tests {
 		r, e := NewRR(i)
 		if e != nil {
-			t.Logf("failed to parse %s: %s\n", i, e.Error())
-			t.Fail()
+			t.Errorf("failed to parse %s: %s\n", i, e.Error())
 		}
 		if r.String() != o {
-			t.Logf("want %s, got %s\n", o, r.String())
-			t.Fail()
+			t.Errorf("want %s, got %s\n", o, r.String())
 		}
 	}
 }
@@ -1039,12 +999,10 @@ func TestUserRR(t *testing.T) {
 	for i, o := range tests {
 		r, e := NewRR(i)
 		if e != nil {
-			t.Logf("failed to parse %s: %s\n", i, e.Error())
-			t.Fail()
+			t.Errorf("failed to parse %s: %s\n", i, e.Error())
 		}
 		if r.String() != o {
-			t.Logf("want %s, got %s\n", o, r.String())
-			t.Fail()
+			t.Errorf("want %s, got %s\n", o, r.String())
 		}
 	}
 }
@@ -1114,18 +1072,15 @@ func TestTXT(t *testing.T) {
 func TestTypeXXXX(t *testing.T) {
 	_, err := NewRR("example.com IN TYPE1234 \\# 4 aabbccdd")
 	if err != nil {
-		t.Logf("failed to parse TYPE1234 RR: %s", err.Error())
-		t.Fail()
+		t.Errorf("failed to parse TYPE1234 RR: %s", err.Error())
 	}
 	_, err = NewRR("example.com IN TYPE655341 \\# 8 aabbccddaabbccdd")
 	if err == nil {
-		t.Logf("this should not work, for TYPE655341")
-		t.Fail()
+		t.Errorf("this should not work, for TYPE655341")
 	}
 	_, err = NewRR("example.com IN TYPE1 \\# 4 0a000001")
 	if err == nil {
-		t.Logf("this should not work")
-		t.Fail()
+		t.Errorf("this should not work")
 	}
 }
 
@@ -1172,8 +1127,7 @@ func TestParseRRSIGTimestamp(t *testing.T) {
 	for r := range tests {
 		_, e := NewRR(r)
 		if e != nil {
-			t.Fail()
-			t.Logf("%s\n", e.Error())
+			t.Errorf("%s\n", e.Error())
 		}
 	}
 }
@@ -1184,9 +1138,9 @@ func TestTxtEqual(t *testing.T) {
 	rr1.Txt = []string{"a\"a", "\"", "b"}
 	rr2, _ := NewRR(rr1.String())
 	if rr1.String() != rr2.String() {
-		t.Logf("these two TXT records should match")
-		t.Logf("\n%s\n%s\n", rr1.String(), rr2.String())
-		t.Fail() // This is not an error, but keep this test.
+		// This is not an error, but keep this test.
+		t.Errorf("these two TXT records should match")
+		t.Errorf("\n%s\n%s\n", rr1.String(), rr2.String())
 	}
 	t.Logf("\n%s\n%s\n", rr1.String(), rr2.String())
 }
@@ -1202,8 +1156,7 @@ func TestTxtLong(t *testing.T) {
 	}
 	str := rr1.String()
 	if len(str) < len(rr1.Txt[0]) {
-		t.Logf("string conversion should work")
-		t.Fail()
+		t.Error("string conversion should work")
 	}
 }
 
@@ -1258,8 +1211,8 @@ func TestNewPrivateKey(t *testing.T) {
 
 		newPrivKey, err := key.NewPrivateKey(key.PrivateKeyString(privkey))
 		if err != nil {
-			t.Log(key.String())
-			t.Log(key.PrivateKeyString(privkey))
+			t.Error(key.String())
+			t.Error(key.PrivateKeyString(privkey))
 
 			t.Fatal(err.Error())
 		}
@@ -1396,13 +1349,12 @@ func TestParseIPSECKEY(t *testing.T) {
 		e1 := tests[i+1]
 		r, e := NewRR(t1)
 		if e != nil {
-			t.Logf("failed to parse IPSECKEY %s", e)
+			t.Errorf("failed to parse IPSECKEY %s", e)
 			continue
 		}
 		if r.String() != e1 {
-			t.Logf("these two IPSECKEY records should match")
-			t.Logf("\n%s\n%s\n", r.String(), e1)
-			t.Fail()
+			t.Errorf("these two IPSECKEY records should match")
+			t.Errorf("\n%s\n%s\n", r.String(), e1)
 		}
 		i++
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -104,38 +104,32 @@ func TestServing(t *testing.T) {
 	m.SetQuestion("miek.nl.", TypeTXT)
 	r, _, err := c.Exchange(m, addrstr)
 	if err != nil || len(r.Extra) == 0 {
-		t.Log("failed to exchange miek.nl", err)
-		t.FailNow()
+		t.Fatal("failed to exchange miek.nl", err)
 	}
 	txt := r.Extra[0].(*TXT).Txt[0]
 	if txt != "Hello world" {
-		t.Log("Unexpected result for miek.nl", txt, "!= Hello world")
-		t.Fail()
+		t.Error("Unexpected result for miek.nl", txt, "!= Hello world")
 	}
 
 	m.SetQuestion("example.com.", TypeTXT)
 	r, _, err = c.Exchange(m, addrstr)
 	if err != nil {
-		t.Log("failed to exchange example.com", err)
-		t.FailNow()
+		t.Fatal("failed to exchange example.com", err)
 	}
 	txt = r.Extra[0].(*TXT).Txt[0]
 	if txt != "Hello example" {
-		t.Log("Unexpected result for example.com", txt, "!= Hello example")
-		t.Fail()
+		t.Error("Unexpected result for example.com", txt, "!= Hello example")
 	}
 
 	// Test Mixes cased as noticed by Ask.
 	m.SetQuestion("eXaMplE.cOm.", TypeTXT)
 	r, _, err = c.Exchange(m, addrstr)
 	if err != nil {
-		t.Log("failed to exchange eXaMplE.cOm", err)
-		t.Fail()
+		t.Error("failed to exchange eXaMplE.cOm", err)
 	}
 	txt = r.Extra[0].(*TXT).Txt[0]
 	if txt != "Hello example" {
-		t.Log("Unexpected result for example.com", txt, "!= Hello example")
-		t.Fail()
+		t.Error("Unexpected result for example.com", txt, "!= Hello example")
 	}
 }
 
@@ -316,8 +310,7 @@ func TestServingLargeResponses(t *testing.T) {
 	M.Unlock()
 	_, _, err = c.Exchange(m, addrstr)
 	if err != nil {
-		t.Logf("failed to exchange: %s", err.Error())
-		t.Fail()
+		t.Errorf("failed to exchange: %s", err.Error())
 	}
 	// This must fail
 	M.Lock()
@@ -325,15 +318,13 @@ func TestServingLargeResponses(t *testing.T) {
 	M.Unlock()
 	_, _, err = c.Exchange(m, addrstr)
 	if err == nil {
-		t.Logf("failed to fail exchange, this should generate packet error")
-		t.Fail()
+		t.Error("failed to fail exchange, this should generate packet error")
 	}
 	// But this must work again
 	c.UDPSize = 7000
 	_, _, err = c.Exchange(m, addrstr)
 	if err != nil {
-		t.Logf("failed to exchange: %s", err.Error())
-		t.Fail()
+		t.Errorf("failed to exchange: %s", err.Error())
 	}
 }
 
@@ -353,14 +344,12 @@ func TestServingResponse(t *testing.T) {
 	m.Response = false
 	_, _, err = c.Exchange(m, addrstr)
 	if err != nil {
-		t.Log("failed to exchange", err)
-		t.FailNow()
+		t.Fatal("failed to exchange", err)
 	}
 	m.Response = true
 	_, _, err = c.Exchange(m, addrstr)
 	if err == nil {
-		t.Log("exchanged response message")
-		t.FailNow()
+		t.Fatal("exchanged response message")
 	}
 
 	s.Shutdown()
@@ -373,8 +362,7 @@ func TestServingResponse(t *testing.T) {
 	m.Response = true
 	_, _, err = c.Exchange(m, addrstr)
 	if err != nil {
-		t.Log("could exchanged response message in Unsafe mode")
-		t.FailNow()
+		t.Fatal("could exchanged response message in Unsafe mode")
 	}
 }
 

--- a/sig0_test.go
+++ b/sig0_test.go
@@ -27,8 +27,7 @@ func TestSIG0(t *testing.T) {
 		}
 		pk, err := keyrr.Generate(keysize)
 		if err != nil {
-			t.Logf("Failed to generate key for “%s”: %v", algstr, err)
-			t.Fail()
+			t.Errorf("Failed to generate key for “%s”: %v", algstr, err)
 			continue
 		}
 		now := uint32(time.Now().Unix())
@@ -43,19 +42,16 @@ func TestSIG0(t *testing.T) {
 		sigrr.SignerName = keyrr.Hdr.Name
 		mb, err := sigrr.Sign(pk, m)
 		if err != nil {
-			t.Logf("Failed to sign message using “%s”: %v", algstr, err)
-			t.Fail()
+			t.Errorf("Failed to sign message using “%s”: %v", algstr, err)
 			continue
 		}
 		m := new(Msg)
 		if err := m.Unpack(mb); err != nil {
-			t.Logf("Failed to unpack message signed using “%s”: %v", algstr, err)
-			t.Fail()
+			t.Errorf("Failed to unpack message signed using “%s”: %v", algstr, err)
 			continue
 		}
 		if len(m.Extra) != 1 {
-			t.Logf("Missing SIG for message signed using “%s”", algstr)
-			t.Fail()
+			t.Errorf("Missing SIG for message signed using “%s”", algstr)
 			continue
 		}
 		var sigrrwire *SIG
@@ -63,8 +59,7 @@ func TestSIG0(t *testing.T) {
 		case *SIG:
 			sigrrwire = rr
 		default:
-			t.Logf("Expected SIG RR, instead: %v", rr)
-			t.Fail()
+			t.Errorf("Expected SIG RR, instead: %v", rr)
 			continue
 		}
 		for _, rr := range []*SIG{sigrr, sigrrwire} {
@@ -73,23 +68,20 @@ func TestSIG0(t *testing.T) {
 				id = "sigrrwire"
 			}
 			if err := rr.Verify(keyrr, mb); err != nil {
-				t.Logf("Failed to verify “%s” signed SIG(%s): %v", algstr, id, err)
-				t.Fail()
+				t.Errorf("Failed to verify “%s” signed SIG(%s): %v", algstr, id, err)
 				continue
 			}
 		}
 		mb[13]++
 		if err := sigrr.Verify(keyrr, mb); err == nil {
-			t.Logf("Verify succeeded on an altered message using “%s”", algstr)
-			t.Fail()
+			t.Errorf("Verify succeeded on an altered message using “%s”", algstr)
 			continue
 		}
 		sigrr.Expiration = 2
 		sigrr.Inception = 1
 		mb, _ = sigrr.Sign(pk, m)
 		if err := sigrr.Verify(keyrr, mb); err == nil {
-			t.Logf("Verify succeeded on an expired message using “%s”", algstr)
-			t.Fail()
+			t.Errorf("Verify succeeded on an expired message using “%s”", algstr)
 			continue
 		}
 	}

--- a/update_test.go
+++ b/update_test.go
@@ -14,8 +14,7 @@ func TestDynamicUpdateParsing(t *testing.T) {
 		}
 		r, e := NewRR(prefix + typ)
 		if e != nil {
-			t.Log("failure to parse: " + prefix + typ)
-			t.Fail()
+			t.Error("failure to parse: " + prefix + typ)
 		} else {
 			t.Logf("parsed: %s", r.String())
 		}
@@ -31,8 +30,7 @@ func TestDynamicUpdateUnpack(t *testing.T) {
 	msg := new(Msg)
 	err := msg.Unpack(buf)
 	if err != nil {
-		t.Log("failed to unpack: " + err.Error() + "\n" + msg.String())
-		t.Fail()
+		t.Error("failed to unpack: " + err.Error() + "\n" + msg.String())
 	}
 }
 
@@ -45,13 +43,11 @@ func TestDynamicUpdateZeroRdataUnpack(t *testing.T) {
 		rr.Rrtype = n
 		bytes, err := m.Pack()
 		if err != nil {
-			t.Logf("failed to pack %s: %v", s, err)
-			t.Fail()
+			t.Errorf("failed to pack %s: %v", s, err)
 			continue
 		}
 		if err := new(Msg).Unpack(bytes); err != nil {
-			t.Logf("failed to unpack %s: %v", s, err)
-			t.Fail()
+			t.Errorf("failed to unpack %s: %v", s, err)
 		}
 	}
 }
@@ -82,8 +78,7 @@ func TestRemoveRRset(t *testing.T) {
 		if err := tmp.Unpack(actual); err != nil {
 			t.Fatalf("Error unpacking actual msg: %v", err)
 		}
-		t.Logf("Expected msg:\n%s", expectstr)
-		t.Logf("Actual msg:\n%v", tmp)
-		t.Fail()
+		t.Errorf("Expected msg:\n%s", expectstr)
+		t.Errorf("Actual msg:\n%v", tmp)
 	}
 }

--- a/xfr_test.go
+++ b/xfr_test.go
@@ -28,13 +28,11 @@ func testClientAXFR(t *testing.T) {
 	tr := new(Transfer)
 
 	if a, err := tr.In(m, net.JoinHostPort(server, "53")); err != nil {
-		t.Log("failed to setup axfr: " + err.Error())
-		t.FailNow()
+		t.Fatal("failed to setup axfr: ", err)
 	} else {
 		for ex := range a {
 			if ex.Error != nil {
-				t.Logf("error %s\n", ex.Error.Error())
-				t.Fail()
+				t.Errorf("error %s\n", ex.Error.Error())
 				break
 			}
 			for _, rr := range ex.RR {
@@ -56,13 +54,12 @@ func testClientAXFRMultipleEnvelopes(t *testing.T) {
 
 	tr := new(Transfer)
 	if a, err := tr.In(m, net.JoinHostPort(server, "53")); err != nil {
-		t.Log("Failed to setup axfr" + err.Error() + "for server: " + server)
-		t.FailNow()
+		t.Fatal("Failed to setup axfr" + err.Error() + "for server: " + server)
+		return
 	} else {
 		for ex := range a {
 			if ex.Error != nil {
-				t.Logf("Error %s\n", ex.Error.Error())
-				t.Fail()
+				t.Errorf("Error %s\n", ex.Error.Error())
 				break
 			}
 		}
@@ -81,13 +78,11 @@ func testClientTsigAXFR(t *testing.T) {
 	tr.TsigSecret = map[string]string{"axfr.": "so6ZGir4GPAqINNh9U5c3A=="}
 
 	if a, err := tr.In(m, "176.58.119.54:53"); err != nil {
-		t.Log("failed to setup axfr: " + err.Error())
-		t.FailNow()
+		t.Fatal("failed to setup axfr: ", err)
 	} else {
 		for ex := range a {
 			if ex.Error != nil {
-				t.Logf("error %s\n", ex.Error.Error())
-				t.Fail()
+				t.Errorf("error %s\n", ex.Error.Error())
 				break
 			}
 			for _, rr := range ex.RR {


### PR DESCRIPTION
Convert tests from being t.Log(..) then t.Fail() to just t.Error(...) as t.Error(...) does both and makes it more clear which messages are errors vs information log messages.