### PR TITLE
Dedup rrset - WIP do not merge.

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,50 @@
+package dns
+
+import "bytes"
+
+// Contains functions the sanitize RRsets and messages.
+
+// Dedup will deduplicate rrs. It will detect and remove RRs that have
+// an idential ownername, type, class and rdata. Note that the order
+// of the RRs in the set is randomized after this function. TODO(miek): fix the latter.
+// panic when not valid???
+func Dedup(rrs []RR) []RR {
+	buf := make([]byte, MaxMsgSize)
+	m := make(map[string]RR)
+
+	for _, r := range rrs {
+		n, err := PackStruct(r, buf, 0)
+		if err != nil {
+			panic("dns: failure to dedup: " + err.Error())
+		}
+
+		// We are going to normalized the domainname (lowercase it)
+		end, _ := rawDomainNameIndex(buf, 0) // TODO(miek): check boolean?
+		rawSetBytes(buf, 0, end, bytes.ToLower)
+
+		// And set the TTL to 0.
+		rawSetBytes(buf, end+5, end+10, func([]byte) []byte {
+			return []byte{0, 0, 0, 0}
+		})
+
+		key := string(buf[:n]) // make a string (and thus copy) for use in the map
+
+		if r1, ok := m[key]; ok {
+			if r1.Header().Ttl > r.Header().Ttl {
+				m[key].Header().Ttl = r.Header().Ttl
+			}
+			continue
+		}
+		m[key] = r
+	}
+
+	// A map is random so the order here is wrong
+	// We can range over the original rrs, but to find the key in the
+	// map we need to normalize again... TODO(miek)
+	i := 0
+	for _, r := range m {
+		rrs[i] = r
+		i++
+	}
+	return rrs[:i]
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,46 @@
+package dns
+
+import "testing"
+
+func TestDedup(t *testing.T) {
+	in := []RR{
+		newRR("miek.nl. IN A 127.0.0.1"),
+		newRR("miek.nl. IN A 127.0.0.1"),
+	}
+	in = Dedup(in)
+	t.Logf("%v\n", in)
+
+	in = []RR{}
+	in = Dedup(in)
+	t.Logf("%v\n", in)
+
+	in = []RR{
+		newRR("miek.nl. IN A 127.0.0.1"),
+		newRR("miek.nl. IN A 127.0.0.2"),
+	}
+	in = Dedup(in)
+	t.Logf("%v\n", in)
+
+	in = []RR{
+		newRR("miek.nl. IN A 127.0.0.1"),
+		newRR("miek.nl. IN A 127.0.0.2"),
+		newRR("miek.nl. IN A 127.0.0.1"),
+	}
+	in = Dedup(in)
+	t.Logf("%v\n", in)
+
+	in = []RR{
+		newRR("miek.nl. 300 IN A 127.0.0.1"),
+		newRR("miek.nl. 200 IN A 127.0.0.1"),
+	}
+	in = Dedup(in)
+	t.Logf("%v\n", in)
+
+	t.Fail()
+}
+
+// Mainly here to disregard the error.
+func newRR(s string) RR {
+	r, _ := NewRR(s)
+	return r
+}


### PR DESCRIPTION
New approach: work on the binary data and normalize that. Few fixes:
like looking the TTL of the records and a few new problems, like
randomizing the return value.