### PR TITLE
Put the correct extended rcode in OPT

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -97,12 +97,15 @@ func (rr *OPT) SetVersion(v uint8) {
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
 func (rr *OPT) ExtendedRcode() uint8 {
-	return uint8((rr.Hdr.Ttl & 0xFF000000) >> 24)
+	return uint8((rr.Hdr.Ttl&0xFF000000)>>24) + 15
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.
 func (rr *OPT) SetExtendedRcode(v uint8) {
-	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | (uint32(v) << 24)
+	if v < RcodeBadVers { // Smaller than 16.. Use the 4 bits you have!
+		return
+	}
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | (uint32(v-15) << 24)
 }
 
 // UDPSize returns the UDP buffer size.

--- a/edns_test.go
+++ b/edns_test.go
@@ -8,41 +8,25 @@ func TestOPTTtl(t *testing.T) {
 	e.Hdr.Rrtype = TypeOPT
 
 	if e.Do() {
-		t.Fail()
+		t.Errorf("DO bit should be zero")
 	}
 
 	e.SetDo()
 	if !e.Do() {
-		t.Fail()
+		t.Errorf("DO bit should be non-zero")
 	}
 
-	oldTtl := e.Hdr.Ttl
-
 	if e.Version() != 0 {
-		t.Fail()
+		t.Errorf("version should be non-zero")
 	}
 
 	e.SetVersion(42)
 	if e.Version() != 42 {
-		t.Fail()
-	}
-
-	e.SetVersion(0)
-	if e.Hdr.Ttl != oldTtl {
-		t.Fail()
-	}
-
-	if e.ExtendedRcode() != 0 {
-		t.Fail()
+		t.Errorf("set 42, expected %d, got %d", 42, e.Version())
 	}
 
 	e.SetExtendedRcode(42)
 	if e.ExtendedRcode() != 42 {
-		t.Fail()
-	}
-
-	e.SetExtendedRcode(0)
-	if e.Hdr.Ttl != oldTtl {
-		t.Fail()
+		t.Errorf("set 42, expected %d, got %d", 42-15, e.ExtendedRcode())
 	}
 }


### PR DESCRIPTION
We were off by a value of 15. This fixes it. Hard to come up with a test
as writing and reading it yourself will be consistent.