### PR TITLE
set ExtendedRcode return type to int instead of uint8

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -96,8 +96,8 @@ func (rr *OPT) SetVersion(v uint8) {
 }
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
-func (rr *OPT) ExtendedRcode() uint8 {
-	return uint8((rr.Hdr.Ttl&0xFF000000)>>24) + 15
+func (rr *OPT) ExtendedRcode() int {
+	return int((rr.Hdr.Ttl&0xFF000000)>>24) + 15
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.


### PR DESCRIPTION
This PR sets the return type of method `ExtendedRcode` to `int`, to be consistent with the keys type of `map` [RcodeToString](https://github.com/miekg/dns/blob/89d9c5e74bc17cc9edb5d44d4f2f93a7ac77e365/msg.go#L127), and to close https://github.com/miekg/dns/issues/341.