### PR TITLE
Add Dedup function - take 4 - wip don't merge

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -36,7 +36,7 @@ var (
 	// ErrFqdn indicates that a domain name does not have a closing dot.
 	ErrFqdn error = &Error{err: "domain must be fully qualified"}
 	// ErrId indicates there is a mismatch with the message's ID.
-	ErrId        error = &Error{err: "id mismatch"}
+	ErrId error = &Error{err: "id mismatch"}
 	// ErrKeyAlg indicates that the algorithm in the key is not valid.
 	ErrKeyAlg    error = &Error{err: "bad key algorithm"}
 	ErrKey       error = &Error{err: "bad key"}

--- a/parse_test.go
+++ b/parse_test.go
@@ -907,11 +907,11 @@ func TestILNP(t *testing.T) {
 
 func TestGposEidNimloc(t *testing.T) {
 	dt := map[string]string{
-		"444433332222111199990123000000ff. NSAP-PTR foo.bar.com.":                  "444433332222111199990123000000ff.\t3600\tIN\tNSAP-PTR\tfoo.bar.com.",
-		"lillee. IN  GPOS -32.6882 116.8652 10.0":                                  "lillee.\t3600\tIN\tGPOS\t-32.6882 116.8652 10.0",
-		"hinault. IN GPOS -22.6882 116.8652 250.0":                                 "hinault.\t3600\tIN\tGPOS\t-22.6882 116.8652 250.0",
-		"VENERA.   IN NIMLOC  75234159EAC457800920":                                "VENERA.\t3600\tIN\tNIMLOC\t75234159EAC457800920",
-		"VAXA.     IN EID     3141592653589793":                                    "VAXA.\t3600\tIN\tEID\t3141592653589793",
+		"444433332222111199990123000000ff. NSAP-PTR foo.bar.com.": "444433332222111199990123000000ff.\t3600\tIN\tNSAP-PTR\tfoo.bar.com.",
+		"lillee. IN  GPOS -32.6882 116.8652 10.0":                 "lillee.\t3600\tIN\tGPOS\t-32.6882 116.8652 10.0",
+		"hinault. IN GPOS -22.6882 116.8652 250.0":                "hinault.\t3600\tIN\tGPOS\t-22.6882 116.8652 250.0",
+		"VENERA.   IN NIMLOC  75234159EAC457800920":               "VENERA.\t3600\tIN\tNIMLOC\t75234159EAC457800920",
+		"VAXA.     IN EID     3141592653589793":                   "VAXA.\t3600\tIN\tEID\t3141592653589793",
 	}
 	for i, o := range dt {
 		rr, err := NewRR(i)
@@ -1507,7 +1507,7 @@ func TestPackCAA(t *testing.T) {
 func TestParseURI(t *testing.T) {
 	lt := map[string]string{
 		"_http._tcp. IN URI   10 1 \"http://www.example.com/path\"": "_http._tcp.\t3600\tIN\tURI\t10 1 \"http://www.example.com/path\"",
-		"_http._tcp. IN URI   10 1 \"\"": "_http._tcp.\t3600\tIN\tURI\t10 1 \"\"",
+		"_http._tcp. IN URI   10 1 \"\"":                            "_http._tcp.\t3600\tIN\tURI\t10 1 \"\"",
 	}
 	for i, o := range lt {
 		rr, err := NewRR(i)

--- a/privaterr.go
+++ b/privaterr.go
@@ -49,7 +49,7 @@ func mkPrivateRR(rrtype uint16) *PrivateRR {
 // Header return the RR header of r.
 func (r *PrivateRR) Header() *RR_Header { return &r.Hdr }
 
-func (r *PrivateRR) String() string     { return r.Hdr.String() + r.Data.String() }
+func (r *PrivateRR) String() string { return r.Hdr.String() + r.Data.String() }
 
 // Private len and copy parts to satisfy RR interface.
 func (r *PrivateRR) len() int { return r.Hdr.len() + r.Data.Len() }

--- a/sanitize.go
+++ b/sanitize.go
@@ -117,6 +117,8 @@ func normalizedString(r RR) (string, int) {
 // needsDeletion checks if the RR is masked by either a CNAME or a DNAME.
 // If so it return true.
 func needsDeletion(r RR, s string, cname, dname []string) bool {
+	// TODO(miek): fix.
+	// This is too broad, but we have to be care full not to delete ourselves.
 	if r.Header().Rrtype == TypeCNAME || r.Header().Rrtype == TypeDNAME {
 		return false
 	}

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,10 +1,11 @@
 package dns
 
 // Dedup removes identical RRs from rrs. It preserves the original ordering.
+// The lowest TTL of any duplicates is used in the remaining one.
 // TODO(miek): CNAME, DNAME 'n stuff.
 func Dedup(rrs []RR) []RR {
 	m := make(map[string]RR)
-	keys := []string{}
+	keys := make([]string, 0, len(rrs))
 
 	for _, r := range rrs {
 		key := normalizedString(r)
@@ -19,8 +20,7 @@ func Dedup(rrs []RR) []RR {
 		m[key] = r
 	}
 	// If the length of the result map equals the amount of RRs we got,
-	// it means they were all different. We can then just return the original
-	// rrset.
+	// it means they were all different. We can then just return the original rrset.
 	if len(m) == len(rrs) {
 		return rrs
 	}

--- a/sanitize.go
+++ b/sanitize.go
@@ -8,28 +8,28 @@ package dns
 // if it finds a: a.miek.nl. CNAME foo, all other RRs with the ownername a.miek.nl.
 // will be removed. When a DNAME is found all RRs with an ownername below that of
 // the DNAME will be removed.
+// Note that the class of the CNAME/DNAME is *not* taken into account. TODO(miek)?
 func Dedup(rrs []RR) []RR {
 	m := make(map[string]RR)
 	keys := make([]string, 0, len(rrs))
-	var cname map[nameClass]bool
-	var dname map[nameClass]bool
 
-	for _, r := range rrs {
+	/*
+		make separate step that remove cname, dname
 		switch r.Header().Rrtype {
 		case TypeCNAME:
-			if cname == nil {
-				cname = make(map[nameClass]bool)
-			}
-			cname[nameClass{r.Header().Name, r.Header().Class}] = true
+			cname = append(cname, strings.ToLower(r.Header().Name))
 		case TypeDNAME:
-			if dname == nil {
-				dname = make(map[nameClass]bool)
-			}
-			dname[nameClass{r.Header().Name, r.Header().Class}] = true
+			dname = append(dname, strings.ToLower(r.Header().Name))
 		default:
-			if
+			if len(cname) == 0 && len(dname) == 0 {
+				break
+			}
+			if strings.EqualFold
 		}
+	*/
 
+
+	for _, r := range rrs {
 		key := normalizedString(r)
 		keys = append(keys, key)
 		if _, ok := m[key]; ok {
@@ -55,12 +55,6 @@ func Dedup(rrs []RR) []RR {
 		delete(m, keys[i])
 	}
 	return rrs[:i]
-}
-
-// nameClass is used to index the CNAME and DNAME maps.
-type nameClass struct {
-	name string
-	class uint16
 }
 
 // normalizedString returns a normalized string from r. The TTL

--- a/sanitize.go
+++ b/sanitize.go
@@ -54,6 +54,8 @@ func Dedup(rrs []RR) []RR {
 		// it from the map.
 		if _, ok := m[keys[i]]; ok {
 			if needsDeletion(r, keys[i], cname, dname) {
+				// It the RR is masked by an CNAME or DNAME, we only
+				// delete it from the map, but don't copy it.
 				delete(m, keys[i])
 				continue
 			}

--- a/sanitize.go
+++ b/sanitize.go
@@ -84,7 +84,7 @@ func normalizedString(r RR) string {
 // dropCNAMEAndDNAME drops records from rrs that are not allowed, taking the rules
 // for CNAME and DNAME into account.
 func dropCNAMEAndDNAME(rrs []RR) []RR {
-	ret := make([]RR, 0, len(rrs)
+	ret := make([]RR, 0, len(rrs))
 
 
 	return nil

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,26 +1,13 @@
 package dns
 
-import "strings"
-
 // Dedup removes identical RRs from rrs. It preserves the original ordering.
 // The lowest TTL of any duplicates is used in the remaining one.
-//
-// TODO(miek): This function will be extended to also look for CNAMEs and DNAMEs.
-// if found, it will prune rrs from the "other data" that can exist. Example:
-// if it finds a: a.miek.nl. CNAME foo, all other RRs with the ownername a.miek.nl.
-// will be removed. When a DNAME is found all RRs with an ownername below that of
-// the DNAME will be removed.
 func Dedup(rrs []RR) []RR {
 	m := make(map[string]RR)
 	keys := make([]string, 0, len(rrs))
 
-	// Save possible cname and dname domainnames. Currently a slice, don't
-	// expect millions here..
-	cname := []string{}
-	dname := []string{}
-
 	for _, r := range rrs {
-		key, end := normalizedString(r)
+		key := normalizedString(r)
 		keys = append(keys, key)
 		if _, ok := m[key]; ok {
 			// Shortest TTL wins.
@@ -30,37 +17,18 @@ func Dedup(rrs []RR) []RR {
 			continue
 		}
 
-		if r.Header().Rrtype == TypeCNAME {
-			// we do end+3 here, so we capture the full domain name *and*
-			// the class field which mnemonic is always two chars.
-			cname = append(cname, key[:end+3])
-
-		}
-		if r.Header().Rrtype == TypeDNAME {
-			dname = append(dname, key[:end+3])
-		}
-
 		m[key] = r
 	}
 	// If the length of the result map equals the amount of RRs we got,
 	// it means they were all different. We can then just return the original rrset.
-	// We can only do this when we haven't found a CNAME or DNAME.
-	if len(m) == len(rrs) && len(cname) == 0 && len(dname) == 0 {
+	if len(m) == len(rrs) {
 		return rrs
 	}
 
 	ret := make([]RR, 0, len(rrs))
 	for i, r := range rrs {
-		// If keys[i] lives in the map, we should copy it and remove
-		// it from the map.
+		// If keys[i] lives in the map, we should copy and remove it.
 		if _, ok := m[keys[i]]; ok {
-			if needsDeletion(r, keys[i], cname, dname) {
-				// It the RR is masked by an CNAME or DNAME, we only
-				// delete it from the map, but don't copy it.
-				delete(m, keys[i])
-				continue
-			}
-
 			delete(m, keys[i])
 			ret = append(ret, r)
 		}
@@ -74,70 +42,37 @@ func Dedup(rrs []RR) []RR {
 }
 
 // normalizedString returns a normalized string from r. The TTL
-// is removed and the domain name is lowercased. The returned integer
-// is the index where the domain name ends + 1.
-func normalizedString(r RR) (string, int) {
+// is removed and the domain name is lowercased. We go from this:
+// DomainName<TAB>TTL<TAB>CLASS<TAB>TYPE<TAB>RDATA to:
+// lowercasename<TAB>CLASS<TAB>TYPE...
+func normalizedString(r RR) string {
 	// A string Go DNS makes has: domainname<TAB>TTL<TAB>...
 	b := []byte(r.String())
 
-	// find the first non-escaped tab, then another, so we capture
-	// where the TTL lives.
+	// find the first non-escaped tab, then another, so we capture where the TTL lives.
 	esc := false
 	ttlStart, ttlEnd := 0, 0
-	for i, c := range b {
-		if c == '\\' {
-			esc = true
-			continue
-		}
-		if esc {
-			esc = false
-			continue
-		}
-		if c == '\t' {
+	for i := 0; i < len(b) && ttlEnd == 0; i++ {
+		switch {
+		case b[i] == '\\':
+			esc = !esc
+		case b[i] == '\t' && !esc:
 			if ttlStart == 0 {
 				ttlStart = i
 				continue
 			}
 			if ttlEnd == 0 {
 				ttlEnd = i
-				break
 			}
-		}
-		if c >= 'A' && c <= 'Z' {
-			b[i] = c + 32
+		case b[i] >= 'A' && b[i] <= 'Z' && !esc:
+			b[i] += 32
+		default:
+			esc = false
 		}
 	}
 
 	// remove TTL.
 	copy(b[ttlStart:], b[ttlEnd:])
 	cut := ttlEnd - ttlStart
-	// ttlStart + 3 puts us on the start of the rdata
-	return string(b[:len(b)-cut]), ttlStart
-}
-
-// needsDeletion checks if the RR is masked by either a CNAME or a DNAME.
-// If so it return true.
-func needsDeletion(r RR, s string, cname, dname []string) bool {
-	// For CNAME we can do strings.HasPrefix with s.
-	// For DNAME we can do strings.Contains with s.
-	// Either signals a removal of this RR.
-	for _, c := range cname {
-		if strings.HasPrefix(s, c) {
-			if r.Header().Rrtype == TypeCNAME {
-				// don't delete yourself
-				continue
-			}
-			return true
-		}
-	}
-	for _, d := range dname {
-		if strings.Contains(s, d) {
-			if r.Header().Rrtype == TypeDNAME && strings.HasPrefix(s, d) {
-				// don't delete yourself
-				continue
-			}
-			return true
-		}
-	}
-	return false
+	return string(b[:len(b)-cut])
 }

--- a/sanitize.go
+++ b/sanitize.go
@@ -13,22 +13,6 @@ func Dedup(rrs []RR) []RR {
 	m := make(map[string]RR)
 	keys := make([]string, 0, len(rrs))
 
-	/*
-		make separate step that remove cname, dname
-		switch r.Header().Rrtype {
-		case TypeCNAME:
-			cname = append(cname, strings.ToLower(r.Header().Name))
-		case TypeDNAME:
-			dname = append(dname, strings.ToLower(r.Header().Name))
-		default:
-			if len(cname) == 0 && len(dname) == 0 {
-				break
-			}
-			if strings.EqualFold
-		}
-	*/
-
-
 	for _, r := range rrs {
 		key := normalizedString(r)
 		keys = append(keys, key)
@@ -95,4 +79,29 @@ func normalizedString(r RR) string {
 	copy(b[ttlStart:], b[ttlEnd:])
 	cut := ttlEnd - ttlStart
 	return string(b[:len(b)-cut])
+}
+
+// dropCNAMEAndDNAME drops records from rrs that are not allowed, taking the rules
+// for CNAME and DNAME into account.
+func dropCNAMEAndDNAME(rrs []RR) []RR {
+	ret := make([]RR, 0, len(rrs)
+
+
+	return nil
+	/*
+		make separate step that remove cname, dname
+		switch r.Header().Rrtype {
+		case TypeCNAME:
+			cname = append(cname, strings.ToLower(r.Header().Name))
+		case TypeDNAME:
+			dname = append(dname, strings.ToLower(r.Header().Name))
+		default:
+			if len(cname) == 0 && len(dname) == 0 {
+				break
+			}
+			if strings.EqualFold
+		}
+	*/
+
+
 }

--- a/sanitize.go
+++ b/sanitize.go
@@ -8,8 +8,7 @@ func Dedup(rrs []RR, m map[string]RR) []RR {
 	if m == nil {
 		m = make(map[string]RR)
 	}
-	// We need a (ordered) slice of keys to preserve the original ordering.
-	// Otherwise we could just range of the map directly.
+	// Save the keys, so we don't have to call normalizedString twice.
 	keys := make([]*string, 0, len(rrs))
 
 	for _, r := range rrs {

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,76 @@
+package dns
+
+// Dedup removes identical RRs from rrs. It preserves the original ordering.
+// TODO(miek): CNAME, DNAME 'n stuff.
+func Dedup(rrs []RR) []RR {
+	m := make(map[string]RR)
+	keys := []string{}
+
+	for _, r := range rrs {
+		key := normalizedString(r)
+		keys = append(keys, key)
+		if _, ok := m[key]; ok {
+			// Shortest TTL wins.
+			if m[key].Header().Ttl > r.Header().Ttl {
+				m[key].Header().Ttl = r.Header().Ttl
+			}
+			continue
+		}
+		m[key] = r
+	}
+	// If the length of the result map equals the amount of RRs we got,
+	// it means they were all different. We can then just return the original
+	// rrset.
+	if len(m) == len(rrs) {
+		return rrs
+	}
+	var i = 0
+	for i, _ = range rrs {
+		if len(m) == 0 {
+			break
+		}
+		// We saved the key for each RR.
+		delete(m, keys[i])
+	}
+	return rrs[:i]
+}
+
+// normalizedString returns a normalized string from r. The TTL
+// is removed and the domain name is lowercased.
+func normalizedString(r RR) string {
+	// A string Go DNS makes has: domainname<TAB>TTL<TAB>...
+	b := []byte(r.String())
+
+	// find the first non-escaped tab, then another, so we capture
+	// where the TTL lives.
+	esc := false
+	ttlStart, ttlEnd := 0, 0
+	for i, c := range b {
+		if c == '\\' {
+			esc = true
+			continue
+		}
+		if esc {
+			esc = false
+			continue
+		}
+		if c == '\t' {
+			if ttlStart == 0 {
+				ttlStart = i
+				continue
+			}
+			if ttlEnd == 0 {
+				ttlEnd = i
+				break
+			}
+		}
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + 32
+		}
+	}
+
+	// remove TTL.
+	copy(b[ttlStart:], b[ttlEnd:])
+	cut := ttlEnd - ttlStart
+	return string(b[:len(b)-cut])
+}

--- a/sanitize.go
+++ b/sanitize.go
@@ -114,6 +114,8 @@ func normalizedString(r RR) (string, int) {
 	return string(b[:len(b)-cut]), ttlStart
 }
 
+// needsDeletion checks if the RR is masked by either a CNAME or a DNAME.
+// If so it return true.
 func needsDeletion(r RR, s string, cname, dname []string) bool {
 	if r.Header().Rrtype == TypeCNAME || r.Header().Rrtype == TypeDNAME {
 		return false

--- a/sanitize.go
+++ b/sanitize.go
@@ -2,7 +2,11 @@ package dns
 
 // Dedup removes identical RRs from rrs. It preserves the original ordering.
 // The lowest TTL of any duplicates is used in the remaining one.
-// TODO(miek): CNAME, DNAME 'n stuff.
+//
+// TODO(miek): This function will be extended to also look for CNAMEs and DNAMEs.
+// if found, it will prune rrs from the "other data" that can exist. Example:
+// if it finds a: a.miek.nl. CNAME foo, all other RRs with the ownername a.miek.nl.
+// will be removed.
 func Dedup(rrs []RR) []RR {
 	m := make(map[string]RR)
 	keys := make([]string, 0, len(rrs))

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,42 +1,63 @@
 package dns
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestDedup(t *testing.T) {
-	testcases := map[[3]RR]string{
+	// make it []string
+	testcases := map[[3]RR][]string{
 		[...]RR{
 			newRR(t, "mIek.nl. IN A 127.0.0.1"),
 			newRR(t, "mieK.nl. IN A 127.0.0.1"),
 			newRR(t, "miek.Nl. IN A 127.0.0.1"),
-		}: "mIek.nl.\t3600\tIN\tA\t127.0.0.1",
+		}: []string{"mIek.nl.\t3600\tIN\tA\t127.0.0.1"},
 		[...]RR{
 			newRR(t, "miEk.nl. 2000 IN A 127.0.0.1"),
 			newRR(t, "mieK.Nl. 1000 IN A 127.0.0.1"),
 			newRR(t, "Miek.nL. 500 IN A 127.0.0.1"),
-		}: "miEk.nl.\t500\tIN\tA\t127.0.0.1",
+		}: []string{"miEk.nl.\t500\tIN\tA\t127.0.0.1"},
 		[...]RR{
 			newRR(t, "miek.nl. IN A 127.0.0.1"),
 			newRR(t, "miek.nl. CH A 127.0.0.1"),
 			newRR(t, "miek.nl. IN A 127.0.0.1"),
-		}: "miek.nl.\t3600\tIN\tA\t127.0.0.1",
+		}: []string{"miek.nl.\t3600\tIN\tA\t127.0.0.1",
+			"miek.nl.\t3600\tCH\tA\t127.0.0.1",
+		},
 		[...]RR{
 			newRR(t, "miek.nl. CH A 127.0.0.1"),
 			newRR(t, "miek.nl. IN A 127.0.0.1"),
+			newRR(t, "miek.de. IN A 127.0.0.1"),
+		}: []string{"miek.nl.\t3600\tCH\tA\t127.0.0.1",
+			"miek.de.\t3600\tIN\tA\t127.0.0.1",
+		},
+		[...]RR{
+			newRR(t, "miek.de. IN A 127.0.0.1"),
 			newRR(t, "miek.nl. IN A 127.0.0.1"),
-		}: "miek.nl.\t3600\tCH\tA\t127.0.0.1",
+			newRR(t, "miek.nl. IN A 127.0.0.1"),
+		}: []string{"miek.de.\t3600\tIN\tA\t127.0.0.1",
+			"miek.de.\t3600\tIN\tA\t127.0.0.1",
+		},
 	}
 
 	for rr, expected := range testcases {
 		out := Dedup([]RR{rr[0], rr[1], rr[2]})
-		if len(out) == 0 || len(out) == 3 {
-			t.Logf("dedup failed, wrong number of RRs returned")
-			t.Fail()
-		}
-		if o := out[0].String(); o != expected {
-			t.Logf("dedup failed, expected %s, got %s", expected, o)
-			t.Fail()
+		if !reflect.DeepEqual(out, expected) {
+			t.Fatalf("expected %v, got %v", expected, out)
 		}
 	}
+}
+
+func TestDedupWithCNAME(t *testing.T) {
+	in := []RR{
+		newRR(t, "miek.Nl. CNAME a."),
+		newRR(t, "miEk.nl. IN A 127.0.0.1"),
+		newRR(t, "miek.Nl. IN A 127.0.0.1"),
+		newRR(t, "miek.de. IN A 127.0.0.1"),
+	}
+	out := Dedup(in)
+	t.Logf("%+v\n", out)
 }
 
 func TestNormalizedString(t *testing.T) {
@@ -46,7 +67,7 @@ func TestNormalizedString(t *testing.T) {
 		newRR(t, "m\\\tIeK.nl. 3600 in A 127.0.0.1"): "m\\tiek.nl.\tIN\tA\t127.0.0.1",
 	}
 	for tc, expected := range tests {
-		a1 := normalizedString(tc)
+		a1, _ := normalizedString(tc)
 		if a1 != expected {
 			t.Logf("expected %s, got %s", expected, a1)
 			t.Fail()

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -70,14 +70,14 @@ func TestDedupWithCNAMEDNAME(t *testing.T) {
 			newRR(t, "a.miek.nl. CNAME a."),
 			newRR(t, "a.miek.nl. CNAME a."),
 		}: []string{"miek.nl.\t3600\tIN\tCNAME\ta.",
-		"a.miek.nl.\t3600\tIN\tCNAME\ta."},
+			"a.miek.nl.\t3600\tIN\tCNAME\ta."},
 		[...]RR{
 			newRR(t, "miek.nl. DNAME a."),
 			newRR(t, "a.miek.nl. CNAME a."),
 			newRR(t, "b.miek.nl. IN A 127.0.0.1"),
 			newRR(t, "a.miek.de. IN A 127.0.0.1"),
 		}: []string{"miek.nl.\t3600\tIN\tDNAME\ta.",
-		"a.miek.de.\t3600\tIN\tA\t127.0.0.1"},
+			"a.miek.de.\t3600\tIN\tA\t127.0.0.1"},
 		[...]RR{
 			newRR(t, "miek.nl. DNAME a."),
 			newRR(t, "a.miek.nl. DNAME a."),

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -39,15 +39,13 @@ func TestDedup(t *testing.T) {
 		},
 	}
 
-	T := 0
 	for rr, expected := range testcases {
 		out := Dedup([]RR{rr[0], rr[1], rr[2]})
 		for i, o := range out {
 			if o.String() != expected[i] {
-				t.Fatalf("test %d, expected %v, got %v", T, expected[i], o.String())
+				t.Fatalf("expected %v, got %v", expected[i], o.String())
 			}
 		}
-		T++
 	}
 }
 
@@ -88,17 +86,17 @@ func TestDedupWithCNAMEDNAME(t *testing.T) {
 		}: []string{"miek.nl.\t3600\tIN\tDNAME\ta."},
 	}
 
-	T := 0
 	for rr, expected := range testcases {
 		out := Dedup([]RR{rr[0], rr[1], rr[2], rr[3]})
 		for i, o := range out {
 			if o.String() != expected[i] {
-				t.Fatalf("test %d, expected %v, got %v", T, expected[i], o.String())
+				t.Fatalf("expected %v, got %v", expected[i], o.String())
 			}
 		}
-		T++
 	}
 }
+
+// BenchMark test as well TODO(miek)
 
 func TestNormalizedString(t *testing.T) {
 	tests := map[RR]string{

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,83 @@
+package dns
+
+import "testing"
+
+func TestDedup(t *testing.T) {
+	in := []RR{
+		newRR(t, "miek.nl. IN A 127.0.0.1"),
+		newRR(t, "miek.nl. IN A 127.0.0.1"),
+	}
+	out := Dedup(in)
+	if len(out) != 1 && out[0].String() != "miek.nl. IN A 127.0.0.1" {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 1, len(out))
+	}
+
+	in = []RR{}
+	out = Dedup(in)
+	if len(out) != 0 {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 0, len(out))
+	}
+
+	in = []RR{
+		newRR(t, "miEk.nl. 2000 IN A 127.0.0.1"),
+		newRR(t, "mieK.Nl. 1000 IN A 127.0.0.1"),
+	}
+	out = Dedup(in)
+	if len(out) != 1 {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	}
+
+	in = []RR{
+		newRR(t, "miek.nl. IN A 127.0.0.1"),
+		newRR(t, "miek.nl. CH A 127.0.0.1"),
+	}
+	out = Dedup(in)
+	if len(out) != 2 {
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	}
+	in = []RR{
+		newRR(t, "miek.nl. CH A 127.0.0.1"),
+		newRR(t, "miek.nl. IN A 127.0.0.1"),
+		newRR(t, "mIek.Nl. IN A 127.0.0.1"),
+	}
+	out = Dedup(in)
+	if len(out) != 2 {
+		// TODO(miek): check ordering.
+		dump(out, t)
+		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	}
+}
+
+func dump(rrs []RR, t *testing.T) {
+	t.Logf("********\n")
+	for _, r := range rrs {
+		t.Logf("%v\n", r)
+	}
+}
+
+func TestNormalizedString(t *testing.T) {
+	tests := map[RR]string{
+		newRR(t, "mIEk.Nl. 3600 IN A 127.0.0.1"):     "miek.nl.\tIN\tA\t127.0.0.1",
+		newRR(t, "m\\ iek.nL. 3600 IN A 127.0.0.1"):  "m\\ iek.nl.\tIN\tA\t127.0.0.1",
+		newRR(t, "m\\\tIeK.nl. 3600 in A 127.0.0.1"): "m\\tiek.nl.\tIN\tA\t127.0.0.1",
+	}
+	for tc, expected := range tests {
+		a1 := normalizedString(tc)
+		if a1 != expected {
+			t.Logf("expected %s, got %s", expected, a1)
+			t.Fail()
+		}
+	}
+}
+
+func newRR(t *testing.T, s string) RR {
+	r, e := NewRR(s)
+	if e != nil {
+		t.Logf("newRR: %s", e)
+	}
+	return r
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -3,59 +3,39 @@ package dns
 import "testing"
 
 func TestDedup(t *testing.T) {
-	in := []RR{
-		newRR(t, "miek.nl. IN A 127.0.0.1"),
-		newRR(t, "miek.nl. IN A 127.0.0.1"),
-	}
-	out := Dedup(in)
-	if len(out) != 1 && out[0].String() != "miek.nl. IN A 127.0.0.1" {
-		dump(out, t)
-		t.Errorf("dedup failed, expected %d, got %d", 1, len(out))
-	}
-
-	in = []RR{}
-	out = Dedup(in)
-	if len(out) != 0 {
-		dump(out, t)
-		t.Errorf("dedup failed, expected %d, got %d", 0, len(out))
-	}
-
-	in = []RR{
-		newRR(t, "miEk.nl. 2000 IN A 127.0.0.1"),
-		newRR(t, "mieK.Nl. 1000 IN A 127.0.0.1"),
-	}
-	out = Dedup(in)
-	if len(out) != 1 {
-		dump(out, t)
-		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
+	testcases := map[[3]RR]string{
+		[...]RR{
+			newRR(t, "mIek.nl. IN A 127.0.0.1"),
+			newRR(t, "mieK.nl. IN A 127.0.0.1"),
+			newRR(t, "miek.Nl. IN A 127.0.0.1"),
+		}: "mIek.nl.\t3600\tIN\tA\t127.0.0.1",
+		[...]RR{
+			newRR(t, "miEk.nl. 2000 IN A 127.0.0.1"),
+			newRR(t, "mieK.Nl. 1000 IN A 127.0.0.1"),
+			newRR(t, "Miek.nL. 500 IN A 127.0.0.1"),
+		}: "miEk.nl.\t500\tIN\tA\t127.0.0.1",
+		[...]RR{
+			newRR(t, "miek.nl. IN A 127.0.0.1"),
+			newRR(t, "miek.nl. CH A 127.0.0.1"),
+			newRR(t, "miek.nl. IN A 127.0.0.1"),
+		}: "miek.nl.\t3600\tIN\tA\t127.0.0.1",
+		[...]RR{
+			newRR(t, "miek.nl. CH A 127.0.0.1"),
+			newRR(t, "miek.nl. IN A 127.0.0.1"),
+			newRR(t, "miek.nl. IN A 127.0.0.1"),
+		}: "miek.nl.\t3600\tCH\tA\t127.0.0.1",
 	}
 
-	in = []RR{
-		newRR(t, "miek.nl. IN A 127.0.0.1"),
-		newRR(t, "miek.nl. CH A 127.0.0.1"),
-	}
-	out = Dedup(in)
-	if len(out) != 2 {
-		dump(out, t)
-		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
-	}
-	in = []RR{
-		newRR(t, "miek.nl. CH A 127.0.0.1"),
-		newRR(t, "miek.nl. IN A 127.0.0.1"),
-		newRR(t, "mIek.Nl. IN A 127.0.0.1"),
-	}
-	out = Dedup(in)
-	if len(out) != 2 {
-		// TODO(miek): check ordering.
-		dump(out, t)
-		t.Errorf("dedup failed, expected %d, got %d", 2, len(out))
-	}
-}
-
-func dump(rrs []RR, t *testing.T) {
-	t.Logf("********\n")
-	for _, r := range rrs {
-		t.Logf("%v\n", r)
+	for rr, expected := range testcases {
+		out := Dedup([]RR{rr[0], rr[1], rr[2]})
+		if len(out) == 0 || len(out) == 3 {
+			t.Logf("dedup failed, wrong number of RRs returned")
+			t.Fail()
+		}
+		if o := out[0].String(); o != expected {
+			t.Logf("dedup failed, expected %s, got %s", expected, o)
+			t.Fail()
+		}
 	}
 }
 

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -40,7 +40,7 @@ func TestDedup(t *testing.T) {
 	}
 
 	for rr, expected := range testcases {
-		out := Dedup([]RR{rr[0], rr[1], rr[2]})
+		out := Dedup([]RR{rr[0], rr[1], rr[2]}, nil)
 		for i, o := range out {
 			if o.String() != expected[i] {
 				t.Fatalf("expected %v, got %v", expected[i], o.String())
@@ -55,8 +55,9 @@ func BenchmarkDedup(b *testing.B) {
 		newRR(nil, "mieK.Nl. 1000 IN A 127.0.0.1"),
 		newRR(nil, "Miek.nL. 500 IN A 127.0.0.1"),
 	}
+	m := make(map[string]RR)
 	for i := 0; i < b.N; i++ {
-		Dedup(rrs)
+		Dedup(rrs,m )
 	}
 }
 

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -66,11 +66,31 @@ func TestDedupWithCNAMEDNAME(t *testing.T) {
 			newRR(t, "miEk.nl. CNAME a."),
 			newRR(t, "mieK.nl. CNAME a."),
 		}: []string{"Miek.nl.\t3600\tIN\tCNAME\ta."},
+		[...]RR{
+			newRR(t, "miek.nl. CNAME a."),
+			newRR(t, "a.miek.nl. CNAME a."),
+			newRR(t, "a.miek.nl. CNAME a."),
+			newRR(t, "a.miek.nl. CNAME a."),
+		}: []string{"miek.nl.\t3600\tIN\tCNAME\ta.",
+		"a.miek.nl.\t3600\tIN\tCNAME\ta."},
+		[...]RR{
+			newRR(t, "miek.nl. DNAME a."),
+			newRR(t, "a.miek.nl. CNAME a."),
+			newRR(t, "b.miek.nl. IN A 127.0.0.1"),
+			newRR(t, "a.miek.de. IN A 127.0.0.1"),
+		}: []string{"miek.nl.\t3600\tIN\tDNAME\ta.",
+		"a.miek.de.\t3600\tIN\tA\t127.0.0.1"},
+		[...]RR{
+			newRR(t, "miek.nl. DNAME a."),
+			newRR(t, "a.miek.nl. DNAME a."),
+			newRR(t, "b.miek.nl. DNAME b."),
+			newRR(t, "a.b.miek.nl. DNAME a.b"),
+		}: []string{"miek.nl.\t3600\tIN\tDNAME\ta."},
 	}
 
 	T := 0
 	for rr, expected := range testcases {
-		out := Dedup([]RR{rr[0], rr[1], rr[2]})
+		out := Dedup([]RR{rr[0], rr[1], rr[2], rr[3]})
 		for i, o := range out {
 			if o.String() != expected[i] {
 				t.Fatalf("test %d, expected %v, got %v", T, expected[i], o.String())


### PR DESCRIPTION
Add function that dedups a list of RRs. Work on strings, which
adds garbage, but seems to be the least intrusive and takes the
last amount of memory.

Some fmt changes snook in as well.