### PR TITLE
TSIG: lowercase algorithm before use

### DIFF
--- a/tsig.go
+++ b/tsig.go
@@ -112,7 +112,7 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 
 	t := new(TSIG)
 	var h hash.Hash
-	switch rr.Algorithm {
+	switch strings.ToLower(rr.Algorithm) {
 	case HmacMD5:
 		h = hmac.New(md5.New, []byte(rawsecret))
 	case HmacSHA1:
@@ -178,7 +178,7 @@ func TsigVerify(msg []byte, secret, requestMAC string, timersOnly bool) error {
 	}
 
 	var h hash.Hash
-	switch tsig.Algorithm {
+	switch strings.ToLower(tsig.Algorithm) {
 	case HmacMD5:
 		h = hmac.New(md5.New, rawsecret)
 	case HmacSHA1:

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -1,0 +1,37 @@
+package dns
+
+import (
+	"testing"
+	"time"
+)
+
+func newTsig(algo string) *Msg {
+	m := new(Msg)
+	m.SetQuestion("example.org.", TypeA)
+	m.SetTsig("example.", algo, 300, time.Now().Unix())
+	return m
+}
+
+func TestTsig(t *testing.T) {
+	m := newTsig(HmacMD5)
+	buf, _, err := TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = TsigVerify(buf, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTsigCase(t *testing.T) {
+	m := newTsig("HmAc-mD5.sig-ALg.rEg.int.") // HmacMD5
+	buf, _, err := TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = TsigVerify(buf, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
These strings are domain names, so we should lowercase them before
using them.

Also add some tests for Tsig generation and verification.

(/ht ldns release).