### PR TITLE
Allow supplying a Conn in Transfer struct

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -23,14 +23,26 @@ type Transfer struct {
 // Think we need to away to stop the transfer
 
 // In performs an incoming transfer with the server in a.
+// If you would like to set the source IP, or some other attribute
+// of a Dialer for a Transfer, you can do so by specifying the attributes
+// in the Transfer.Conn:
+//
+//	d := net.Dialer{LocalAddr: transfer_source}
+//	con, _ := d.Dial("tcp", *master)
+//	dnscon := &dns.Conn{Conn:con}
+//	transfer = &dns.Transfer{Conn: dnscon}
+//	channel, err := transfer.In(message, *master)
+//
 func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 	timeout := dnsTimeout
 	if t.DialTimeout != 0 {
 		timeout = t.DialTimeout
 	}
-	t.Conn, err = DialTimeout("tcp", a, timeout)
-	if err != nil {
-		return nil, err
+	if t.Conn == nil {
+		t.Conn, err = DialTimeout("tcp", a, timeout)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := t.WriteMsg(q); err != nil {
 		return nil, err


### PR DESCRIPTION
- This allows a user to call `Dial` before they call `Transfer.In`,
thus specifying the attributes of a [Dialer](https://golang.org/src/net/dial.go?s=5630:5708#L17)
before their AXFR

This is what it looks like to use:
```go
d := net.Dialer{LocalAddr: transfer_source}
c, _ := d.Dial("tcp", *master)
dnscon := &dns.Conn{Conn:c}
transfer = &dns.Transfer{Conn: dnscon}
channel, err := transfer.In(message, *master)
```
closes #264