### PR TITLE
Export SessionUDP

### DIFF
--- a/server.go
+++ b/server.go
@@ -45,7 +45,7 @@ type response struct {
 	tsigSecret     map[string]string // the tsig secrets
 	udp            *net.UDPConn      // i/o connection if UDP was used
 	tcp            *net.TCPConn      // i/o connection if TCP was used
-	udpSession     *sessionUDP       // oob data to get egress interface right
+	udpSession     *SessionUDP       // oob data to get egress interface right
 	remoteAddr     net.Addr          // address of the client
 }
 
@@ -438,7 +438,7 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 }
 
 // Serve a new connection.
-func (srv *Server) serve(a net.Addr, h Handler, m []byte, u *net.UDPConn, s *sessionUDP, t *net.TCPConn) {
+func (srv *Server) serve(a net.Addr, h Handler, m []byte, u *net.UDPConn, s *SessionUDP, t *net.TCPConn) {
 	w := &response{tsigSecret: srv.TsigSecret, udp: u, tcp: t, remoteAddr: a, udpSession: s}
 	q := 0
 	defer func() {
@@ -537,10 +537,10 @@ func (srv *Server) readTCP(conn *net.TCPConn, timeout time.Duration) ([]byte, er
 	return m, nil
 }
 
-func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *sessionUDP, error) {
+func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error) {
 	conn.SetReadDeadline(time.Now().Add(timeout))
 	m := make([]byte, srv.UDPSize)
-	n, s, e := readFromSessionUDP(conn, m)
+	n, s, e := ReadFromSessionUDP(conn, m)
 	if e != nil || n == 0 {
 		if e != nil {
 			return nil, nil, e
@@ -576,7 +576,7 @@ func (w *response) WriteMsg(m *Msg) (err error) {
 func (w *response) Write(m []byte) (int, error) {
 	switch {
 	case w.udp != nil:
-		n, err := writeToSessionUDP(w.udp, m, w.udpSession)
+		n, err := WriteToSessionUDP(w.udp, m, w.udpSession)
 		return n, err
 	case w.tcp != nil:
 		lm := len(m)

--- a/udp.go
+++ b/udp.go
@@ -7,12 +7,12 @@ import (
 	"syscall"
 )
 
-type sessionUDP struct {
+type SessionUDP struct {
 	raddr   *net.UDPAddr
 	context []byte
 }
 
-func (s *sessionUDP) RemoteAddr() net.Addr { return s.raddr }
+func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
 
 // setUDPSocketOptions sets the UDP socket options.
 // This function is implemented on a per platform basis. See udp_*.go for more details
@@ -37,19 +37,19 @@ func setUDPSocketOptions(conn *net.UDPConn) error {
 	return nil
 }
 
-// readFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
+// ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
-func readFromSessionUDP(conn *net.UDPConn, b []byte) (int, *sessionUDP, error) {
+func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 	oob := make([]byte, 40)
 	n, oobn, _, raddr, err := conn.ReadMsgUDP(b, oob)
 	if err != nil {
 		return n, nil, err
 	}
-	return n, &sessionUDP{raddr, oob[:oobn]}, err
+	return n, &SessionUDP{raddr, oob[:oobn]}, err
 }
 
-// writeToSessionUDP acts just like net.UDPConn.WritetTo(), but uses a *sessionUDP instead of a net.Addr.
-func writeToSessionUDP(conn *net.UDPConn, b []byte, session *sessionUDP) (int, error) {
+// WriteToSessionUDP acts just like net.UDPConn.WritetTo(), but uses a *SessionUDP instead of a net.Addr.
+func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
 	n, _, err := conn.WriteMsgUDP(b, session.context, session.raddr)
 	return n, err
 }

--- a/udp_windows.go
+++ b/udp_windows.go
@@ -4,28 +4,28 @@ package dns
 
 import "net"
 
-type sessionUDP struct {
+type SessionUDP struct {
 	raddr *net.UDPAddr
 }
 
-// readFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
+// ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
-func readFromSessionUDP(conn *net.UDPConn, b []byte) (int, *sessionUDP, error) {
+func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 	n, raddr, err := conn.ReadFrom(b)
 	if err != nil {
 		return n, nil, err
 	}
-	session := &sessionUDP{raddr.(*net.UDPAddr)}
+	session := &SessionUDP{raddr.(*net.UDPAddr)}
 	return n, session, err
 }
 
-// writeToSessionUDP acts just like net.UDPConn.WritetTo(), but uses a *sessionUDP instead of a net.Addr.
-func writeToSessionUDP(conn *net.UDPConn, b []byte, session *sessionUDP) (int, error) {
+// WriteToSessionUDP acts just like net.UDPConn.WritetTo(), but uses a *SessionUDP instead of a net.Addr.
+func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
 	n, err := conn.WriteTo(b, session.raddr)
 	return n, err
 }
 
-func (s *sessionUDP) RemoteAddr() net.Addr { return s.raddr }
+func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
 
 // setUDPSocketOptions sets the UDP socket options.
 // This function is implemented on a per platform basis. See udp_*.go for more details


### PR DESCRIPTION
This PR makes the sessionUDP struct exported from the dns package (by renaming it SessionUDP).  This makes it possible for consumers of the library to reuse it when building their own servers and UDP interfaces.

I found exposing it very helpful when building a multi-listen interface server.