### PR TITLE
Fix crash in inIxfr when ReadMsg fails

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -107,7 +107,7 @@ func (t *Transfer) inIxfr(id uint16, c chan *Envelope) {
 		t.SetReadDeadline(time.Now().Add(timeout))
 		in, err := t.ReadMsg()
 		if err != nil {
-			c <- &Envelope{in.Answer, err}
+			c <- &Envelope{nil, err}
 			return
 		}
 		if id != in.Id {


### PR DESCRIPTION
When ReadMsg returns an error, we should not try to access the returned structure as it might be nil.
The inIxfr code tries to access "in.Answer", causing a crash.

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x5dc851]

goroutine 41 [running]:
github.com/miekg/dns.(*Transfer).inIxfr(0xc2127648d0, 0x437bcc, 0xc21678c600)
        /mnt/data/xxxxx/third-party/src/github.com/miekg/dns/xfr.go:110 +0x231
created by github.com/miekg/dns.func·073
        /mnt/data/xxxxx/third-party/src/github.com/miekg/dns/xfr.go:45 +0xf5