### PR TITLE
Mirror Bufsize in OPT RR

### DIFF
--- a/client.go
+++ b/client.go
@@ -192,6 +192,8 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 	// Otherwise use the client's configured UDP size.
 	if opt == nil && c.UDPSize >= MinMsgSize {
 		co.UDPSize = c.UDPSize
+		// In this case also set the the EDNS0 bufsize to allow for larger responses.
+		m.SetEdns0(c.UDPSize, false /* dnssec */ )
 	}
 
 	co.TsigSecret = c.TsigSecret


### PR DESCRIPTION
When the Bufsize is set we use a larger buffer to capture the
return packet. We didn't add a OPT RR to advertise this larger
size to the remote server leading to all kinds of mayhem.

When no OPT RR is set, create one and set the Bufsize.

Fixes: #312