### PR TITLE
add interfaces to allow packet-level inspection for pre/post processing

### DIFF
--- a/server.go
+++ b/server.go
@@ -198,17 +198,17 @@ func HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
 	DefaultServeMux.HandleFunc(pattern, handler)
 }
 
-// Writer writes DNS data frames; each call to Write should send an entire frame.
+// Writer writes raw DNS messages; each call to Write should send an entire message.
 type Writer interface {
 	io.Writer
 }
 
-// Reader reads DNS data frames; each call to ReadTCP or ReadUDP should return an entire frame.
+// Reader reads raw DNS messages; each call to ReadTCP or ReadUDP should return an entire message.
 type Reader interface {
-	// ReadTCP reads a data frame from a TCP connection. Implementations may alter
+	// ReadTCP reads a raw message from a TCP connection. Implementations may alter
 	// connection properties, for example the read-deadline.
 	ReadTCP(conn *net.TCPConn, timeout time.Duration) ([]byte, error)
-	// ReadUDP reads a data frame from a UDP connection. Implementations may alter
+	// ReadUDP reads a raw message from a UDP connection. Implementations may alter
 	// connection properties, for example the read-deadline.
 	ReadUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error)
 }
@@ -263,9 +263,9 @@ type Server struct {
 	Unsafe bool
 	// If NotifyStartedFunc is set is is called, once the server has started listening.
 	NotifyStartedFunc func()
-	// DecorateReader is optional, allows customization of the process that reads DNS frames.
+	// DecorateReader is optional, allows customization of the process that reads raw DNS messages.
 	DecorateReader DecorateReader
-	// DecorateWriter is optional, allows customization of the process that writes DNS frames.
+	// DecorateWriter is optional, allows customization of the process that writes raw DNS messages.
 	DecorateWriter DecorateWriter
 
 	// For graceful shutdown.

--- a/server_test.go
+++ b/server_test.go
@@ -403,12 +403,12 @@ type ExampleFrameLengthWriter struct {
 }
 
 func (e *ExampleFrameLengthWriter) Write(m []byte) (int, error) {
-	fmt.Println("writing DNS data frame of length", len(m))
+	fmt.Println("writing raw DNS message of length", len(m))
 	return e.Writer.Write(m)
 }
 
 func ExampleDecorateWriter() {
-	// instrument DNS data frame writing
+	// instrument raw DNS message writing
 	wf := DecorateWriter(func(w Writer) Writer {
 		return &ExampleFrameLengthWriter{w}
 	})
@@ -446,5 +446,5 @@ func ExampleDecorateWriter() {
 		fmt.Println("failed to exchange", err.Error())
 		return
 	}
-	// Output: writing DNS data frame of length 56
+	// Output: writing raw DNS message of length 56
 }

--- a/server_test.go
+++ b/server_test.go
@@ -397,3 +397,54 @@ func TestShutdownUDP(t *testing.T) {
 		t.Errorf("Could not shutdown test UDP server, %v", err)
 	}
 }
+
+type ExampleFrameLengthWriter struct {
+	Writer
+}
+
+func (e *ExampleFrameLengthWriter) Write(m []byte) (int, error) {
+	fmt.Println("writing DNS data frame of length", len(m))
+	return e.Writer.Write(m)
+}
+
+func ExampleDecorateWriter() {
+	// instrument DNS data frame writing
+	wf := DecorateWriter(func(w Writer) Writer {
+		return &ExampleFrameLengthWriter{w}
+	})
+
+	// simple UDP server
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	server := &Server{
+		PacketConn:     pc,
+		DecorateWriter: wf,
+	}
+
+	waitLock := sync.Mutex{}
+	waitLock.Lock()
+	server.NotifyStartedFunc = waitLock.Unlock
+	defer server.Shutdown()
+
+	go func() {
+		server.ActivateAndServe()
+		pc.Close()
+	}()
+
+	waitLock.Lock()
+
+	HandleFunc("miek.nl.", HelloServer)
+
+	c := new(Client)
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeTXT)
+	_, _, err = c.Exchange(m, pc.LocalAddr().String())
+	if err != nil {
+		fmt.Println("failed to exchange", err.Error())
+		return
+	}
+	// Output: writing DNS data frame of length 56
+}


### PR DESCRIPTION
I've been thinking of adding support for "dnstap" to mesos-dns. Having direct access to the DNS data frames would be *much* more efficient (and accurate) than packing/unpacking Msg objects.

This PR defines additional, optional fields to Server that allow callers to optionally inject pre/post processing for DNS data frames.