### PR TITLE
adding TurboBytes Pulse as a user

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://github.com/StalkR/dns-reverse-proxy
 * https://github.com/tianon/rawdns
 * https://mesosphere.github.io/mesos-dns/
+* https://pulse.turbobytes.com/
 
 Send pull request if you want to be listed here.
 


### PR DESCRIPTION
The DNS test in TurboBytes Pulse is handled using this library. 
ref: https://github.com/turbobytes/pulse/blob/master/utils/dns.go#L34

Thanks for this awesome library. I use it a lot for small internal projects as well.