### PR TITLE
Fix for issue 286 - panic after closing ResponseWriter in server handler

### DIFF
--- a/server.go
+++ b/server.go
@@ -535,6 +535,9 @@ Redo:
 	h.ServeDNS(w, req) // Writes back to the client
 
 Exit:
+	if w.tcp == nil {
+		return
+	}
 	// TODO(miek): make this number configurable?
 	if q > maxTCPQueries { // close socket after this many queries
 		w.Close()


### PR DESCRIPTION
I think the test is okay. I'm not that familiar with `Server{}` but I'm pretty sure this is the only place a check is needed to fix #286. 