### PR TITLE
Fix off by one error in MaxMsgSize

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -9,7 +9,7 @@ const (
 	// MinMsgSize is the minimal size of a DNS packet.
 	MinMsgSize = 512
 	// MaxMsgSize is the largest possible DNS packet.
-	MaxMsgSize = 65536
+	MaxMsgSize = 65535
 	defaultTtl = 3600 // Default internal TTL.
 )
 


### PR DESCRIPTION
The maximum size of a DNS message is actually 65535, the largest value that can be expressed as a 16-bit word.

I did a quick pass over the usage of the constant in the library, and the usage seems to be consistent with the intended value, so this change should not cause any edge case regressions.