### PR TITLE
Check that the RRs passed to Sign and Verify form a valid RFC2181 RRSet

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -188,6 +188,33 @@ func IsFqdn(s string) bool {
 	return s[l-1] == '.'
 }
 
+// IsRRset checks if a set of RRs is a valid RRset as defined by RFC 2181.
+// This means the RRs need to have the same type, name, and class. Returns true
+// if the RR set is valid, otherwise false.
+func IsRRset(rrset []RR) bool {
+	if len(rrset) == 0 {
+		return false
+	}
+	if len(rrset) == 1 {
+		return true
+	}
+	rrHeader := rrset[0].Header()
+	rrType := rrHeader.Rrtype
+	rrClass := rrHeader.Class
+	rrName := rrHeader.Name
+
+	for _, rr := range rrset[1:] {
+		curRRHeader := rr.Header()
+		if curRRHeader.Rrtype != rrType || curRRHeader.Class != rrClass || curRRHeader.Name != rrName {
+			// Mismatch between the records, so this is not a valid rrset for
+			//signing/verifying
+			return false
+		}
+	}
+
+	return true
+}
+
 // Fqdn return the fully qualified domain name from s.
 // If s is already fully qualified, it behaves as the identity function.
 func Fqdn(s string) string {

--- a/dnssec.go
+++ b/dnssec.go
@@ -236,8 +236,7 @@ func isValidRRSet(rrset []RR) bool {
 // the values: Inception, Expiration, KeyTag, SignerName and Algorithm.
 // The rest is copied from the RRset. Sign returns true when the signing went OK,
 // otherwise false.
-// This function checks if RRSet is a proper (RFC 2181) RRSet, and returns
-// ErrRRSet if it is not.
+// There is no check if RRSet is a proper (RFC 2181) RRSet.
 // If OrigTTL is non zero, it is used as-is, otherwise the TTL of the RRset
 // is used as the OrigTTL.
 func (rr *RRSIG) Sign(k PrivateKey, rrset []RR) error {
@@ -247,10 +246,6 @@ func (rr *RRSIG) Sign(k PrivateKey, rrset []RR) error {
 	// s.Inception and s.Expiration may be 0 (rollover etc.), the rest must be set
 	if rr.KeyTag == 0 || len(rr.SignerName) == 0 || rr.Algorithm == 0 {
 		return ErrKey
-	}
-
-	if !isValidRRSet(rrset) {
-		return ErrRRset
 	}
 
 	rr.Hdr.Rrtype = TypeRRSIG

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -690,21 +690,21 @@ func TestInvalidRRSet(t *testing.T) {
 	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	badRecords[1] = &TXT{Hdr: RR_Header{Name: "nama.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"_o/"}}
 
-	if isValidRRSet(badRecords) {
+	if IsRRset(badRecords) {
 		t.Fatal("Record set with inconsistent names considered valid")
 	}
 
 	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	badRecords[1] = &A{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeA, Class: ClassINET, Ttl: 0}}
 
-	if isValidRRSet(badRecords) {
+	if IsRRset(badRecords) {
 		t.Fatal("Record set with inconsistent record types considered valid")
 	}
 
 	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	badRecords[1] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassCHAOS, Ttl: 0}, Txt: []string{"_o/"}}
 
-	if isValidRRSet(badRecords) {
+	if IsRRset(badRecords) {
 		t.Fatal("Record set with inconsistent record class considered valid")
 	}
 

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -656,3 +656,64 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
 		t.Fatalf("RRSIG record differs:\n%v\n%v", ourRRSIG, rrRRSIG.(*RRSIG))
 	}
 }
+
+func TestInvalidRRSet(t *testing.T) {
+	goodRecords := make([]RR, 2)
+	goodRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
+	goodRecords[1] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"_o/"}}
+
+	// Generate key
+	keyname := "cloudflare.com."
+	key := &DNSKEY{
+		Hdr:       RR_Header{Name: keyname, Rrtype: TypeDNSKEY, Class: ClassINET, Ttl: 0},
+		Algorithm: ECDSAP256SHA256,
+		Flags:     ZONE,
+		Protocol:  3,
+	}
+	privatekey, err := key.Generate(256)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// Need to fill in: Inception, Expiration, KeyTag, SignerName and Algorithm
+	curTime := time.Now()
+	signature := &RRSIG{
+		Inception:  uint32(curTime.Unix()),
+		Expiration: uint32(curTime.Add(time.Hour).Unix()),
+		KeyTag:     key.KeyTag(),
+		SignerName: keyname,
+		Algorithm:  ECDSAP256SHA256,
+	}
+
+	// Inconsistent name between records
+	badRecords := make([]RR, 2)
+	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
+	badRecords[1] = &TXT{Hdr: RR_Header{Name: "nama.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"_o/"}}
+
+	if err := signature.Sign(privatekey, badRecords); err != ErrRRset {
+		t.Fatal("Sign returned no error for record set with inconsistent names")
+	}
+
+	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
+	badRecords[1] = &A{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeA, Class: ClassINET, Ttl: 0}}
+
+	if err := signature.Sign(privatekey, badRecords); err != ErrRRset {
+		t.Fatal("Sign returned no error for record set with inconsistent record types")
+	}
+
+	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
+	badRecords[1] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassCHAOS, Ttl: 0}, Txt: []string{"_o/"}}
+
+	if err := signature.Sign(privatekey, badRecords); err != ErrRRset {
+		t.Fatal("Sign returned no error for record set with inconsistent record class")
+	}
+
+	// Sign the good record set and then make sure verification fails on the bad record set
+	if err := signature.Sign(privatekey, goodRecords); err != nil {
+		t.Fatal("Signing good records failed")
+	}
+
+	if err := signature.Verify(key, badRecords); err != ErrRRset {
+		t.Fatal("Verification did not return ErrRRset with inconsistent records")
+	}
+}

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -690,22 +690,22 @@ func TestInvalidRRSet(t *testing.T) {
 	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	badRecords[1] = &TXT{Hdr: RR_Header{Name: "nama.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"_o/"}}
 
-	if err := signature.Sign(privatekey, badRecords); err != ErrRRset {
-		t.Fatal("Sign returned no error for record set with inconsistent names")
+	if isValidRRSet(badRecords) {
+		t.Fatal("Record set with inconsistent names considered valid")
 	}
 
 	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	badRecords[1] = &A{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeA, Class: ClassINET, Ttl: 0}}
 
-	if err := signature.Sign(privatekey, badRecords); err != ErrRRset {
-		t.Fatal("Sign returned no error for record set with inconsistent record types")
+	if isValidRRSet(badRecords) {
+		t.Fatal("Record set with inconsistent record types considered valid")
 	}
 
 	badRecords[0] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	badRecords[1] = &TXT{Hdr: RR_Header{Name: "name.cloudflare.com.", Rrtype: TypeTXT, Class: ClassCHAOS, Ttl: 0}, Txt: []string{"_o/"}}
 
-	if err := signature.Sign(privatekey, badRecords); err != ErrRRset {
-		t.Fatal("Sign returned no error for record set with inconsistent record class")
+	if isValidRRSet(badRecords) {
+		t.Fatal("Record set with inconsistent record class considered valid")
 	}
 
 	// Sign the good record set and then make sure verification fails on the bad record set


### PR DESCRIPTION
Add a sanity check used by RRSig's Sign and Verify functions making sure
that the records they operate on form a valid RRSet (same name, type,
and class).

Add a unit test TestInvalidRRSet that calls RRSig's Sign and Verify
methods with invalid RRSets, and makes sure the correct error is
returned.