### PR TITLE
Travis: -> new architecture; - short mode; + race detector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
+sudo: false
 go:
   - 1.4
   - 1.5rc1
 script:
-  - go test -short -bench=.
+  - go test -race -bench=.


### PR DESCRIPTION
If sudo is not needed, Travis will run the builds in a faster containerized architecture.

Removed "-short", added "-race". Wall time loss seems reasonable.