### PR TITLE
Update ParseZone() documentation

### DIFF
--- a/zscan.go
+++ b/zscan.go
@@ -144,8 +144,10 @@ func ReadRR(q io.Reader, filename string) (RR, error) {
 //
 //	for x := range dns.ParseZone(strings.NewReader(z), "", "") {
 //		if x.Error != nil {
-//			// Do something with x.RR
-//		}
+//                  // log.Println(x.Error)
+//              } else {
+//                  // Do something with x.RR
+//              }
 //	}
 //
 // Comments specified after an RR (and on the same line!) are returned too:


### PR DESCRIPTION
I think this is the correct way to use ParseZone().

an 'else' is not strictly necessary but it's nice to not have to break the for loop and deal with the error somewhere else.

