### PR TITLE
Fix (*HINFO).len() and HINFO canonicalization in rawSignatureData

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -638,6 +638,9 @@ func rawSignatureData(rrset []RR, s *RRSIG) (buf []byte, err error) {
 			x.Target = strings.ToLower(x.Target)
 		case *DNAME:
 			x.Target = strings.ToLower(x.Target)
+		case *HINFO:
+			x.Os = strings.ToLower(x.Os)
+			x.Cpu = strings.ToLower(x.Cpu)
 		}
 		// 6.2. Canonical RR Form. (5) - origTTL
 		wire := make([]byte, r1.len()+1) // +1 to be safe(r)

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -171,6 +171,17 @@ func TestSignVerify(t *testing.T) {
 	srv.Weight = 800
 	srv.Target = "web1.miek.nl."
 
+	hinfo := &HINFO{
+		Hdr: RR_Header{
+			Name:   "miek.nl.",
+			Rrtype: TypeHINFO,
+			Class:  ClassINET,
+			Ttl:    3789,
+		},
+		Cpu: "X",
+		Os:  "Y",
+	}
+
 	// With this key
 	key := new(DNSKEY)
 	key.Hdr.Rrtype = TypeDNSKEY
@@ -194,12 +205,12 @@ func TestSignVerify(t *testing.T) {
 	sig.SignerName = key.Hdr.Name
 	sig.Algorithm = RSASHA256
 
-	for _, r := range []RR{soa, soa1, srv} {
-		if sig.Sign(privkey.(*rsa.PrivateKey), []RR{r}) != nil {
-			t.Error("failure to sign the record")
+	for _, r := range []RR{soa, soa1, srv, hinfo} {
+		if err := sig.Sign(privkey.(*rsa.PrivateKey), []RR{r}); err != nil {
+			t.Error("failure to sign the record:", err)
 			continue
 		}
-		if sig.Verify(key, []RR{r}) != nil {
+		if err := sig.Verify(key, []RR{r}); err != nil {
 			t.Error("failure to validate")
 			continue
 		}

--- a/types.go
+++ b/types.go
@@ -260,7 +260,7 @@ func (rr *HINFO) copy() RR           { return &HINFO{*rr.Hdr.copyHeader(), rr.Cp
 func (rr *HINFO) String() string {
 	return rr.Hdr.String() + sprintTxt([]string{rr.Cpu, rr.Os})
 }
-func (rr *HINFO) len() int { return rr.Hdr.len() + len(rr.Cpu) + len(rr.Os) }
+func (rr *HINFO) len() int { return rr.Hdr.len() + len(rr.Cpu) + 1 + len(rr.Os) + 1 }
 
 type MB struct {
 	Hdr RR_Header


### PR DESCRIPTION
Those len() functions should really be autogenerated