### PR TITLE
Add ToCDNSKEY and ToCDS methods (+bugfix)

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -189,6 +189,22 @@ func (k *DNSKEY) ToDS(h uint8) *DS {
 	return ds
 }
 
+// ToCDNSKEY converts a DNSKEY record to a CDNSKEY record.
+func (k *DNSKEY) ToCDNSKEY() *CDNSKEY {
+	c := &CDNSKEY{DNSKEY: *k}
+	c.Hdr = *k.Hdr.copyHeader()
+	c.Hdr.Rrtype = TypeCDNSKEY
+	return c
+}
+
+// ToCDS converts a DS record to a CDS record.
+func (d *DS) ToCDS() *CDS {
+	c := &CDS{DS: *d}
+	c.Hdr = *d.Hdr.copyHeader()
+	c.Hdr.Rrtype = TypeCDS
+	return c
+}
+
 // Sign signs an RRSet. The signature needs to be filled in with
 // the values: Inception, Expiration, KeyTag, SignerName and Algorithm.
 // The rest is copied from the RRset. Sign returns true when the signing went OK,

--- a/zscan_rr.go
+++ b/zscan_rr.go
@@ -1693,7 +1693,7 @@ func setDLV(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 }
 
 func setCDS(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
-	r, e, s := setDSs(h, c, o, f, "DLV")
+	r, e, s := setDSs(h, c, o, f, "CDS")
 	if r != nil {
 		return &CDS{*r.(*DS)}, e, s
 	}


### PR DESCRIPTION
Since it's easy to forget the `c.Hdr.Rrtype = TypeCDNSKEY` step.