### PR TITLE
tidyup a little with the latest golang.org/x/tools/cmd/vet

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -161,8 +161,8 @@ func TestClientEDNS0Local(t *testing.T) {
 	}
 }
 
-// Example_updateLeaseTSIG shows how to update a lease signed with TSIG.
-func Example_updateLeaseTSIG() {
+// ExampleTsigSecret_updateLeaseTSIG shows how to update a lease signed with TSIG.
+func ExampleTsigSecret_updateLeaseTSIG() {
 	m := new(Msg)
 	m.SetUpdate("t.local.ip6.io.")
 	rr, _ := NewRR("t.local.ip6.io. 30 A 127.0.0.1")

--- a/client_test.go
+++ b/client_test.go
@@ -161,7 +161,7 @@ func TestClientEDNS0Local(t *testing.T) {
 	}
 }
 
-// ExampleTsigSecret_updateLeaseTSIG shows how to update a lease signed with TSIG.
+// ExampleTsigSecret_updateLeaseTSIG shows how to update a lease signed with TSIG
 func ExampleTsigSecret_updateLeaseTSIG() {
 	m := new(Msg)
 	m.SetUpdate("t.local.ip6.io.")

--- a/client_test.go
+++ b/client_test.go
@@ -161,8 +161,8 @@ func TestClientEDNS0Local(t *testing.T) {
 	}
 }
 
-// ExampleUpdateLeaseTSIG shows how to update a lease signed with TSIG.
-func ExampleUpdateLeaseTSIG(t *testing.T) {
+// Example_updateLeaseTSIG shows how to update a lease signed with TSIG.
+func Example_updateLeaseTSIG() {
 	m := new(Msg)
 	m.SetUpdate("t.local.ip6.io.")
 	rr, _ := NewRR("t.local.ip6.io. 30 A 127.0.0.1")
@@ -185,7 +185,7 @@ func ExampleUpdateLeaseTSIG(t *testing.T) {
 
 	_, _, err := c.Exchange(m, "127.0.0.1:53")
 	if err != nil {
-		t.Error(err)
+		panic(err)
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,9 +3,10 @@ package dns_test
 import (
 	"errors"
 	"fmt"
-	"github.com/miekg/dns"
 	"log"
 	"net"
+
+	"github.com/miekg/dns"
 )
 
 // Retrieve the MX records for miek.nl.
@@ -31,11 +32,11 @@ func ExampleMX() {
 
 // Retrieve the DNSKEY records of a zone and convert them
 // to DS records for SHA1, SHA256 and SHA384.
-func ExampleDNSKEY() {
+func ExampleDS() {
 	config, _ := dns.ClientConfigFromFile("/etc/resolv.conf")
 	c := new(dns.Client)
 	m := new(dns.Msg)
-    zone := "miek.nl"
+	zone = "miek.nl"
 	m.SetQuestion(dns.Fqdn(zone), dns.TypeDNSKEY)
 	m.SetEdns0(4096, true)
 	r, _, err := c.Exchange(m, config.Servers[0]+":"+config.Port)

--- a/example_test.go
+++ b/example_test.go
@@ -31,13 +31,11 @@ func ExampleMX() {
 
 // Retrieve the DNSKEY records of a zone and convert them
 // to DS records for SHA1, SHA256 and SHA384.
-func ExampleDS(zone string) {
+func ExampleDNSKEY() {
 	config, _ := dns.ClientConfigFromFile("/etc/resolv.conf")
 	c := new(dns.Client)
 	m := new(dns.Msg)
-	if zone == "" {
-		zone = "miek.nl"
-	}
+    zone := "miek.nl"
 	m.SetQuestion(dns.Fqdn(zone), dns.TypeDNSKEY)
 	m.SetEdns0(4096, true)
 	r, _, err := c.Exchange(m, config.Servers[0]+":"+config.Port)

--- a/example_test.go
+++ b/example_test.go
@@ -36,7 +36,7 @@ func ExampleDS() {
 	config, _ := dns.ClientConfigFromFile("/etc/resolv.conf")
 	c := new(dns.Client)
 	m := new(dns.Msg)
-	zone = "miek.nl"
+	zone := "miek.nl"
 	m.SetQuestion(dns.Fqdn(zone), dns.TypeDNSKEY)
 	m.SetEdns0(4096, true)
 	r, _, err := c.Exchange(m, config.Servers[0]+":"+config.Port)

--- a/idn/punycode.go
+++ b/idn/punycode.go
@@ -199,7 +199,6 @@ func needFromPunycode(s string) bool {
 			return true
 		}
 	}
-	panic("dns: not reached")
 }
 
 // encode transforms Unicode input bytes (that represent DNS label) into

--- a/parse_test.go
+++ b/parse_test.go
@@ -569,7 +569,7 @@ test                          IN CNAME test.a.example.com.
 	t.Logf("%d RRs parsed in %.2f s (%.2f RR/s)", i, float32(delta)/1e9, float32(i)/(float32(delta)/1e9))
 }
 
-func ExampleZone() {
+func ExampleParseZone() {
 	zone := `$ORIGIN .
 $TTL 3600       ; 1 hour
 name                    IN SOA  a6.nstld.com. hostmaster.nic.name. (
@@ -633,7 +633,7 @@ moutamassey             NS      ns01.yahoodomains.jp.
 	// moutamassey.0-g.name.name.	10800	IN	NS	ns02.yahoodomains.jp.
 }
 
-func ExampleHIP() {
+func ExampleNewRR_hip() {
 	h := `www.example.com     IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
                 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p
 9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQ
@@ -684,7 +684,7 @@ b1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D
 	}
 }
 
-func ExampleSOA() {
+func ExampleNewRR_soa() {
 	s := "example.com. 1000 SOA master.example.com. admin.example.com. 1 4294967294 4294967293 4294967295 100"
 	if soa, err := NewRR(s); err == nil {
 		fmt.Println(soa.String())
@@ -799,7 +799,7 @@ func TestLowercaseTokens(t *testing.T) {
 	}
 }
 
-func ExampleGenerate() {
+func ExampleParseZone_generate() {
 	// From the manual: http://www.bind9.net/manual/bind/9.3.2/Bv9ARM.ch06.html#id2566761
 	zone := "$GENERATE 1-2 0 NS SERVER$.EXAMPLE.\n$GENERATE 1-8 $ CNAME $.0"
 	to := ParseZone(strings.NewReader(zone), "0.0.192.IN-ADDR.ARPA.", "")

--- a/parse_test.go
+++ b/parse_test.go
@@ -633,7 +633,7 @@ moutamassey             NS      ns01.yahoodomains.jp.
 	// moutamassey.0-g.name.name.	10800	IN	NS	ns02.yahoodomains.jp.
 }
 
-func ExampleNewRR_hip() {
+func ExampleHIP() {
 	h := `www.example.com     IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
                 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p
 9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQ
@@ -684,7 +684,7 @@ b1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D
 	}
 }
 
-func ExampleNewRR_soa() {
+func ExampleSOA() {
 	s := "example.com. 1000 SOA master.example.com. admin.example.com. 1 4294967294 4294967293 4294967295 100"
 	if soa, err := NewRR(s); err == nil {
 		fmt.Println(soa.String())


### PR DESCRIPTION
client_test.go:165: ExampleUpdateLeaseTSIG should be niladic
client_test.go:165: ExampleUpdateLeaseTSIG refers to unknown identifier: UpdateLeaseTSIG
parse_test.go:572: ExampleZone refers to unknown identifier: Zone
parse_test.go:802: ExampleGenerate refers to unknown identifier: Generate
exit status 1
example_test.go:34: ExampleDS should be niladic
exit status 1
idn/punycode.go:202: unreachable code
exit status 1