### PR TITLE
Fix CAA parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 6605 - ECDSA
 * 6725 - IANA Registry Update
 * 6742 - ILNP DNS
+* 6844 - CAA record
 * 6891 - EDNS0 update
 * 6895 - DNS IANA considerations
 * 6975 - Algorithm Understanding in DNSSEC
@@ -138,6 +139,5 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * privatekey.Precompute() when signing?
 * Last remaining RRs: APL, ATMA, A6 and NXT and IPSECKEY;
 * Missing in parsing: ISDN, UNSPEC, ATMA;
-* CAA parsing is broken;
 * NSEC(3) cover/match/closest enclose;
 * Replies with TC bit are not parsed to the end;

--- a/dns_test.go
+++ b/dns_test.go
@@ -429,9 +429,6 @@ func TestToRFC3597(t *testing.T) {
 func TestNoRdataPack(t *testing.T) {
 	data := make([]byte, 1024)
 	for typ, fn := range typeToRR {
-		if typ == TypeCAA {
-			continue // TODO(miek): known omission
-		}
 		r := fn()
 		*r.Header() = RR_Header{Name: "miek.nl.", Rrtype: typ, Class: ClassINET, Ttl: 3600}
 		_, err := PackRR(r, data, 0, nil, false)

--- a/msg.go
+++ b/msg.go
@@ -100,7 +100,7 @@ var TypeToString = map[uint16]string{
 	TypeANY:        "ANY", // Meta RR
 	TypeATMA:       "ATMA",
 	TypeAXFR:       "AXFR", // Meta RR
-	TypeCAA:        "TYPE257",
+	TypeCAA:        "CAA",
 	TypeCDNSKEY:    "CDNSKEY",
 	TypeCDS:        "CDS",
 	TypeCERT:       "CERT",
@@ -543,6 +543,36 @@ func packTxtString(s string, msg []byte, offset int, tmp []byte) (int, error) {
 	return offset, nil
 }
 
+func packOctetString(s string, msg []byte, offset int, tmp []byte) (int, error) {
+	if offset >= len(msg) {
+		return offset, ErrBuf
+	}
+	bs := tmp[:len(s)]
+	copy(bs, s)
+	for i := 0; i < len(bs); i++ {
+		if len(msg) <= offset {
+			return offset, ErrBuf
+		}
+		if bs[i] == '\\' {
+			i++
+			if i == len(bs) {
+				break
+			}
+			// check for \DDD
+			if i+2 < len(bs) && isDigit(bs[i]) && isDigit(bs[i+1]) && isDigit(bs[i+2]) {
+				msg[offset] = dddToByte(bs[i:])
+				i += 2
+			} else {
+				msg[offset] = bs[i]
+			}
+		} else {
+			msg[offset] = bs[i]
+		}
+		offset++
+	}
+	return offset, nil
+}
+
 func unpackTxt(msg []byte, offset, rdend int) ([]string, int, error) {
 	var err error
 	var ss []string
@@ -890,6 +920,12 @@ func packStructValue(val reflect.Value, msg []byte, off int, compression map[str
 				// length of string. String is RAW (not encoded in hex, nor base64)
 				copy(msg[off:off+len(s)], s)
 				off += len(s)
+			case `dns:"octet"`:
+				var varstrTmp []byte
+				off, err = packOctetString(fv.String(), msg, off, varstrTmp)
+				if err != nil {
+					return lenmsg, err
+				}
 			case `dns:"txt"`:
 				fallthrough
 			case "":
@@ -1254,6 +1290,13 @@ func unpackStructValue(val reflect.Value, msg []byte, off int) (off1 int, err er
 			switch val.Type().Field(i).Tag {
 			default:
 				return lenmsg, &Error{"bad tag unpacking string: " + val.Type().Field(i).Tag.Get("dns")}
+			case `dns:"octet"`:
+				strend := lenrd
+				if strend > lenmsg {
+					return lenmsg, &Error{err: "overflow unpacking octet"}
+				}
+				s = string(msg[off:strend])
+				off = strend
 			case `dns:"hex"`:
 				hexend := lenrd
 				if val.FieldByName("Hdr").FieldByName("Rrtype").Uint() == uint64(TypeHIP) {

--- a/msg.go
+++ b/msg.go
@@ -921,8 +921,8 @@ func packStructValue(val reflect.Value, msg []byte, off int, compression map[str
 				copy(msg[off:off+len(s)], s)
 				off += len(s)
 			case `dns:"octet"`:
-				var varstrTmp []byte
-				off, err = packOctetString(fv.String(), msg, off, varstrTmp)
+				bytesTmp := make([]byte, 0)
+				off, err = packOctetString(fv.String(), msg, off, bytesTmp)
 				if err != nil {
 					return lenmsg, err
 				}

--- a/msg.go
+++ b/msg.go
@@ -100,7 +100,7 @@ var TypeToString = map[uint16]string{
 	TypeANY:        "ANY", // Meta RR
 	TypeATMA:       "ATMA",
 	TypeAXFR:       "AXFR", // Meta RR
-	TypeCAA:        "CAA",
+	TypeCAA:        "TYPE257",
 	TypeCDNSKEY:    "CDNSKEY",
 	TypeCDS:        "CDS",
 	TypeCERT:       "CERT",

--- a/parse_test.go
+++ b/parse_test.go
@@ -1455,3 +1455,25 @@ func TestParseHINFO(t *testing.T) {
 		}
 	}
 }
+
+func TestParseCAA(t *testing.T) {
+	lt := map[string]string{
+		"example.net.	CAA	0 issue \"symantec.com\"": "example.net.\t3600\tIN\tCAA\t0 issue \"symantec.com\"",
+		"example.net.	CAA	0 issuewild \"symantec.com; stuff\"": "example.net.\t3600\tIN\tCAA\t0 issuewild \"symantec.com; stuff\"",
+		"example.net.	CAA	128 tbs \"critical\"": "example.net.\t3600\tIN\tCAA\t128 tbs \"critical\"",
+		"example.net.	CAA	2 auth \"0>09\\006\\010+\\006\\001\\004\\001\\214y\\002\\003\\001\\006\\009`\\134H\\001e\\003\\004\\002\\001\\004 y\\209\\012\\221r\\220\\156Q\\218\\150\\150{\\166\\245:\\231\\182%\\157:\\133\\179}\\1923r\\238\\151\\255\\128q\\145\\002\\001\\000\"": "example.net.\t3600\tIN\tCAA\t2 auth \"0>09\\006\\010+\\006\\001\\004\\001\\214y\\002\\003\\001\\006\\009`\\134H\\001e\\003\\004\\002\\001\\004 y\\209\\012\\221r\\220\\156Q\\218\\150\\150{\\166\\245:\\231\\182%\\157:\\133\\179}\\1923r\\238\\151\\255\\128q\\145\\002\\001\\000\"",
+		"example.net.   TYPE257	0 issue \"symantec.com\"": "example.net.\t3600\tIN\tCAA\t0 issue \"symantec.com\"",
+	}
+	for i, o := range lt {
+		rr, err := NewRR(i)
+		if err != nil {
+			t.Error("failed to parse RR: ", err)
+			continue
+		}
+		if rr.String() != o {
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'", i, o, rr.String())
+		} else {
+			t.Logf("RR is OK: `%s'", rr.String())
+		}
+	}
+}

--- a/types.go
+++ b/types.go
@@ -1541,7 +1541,7 @@ func (rr *CAA) len() int           { return rr.Hdr.len() + 1 + len(rr.Tag) + len
 func (rr *CAA) String() string {
 	s := rr.Hdr.String()
 
-	s += "\\# " + strconv.Itoa(2 + len(rr.Tag) + len(rr.Value)) + " "
+	s += "\\# " + strconv.Itoa(2 + len(rr.Tag) + len(rr.Value)/2) + " "
 	s += fmt.Sprintf("%02X%02X%X%s", rr.Flag, len(rr.Tag), rr.Tag, strings.ToUpper(rr.Value))
 	return s
 }

--- a/types.go
+++ b/types.go
@@ -1527,25 +1527,25 @@ func (rr *EUI64) copy() RR           { return &EUI64{*rr.Hdr.copyHeader(), rr.Ad
 func (rr *EUI64) String() string     { return rr.Hdr.String() + euiToString(rr.Address, 64) }
 func (rr *EUI64) len() int           { return rr.Hdr.len() + 8 }
 
-// Support in incomplete - just handle it as unknown record
-/*
 type CAA struct {
 	Hdr   RR_Header
 	Flag  uint8
 	Tag   string
-	Value string `dns:"octet"`
+	Value string `dns:"hex"`
 }
 
 func (rr *CAA) Header() *RR_Header { return &rr.Hdr }
 func (rr *CAA) copy() RR           { return &CAA{*rr.Hdr.copyHeader(), rr.Flag, rr.Tag, rr.Value} }
-func (rr *CAA) len() int           { return rr.Hdr.len() + 1 + len(rr.Tag) + 1 + len(rr.Value) }
+func (rr *CAA) len() int           { return rr.Hdr.len() + 1 + len(rr.Tag) + len(rr.Value)/2 }
 
 func (rr *CAA) String() string {
-	s := rr.Hdr.String() + strconv.FormatInt(int64(rr.Flag), 10) + " " + rr.Tag
-	s += strconv.QuoteToASCII(rr.Value)
+	s := rr.Hdr.String()
+
+	s += "\\# " + strconv.Itoa(2 + len(rr.Tag) + len(rr.Value)) + " "
+	s += fmt.Sprintf("%02X%02X%X%s", rr.Flag, len(rr.Tag), rr.Tag, strings.ToUpper(rr.Value))
 	return s
 }
-*/
+
 
 type UID struct {
 	Hdr RR_Header
@@ -1668,10 +1668,10 @@ func copyIP(ip net.IP) net.IP {
 
 // Map of constructors for each RR type.
 var typeToRR = map[uint16]func() RR{
-	TypeA:     func() RR { return new(A) },
-	TypeAAAA:  func() RR { return new(AAAA) },
-	TypeAFSDB: func() RR { return new(AFSDB) },
-	//	TypeCAA:        func() RR { return new(CAA) },
+	TypeA:          func() RR { return new(A) },
+	TypeAAAA:       func() RR { return new(AAAA) },
+	TypeAFSDB:      func() RR { return new(AFSDB) },
+	TypeCAA:        func() RR { return new(CAA) },
 	TypeCDS:        func() RR { return new(CDS) },
 	TypeCERT:       func() RR { return new(CERT) },
 	TypeCNAME:      func() RR { return new(CNAME) },

--- a/update_test.go
+++ b/update_test.go
@@ -8,7 +8,7 @@ import (
 func TestDynamicUpdateParsing(t *testing.T) {
 	prefix := "example.com. IN "
 	for _, typ := range TypeToString {
-		if typ == "CAA" || typ == "OPT" || typ == "AXFR" || typ == "IXFR" || typ == "ANY" || typ == "TKEY" ||
+		if typ == "TYPE257" || typ == "OPT" || typ == "AXFR" || typ == "IXFR" || typ == "ANY" || typ == "TKEY" ||
 			typ == "TSIG" || typ == "ISDN" || typ == "UNSPEC" || typ == "NULL" || typ == "ATMA" {
 			continue
 		}

--- a/update_test.go
+++ b/update_test.go
@@ -8,7 +8,7 @@ import (
 func TestDynamicUpdateParsing(t *testing.T) {
 	prefix := "example.com. IN "
 	for _, typ := range TypeToString {
-		if typ == "TYPE257" || typ == "OPT" || typ == "AXFR" || typ == "IXFR" || typ == "ANY" || typ == "TKEY" ||
+		if typ == "CAA" || typ == "OPT" || typ == "AXFR" || typ == "IXFR" || typ == "ANY" || typ == "TKEY" ||
 			typ == "TSIG" || typ == "ISDN" || typ == "UNSPEC" || typ == "NULL" || typ == "ATMA" {
 			continue
 		}

--- a/zscan_rr.go
+++ b/zscan_rr.go
@@ -2197,8 +2197,6 @@ func setCAA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	}
 	if len(s) > 1 {
 		return nil, &ParseError{f, "bad CAA Value", l}, ""
-	} else if len(s) == 0 {
-		rr.Value = ""
 	} else {
 		rr.Value = s[0]
 	}

--- a/zscan_rr.go
+++ b/zscan_rr.go
@@ -2188,7 +2188,7 @@ func setCAA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if e1 != nil {
 		return nil, e1, c1
 	}
-	if rdlength*2 != len(s) || rdlength*2 < 4 {
+	if rdlength*2 != len(s) || len(s) < 4 {
 		return nil, &ParseError{f, "bad CAA Rdata", l}, ""
 	}
 

--- a/zscan_rr.go
+++ b/zscan_rr.go
@@ -2208,11 +2208,13 @@ func setCAA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad CAA Tag length", l}, ""
 	}
 
-	tag, e := hex.DecodeString(s[4:4+taglength])
+	tag, e := hex.DecodeString(s[4:4+(taglength*2)])
 	if e != nil {
 		return nil, &ParseError{f, "bad CAA Tag", l}, ""
 	}
 	rr.Tag = string(tag)
+
+	rr.Value = s[4+(taglength*2):]
 
 	return rr, nil, c1
 }


### PR DESCRIPTION
Enables direct parsing of CAA records instead of parsing them as RFC3597 records. This allows the [Boulder](https://github.com/letsencrypt/boulder) developers to clear CAA record parsing code out of our code base.

I tested this against *almost* all the CAA records I could find in the wild ([relevant gist](https://gist.github.com/rolandshoemaker/4911f0c39acb25d68e80)) and everything seems to be working correctly...