### PR TITLE
Fix TSig check on second DNS message (TCP) #180

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -193,6 +193,7 @@ func (t *Transfer) ReadMsg() (*Msg, error) {
 		}
 		// Need to work on the original message p, as that was used to calculate the tsig.
 		err = TsigVerify(p, t.TsigSecret[ts.Hdr.Name], t.tsigRequestMAC, t.tsigTimersOnly)
+		t.tsigRequestMAC = ts.MAC
 	}
 	return m, err
 }


### PR DESCRIPTION
The next chunk needs to use the previous MAC
Using this fix, I can successfully verify the signatures of not
only the first but the subsequent envelopes as well.

Patch was proposed by andrewtj in a comment. Kudos !