### PR TITLE
Addressed #198, correct decoding should only look at last separator.

### DIFF
--- a/idn/punycode.go
+++ b/idn/punycode.go
@@ -216,8 +216,9 @@ func decode(b []byte) []byte {
 	}
 	out := make([]rune, 0, len(b))
 	b = b[len(_PREFIX):]
-	for pos, x := range b {
-		if x == _DELIMITER {
+	for pos := len(b) - 1; pos >= 0; pos-- {
+		// only last delimiter is our interest
+		if b[pos] == _DELIMITER {
 			out = append(out, bytes.Runes(b[:pos])...)
 			b = b[pos+1:] // trim source string
 			break

--- a/idn/punycode_test.go
+++ b/idn/punycode_test.go
@@ -9,10 +9,12 @@ var testcases = [][2]string{
 	{"", ""},
 	{"a", "a"},
 	{"A-B", "a-b"},
+	{"A-B-C", "a-b-c"},
 	{"AbC", "abc"},
 	{"я", "xn--41a"},
 	{"zя", "xn--z-0ub"},
 	{"ЯZ", "xn--z-zub"},
+	{"а-я", "xn----7sb8g"},
 	{"إختبار", "xn--kgbechtv"},
 	{"آزمایشی", "xn--hgbk6aj7f53bba"},
 	{"测试", "xn--0zwm56d"},
@@ -24,6 +26,7 @@ var testcases = [][2]string{
 	{"טעסט", "xn--deba0ad"},
 	{"テスト", "xn--zckzah"},
 	{"பரிட்சை", "xn--hlcj6aya9esc7a"},
+	{"mamão-com-açúcar", "xn--mamo-com-acar-yeb1e6q"},
 }
 
 func TestEncodeDecodePunycode(t *testing.T) {


### PR DESCRIPTION
PR corresponding to mentioned issue.