### PR TITLE
added proxy support for TCP DNS query

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -28,7 +28,7 @@ func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 	if t.DialTimeout != 0 {
 		timeout = t.DialTimeout
 	}
-	t.Conn, err = DialTimeout("tcp", a, timeout)
+	t.Conn, err = DialTimeout("tcp", "", a, timeout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To support socks5 proxy while performing DNS queries via TCP (eg. 8.8.8.8, 8.8.4.4)
the proxy can be ssh -D to ensure security.