### PR TITLE
Add Dedup function - WIP do not merge

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -30,6 +30,9 @@ type RR interface {
 	Header() *RR_Header
 	// String returns the text representation of the resource record.
 	String() string
+
+	// rdataString returns the text representation of the rdata of record.
+//	rdataString() string
 	// copy returns a copy of the RR
 	copy() RR
 	// len returns the length (in octets) of the uncompressed RR in wire format.

--- a/format.go
+++ b/format.go
@@ -94,3 +94,48 @@ func Field(r RR, i int) string {
 	}
 	return ""
 }
+
+// Sprintf formats according to the format specifier and returns the
+// resulting string. The following verbs are understood by this
+// function:
+//
+//	%n	the ownername
+//	%c	the class
+//	%t	the type
+//	%T	the ttl
+//	%r	the rdata
+//	%%	literal percent sign
+//
+// In the future modifiers and more verbs might be added.
+func Sprintf(format string, r RR) string {
+	s := ""
+	verb := false
+	for _, f := range format {
+		if f == '%' {
+			verb = true
+			continue
+		}
+		if verb {
+			switch f {
+			case 'n':
+				s += r.Header().Name
+			case 'c':
+				s += Class(r.Header().Class).String()
+			case 't':
+				s += Type(r.Header().Class).String()
+			case 'T':
+				s += strconv.Itoa(int(r.Header().Ttl))
+			case 'r':
+				// s+=r.rdataString() // later
+				s+=""
+			case '%':
+				s += "%"
+			}
+		} else {
+			s += string(f)
+		}
+		verb = false
+	}
+
+	return string(s)
+}

--- a/format.go
+++ b/format.go
@@ -106,7 +106,7 @@ func Field(r RR, i int) string {
 //	%r	the rdata
 //	%%	literal percent sign
 //
-// In the future modifiers and more verbs might be added.
+// In the future more modifiers and verbs can be added.
 func Sprintf(format string, r RR) string {
 	s := ""
 	verb := false
@@ -131,9 +131,12 @@ func Sprintf(format string, r RR) string {
 			case '%':
 				s += "%"
 			}
-		} else {
-			s += string(f)
+
+			verb = false
+			continue
 		}
+
+		s += string(f)
 		verb = false
 	}
 

--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,13 @@
+package dns
+
+import "testing"
+
+func TestSprintf(t *testing.T) {
+	ra, _ := NewRR("miek.nl. 2700 IN A 127.0.0.1")
+
+	s := Sprintf("%n hello, %T\n", ra)
+	if s != "miek.nl. hello, 2700\n" {
+		t.Logf("%v\n", s)
+		t.Fail()
+	}
+}

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,30 @@
+package dns
+
+// Dedup removes identical RRs from rrs. It preserves the original ordering.
+func Dedup(rrs []RR) []RR {
+	m := make(map[string]RR)
+
+	for _, r := range rrs {
+		key := mapKey(r)
+		if _, ok := m[key]; ok {
+			continue
+		}
+		m[key] = r
+	}
+	if len(m) == len(rrs) {
+		return rrs
+	}
+	var i = 0
+	var r RR
+	for i, r = range rrs {
+		if len(m) == 0 {
+			break
+		}
+		key := mapKey(r)
+		delete(m, key)
+	}
+	return rrs[:i]
+}
+
+// Returns the rr as a string with the TTL.
+func mapKey(r RR) string { return Sprintf("%n%t%c%r", r) }

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,65 @@
+package dns
+
+import "testing"
+
+func TestDedup(t *testing.T) {
+	in := []RR{
+		newRR("miek.nl. IN A 127.0.0.1"),
+		newRR("miek.nl. IN A 127.0.0.1"),
+	}
+	out := Dedup(in)
+	if len(out) != 1 && out[0].String() != "miek.nl. IN A 127.0.0.1" {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 1, len(out))
+	}
+
+	in = []RR{}
+	out = Dedup(in)
+	if len(out) != 0 {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 0, len(out))
+	}
+
+	in = []RR{
+		newRR("miek.nl. 1000 IN A 127.0.0.1"),
+		newRR("miek.nl. 2000 IN A 127.0.0.1"),
+	}
+	out = Dedup(in)
+	if len(out) != 1 {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	}
+
+	in = []RR{
+		newRR("miek.nl. IN A 127.0.0.1"),
+		newRR("miek.nl. CH A 127.0.0.1"),
+	}
+	out = Dedup(in)
+	if len(out) != 2 {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	}
+	in = []RR{
+		newRR("miek.nl. CH A 127.0.0.1"),
+		newRR("miek.nl. IN A 127.0.0.1"),
+		newRR("miek.nl. IN A 127.0.0.1"),
+	}
+	out = Dedup(in)
+	if len(out) != 2 {
+		// TODO(miek): check ordering.
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	}
+}
+
+func newRR(s string) RR {
+	r, _ := NewRR(s)
+	return r
+}
+
+func dump(rrs []RR, t *testing.T) {
+	t.Logf("********\n")
+	for _, r := range rrs {
+		t.Logf("%v\n", r)
+	}
+}

--- a/types.go
+++ b/types.go
@@ -234,20 +234,22 @@ type ANY struct {
 	// Does not have any rdata
 }
 
-func (rr *ANY) Header() *RR_Header { return &rr.Hdr }
-func (rr *ANY) copy() RR           { return &ANY{*rr.Hdr.copyHeader()} }
-func (rr *ANY) String() string     { return rr.Hdr.String() }
-func (rr *ANY) len() int           { return rr.Hdr.len() }
+func (rr *ANY) Header() *RR_Header  { return &rr.Hdr }
+func (rr *ANY) copy() RR            { return &ANY{*rr.Hdr.copyHeader()} }
+func (rr *ANY) len() int            { return rr.Hdr.len() }
+func (rr *ANY) String() string      { return rr.Hdr.String() }
+func (rr *ANY) rdataString() string { return "" }
 
 type CNAME struct {
 	Hdr    RR_Header
 	Target string `dns:"cdomain-name"`
 }
 
-func (rr *CNAME) Header() *RR_Header { return &rr.Hdr }
-func (rr *CNAME) copy() RR           { return &CNAME{*rr.Hdr.copyHeader(), sprintName(rr.Target)} }
-func (rr *CNAME) String() string     { return rr.Hdr.String() + rr.Target }
-func (rr *CNAME) len() int           { return rr.Hdr.len() + len(rr.Target) + 1 }
+func (rr *CNAME) Header() *RR_Header  { return &rr.Hdr }
+func (rr *CNAME) copy() RR            { return &CNAME{*rr.Hdr.copyHeader(), sprintName(rr.Target)} }
+func (rr *CNAME) len() int            { return rr.Hdr.len() + len(rr.Target) + 1 }
+func (rr *CNAME) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *CNAME) rdataString() string { return rr.Target }
 
 type HINFO struct {
 	Hdr RR_Header
@@ -255,33 +257,33 @@ type HINFO struct {
 	Os  string
 }
 
-func (rr *HINFO) Header() *RR_Header { return &rr.Hdr }
-func (rr *HINFO) copy() RR           { return &HINFO{*rr.Hdr.copyHeader(), rr.Cpu, rr.Os} }
-func (rr *HINFO) String() string {
-	return rr.Hdr.String() + sprintTxt([]string{rr.Cpu, rr.Os})
-}
-func (rr *HINFO) len() int { return rr.Hdr.len() + len(rr.Cpu) + len(rr.Os) }
+func (rr *HINFO) Header() *RR_Header  { return &rr.Hdr }
+func (rr *HINFO) copy() RR            { return &HINFO{*rr.Hdr.copyHeader(), rr.Cpu, rr.Os} }
+func (rr *HINFO) len() int            { return rr.Hdr.len() + len(rr.Cpu) + len(rr.Os) }
+func (rr *HINFO) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *HINFO) rdataString() string { return sprintTxt([]string{rr.Cpu, rr.Os}) }
 
 type MB struct {
 	Hdr RR_Header
 	Mb  string `dns:"cdomain-name"`
 }
 
-func (rr *MB) Header() *RR_Header { return &rr.Hdr }
-func (rr *MB) copy() RR           { return &MB{*rr.Hdr.copyHeader(), sprintName(rr.Mb)} }
-
-func (rr *MB) String() string { return rr.Hdr.String() + rr.Mb }
-func (rr *MB) len() int       { return rr.Hdr.len() + len(rr.Mb) + 1 }
+func (rr *MB) Header() *RR_Header  { return &rr.Hdr }
+func (rr *MB) copy() RR            { return &MB{*rr.Hdr.copyHeader(), sprintName(rr.Mb)} }
+func (rr *MB) len() int            { return rr.Hdr.len() + len(rr.Mb) + 1 }
+func (rr *MB) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *MB) rdataString() string { return rr.Mb }
 
 type MG struct {
 	Hdr RR_Header
 	Mg  string `dns:"cdomain-name"`
 }
 
-func (rr *MG) Header() *RR_Header { return &rr.Hdr }
-func (rr *MG) copy() RR           { return &MG{*rr.Hdr.copyHeader(), rr.Mg} }
-func (rr *MG) len() int           { l := len(rr.Mg) + 1; return rr.Hdr.len() + l }
-func (rr *MG) String() string     { return rr.Hdr.String() + sprintName(rr.Mg) }
+func (rr *MG) Header() *RR_Header  { return &rr.Hdr }
+func (rr *MG) copy() RR            { return &MG{*rr.Hdr.copyHeader(), rr.Mg} }
+func (rr *MG) len() int            { l := len(rr.Mg) + 1; return rr.Hdr.len() + l }
+func (rr *MG) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *MG) rdataString() string { return sprintName(rr.Mg) }
 
 type MINFO struct {
 	Hdr   RR_Header
@@ -289,13 +291,10 @@ type MINFO struct {
 	Email string `dns:"cdomain-name"`
 }
 
-func (rr *MINFO) Header() *RR_Header { return &rr.Hdr }
-func (rr *MINFO) copy() RR           { return &MINFO{*rr.Hdr.copyHeader(), rr.Rmail, rr.Email} }
-
-func (rr *MINFO) String() string {
-	return rr.Hdr.String() + sprintName(rr.Rmail) + " " + sprintName(rr.Email)
-}
-
+func (rr *MINFO) Header() *RR_Header  { return &rr.Hdr }
+func (rr *MINFO) copy() RR            { return &MINFO{*rr.Hdr.copyHeader(), rr.Rmail, rr.Email} }
+func (rr *MINFO) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *MINFO) rdataString() string { return sprintName(rr.Rmail) + " " + sprintName(rr.Email) }
 func (rr *MINFO) len() int {
 	l := len(rr.Rmail) + 1
 	n := len(rr.Email) + 1
@@ -307,26 +306,22 @@ type MR struct {
 	Mr  string `dns:"cdomain-name"`
 }
 
-func (rr *MR) Header() *RR_Header { return &rr.Hdr }
-func (rr *MR) copy() RR           { return &MR{*rr.Hdr.copyHeader(), rr.Mr} }
-func (rr *MR) len() int           { l := len(rr.Mr) + 1; return rr.Hdr.len() + l }
-
-func (rr *MR) String() string {
-	return rr.Hdr.String() + sprintName(rr.Mr)
-}
+func (rr *MR) Header() *RR_Header  { return &rr.Hdr }
+func (rr *MR) copy() RR            { return &MR{*rr.Hdr.copyHeader(), rr.Mr} }
+func (rr *MR) len() int            { l := len(rr.Mr) + 1; return rr.Hdr.len() + l }
+func (rr *MR) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *MR) rdataString() string { return sprintName(rr.Mr) }
 
 type MF struct {
 	Hdr RR_Header
 	Mf  string `dns:"cdomain-name"`
 }
 
-func (rr *MF) Header() *RR_Header { return &rr.Hdr }
-func (rr *MF) copy() RR           { return &MF{*rr.Hdr.copyHeader(), rr.Mf} }
-func (rr *MF) len() int           { return rr.Hdr.len() + len(rr.Mf) + 1 }
-
-func (rr *MF) String() string {
-	return rr.Hdr.String() + sprintName(rr.Mf)
-}
+func (rr *MF) Header() *RR_Header  { return &rr.Hdr }
+func (rr *MF) copy() RR            { return &MF{*rr.Hdr.copyHeader(), rr.Mf} }
+func (rr *MF) len() int            { return rr.Hdr.len() + len(rr.Mf) + 1 }
+func (rr *MF) String() string      { return rr.Hdr.String() + rr.rdataString() }
+func (rr *MF) rdataString() string { return sprintName(rr.Mf) }
 
 type MD struct {
 	Hdr RR_Header
@@ -760,12 +755,13 @@ type A struct {
 func (rr *A) Header() *RR_Header { return &rr.Hdr }
 func (rr *A) copy() RR           { return &A{*rr.Hdr.copyHeader(), copyIP(rr.A)} }
 func (rr *A) len() int           { return rr.Hdr.len() + net.IPv4len }
+func (rr *A) String() string     { return rr.Hdr.String() + rr.rdataString() }
 
-func (rr *A) String() string {
+func (rr *A) rdataString() string {
 	if rr.A == nil {
-		return rr.Hdr.String()
+		return ""
 	}
-	return rr.Hdr.String() + rr.A.String()
+	return rr.A.String()
 }
 
 type AAAA struct {
@@ -776,12 +772,13 @@ type AAAA struct {
 func (rr *AAAA) Header() *RR_Header { return &rr.Hdr }
 func (rr *AAAA) copy() RR           { return &AAAA{*rr.Hdr.copyHeader(), copyIP(rr.AAAA)} }
 func (rr *AAAA) len() int           { return rr.Hdr.len() + net.IPv6len }
+func (rr *AAAA) String() string     { return rr.Hdr.String() + rr.rdataString() }
 
-func (rr *AAAA) String() string {
+func (rr *AAAA) rdataString() string {
 	if rr.AAAA == nil {
-		return rr.Hdr.String()
+		return ""
 	}
-	return rr.Hdr.String() + rr.AAAA.String()
+	return rr.AAAA.String()
 }
 
 type PX struct {


### PR DESCRIPTION
Add a function to dedup an set of RRs. For this to work nicely I needed
something to format an RR with a Sprintf like function. So add that too.
For the Sprintf to work a rdataString() for each RR would be nice: add
that too. The %r modifier in Sprintf allows you to access this.

Don't really want to add RdataString() as an exported function to each
RR, as this add a whole load of extra methods. So just a Sprintf
function.

Also add Dedup function that uses all this.