### PR TITLE
Missing dot between service and protocol.

### DIFF
--- a/tlsa.go
+++ b/tlsa.go
@@ -82,5 +82,5 @@ func TLSAName(name, service, network string) (string, error) {
 	if e != nil {
 		return "", e
 	}
-	return "_" + strconv.Itoa(p) + "_" + network + "." + name, nil
+	return "_" + strconv.Itoa(p) + "._" + network + "." + name, nil
 }


### PR DESCRIPTION
Subject says all. Minor typo, rendering the function useless.