### PR TITLE
Check that the query ID matches the answer ID.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -37,6 +37,29 @@ func TestClientSync(t *testing.T) {
 	}
 }
 
+func TestClientSyncBadId(t *testing.T) {
+	HandleFunc("miek.nl.", HelloServerBadId)
+	defer HandleRemove("miek.nl.")
+
+	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeSOA)
+
+	c := new(Client)
+	if _, _, err := c.Exchange(m, addrstr); err != ErrId {
+		t.Errorf("did not find a bad Id")
+	}
+	// And now with plain Exchange().
+	if _, err := Exchange(m, addrstr); err != ErrId {
+		t.Errorf("did not find a bad Id")
+	}
+}
+
 func TestClientEDNS0(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")

--- a/server_test.go
+++ b/server_test.go
@@ -17,6 +17,16 @@ func HelloServer(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
+func HelloServerBadId(w ResponseWriter, req *Msg) {
+	m := new(Msg)
+	m.SetReply(req)
+	m.Id += 1
+
+	m.Extra = make([]RR, 1)
+	m.Extra[0] = &TXT{Hdr: RR_Header{Name: m.Question[0].Name, Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
+	w.WriteMsg(m)
+}
+
 func AnotherHelloServer(w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)


### PR DESCRIPTION
Reduce some code duplication by making Exchange() use Client.Exchange().

When performing an Exchange if the query ID does not match the answer ID
return an error.  Also add a test for this condition.