### PR TITLE
Expose methods to determine the connection type in the ResponseWriter

### DIFF
--- a/server.go
+++ b/server.go
@@ -38,6 +38,10 @@ type ResponseWriter interface {
 	// Hijack lets the caller take over the connection.
 	// After a call to Hijack(), the DNS package will not do anything with the connection.
 	Hijack()
+	// Returns true if it is a UDP connection
+	IsUDP() bool
+	// Returns true if it is a TCP connection
+	IsTCP() bool
 }
 
 type response struct {
@@ -677,6 +681,22 @@ func (w *response) TsigTimersOnly(b bool) { w.tsigTimersOnly = b }
 
 // Hijack implements the ResponseWriter.Hijack method.
 func (w *response) Hijack() { w.hijacked = true }
+
+// IsUDP implements the ResponseWriter.IsUDP method.
+func (w *response) IsUDP() bool {
+	if w.udp != nil {
+		return true
+	}
+	return false
+}
+
+// IsTCP implements the ResponseWriter.IsTCP method.
+func (w *response) IsTCP() bool {
+	if w.tcp != nil {
+		return true
+	}
+	return false
+}
 
 // Close implements the ResponseWriter.Close method
 func (w *response) Close() error {


### PR DESCRIPTION
Expose methods to determine the connection type in the ResponseWriter to be able to set the Truncate bit for replies bigger than 512 bytes for UDP, e.g.:
```
func handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
        m := new(dns.Msg)
        m.SetReply(r)
        m.Compress = false

       // Code to generate the response...

        answerSize := m.Len()
        if answerSize > 512 && w.IsUDP() {
                m.Truncated = true
                m.Answer = nil
        }
        w.WriteMsg(m)
}
```