### PR TITLE
README update: document has already moved to doc.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ correctly, the following should work:
 
 ## Examples
 
-A short "how to use the API" is at the beginning of dns.go (this also will show
+A short "how to use the API" is at the beginning of doc.go (this also will show
 when you call `godoc github.com/miekg/dns`).
 
 Example programs can be found in the `github.com/miekg/exdns` repository.


### PR DESCRIPTION
This is tiny fix. It seems doc is already moved to doc.go.