### PR TITLE
Seed math/rand with crypto/rand

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -203,3 +203,9 @@ func BenchmarkUnpackMsg(b *testing.B) {
 		_ = msg.Unpack(msgBuf)
 	}
 }
+
+func BenchmarkIdGeneration(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = id()
+	}
+}

--- a/msg.go
+++ b/msg.go
@@ -11,14 +11,27 @@ package dns
 //go:generate go run msg_generate.go
 
 import (
+	crand "crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
+	"math"
 	"math/big"
 	"math/rand"
 	"net"
 	"reflect"
 	"strconv"
-	"time"
 )
+
+func init() {
+	// Initialize default math/rand source using crypto/rand to provide better
+	// security without the performance trade-off.
+	buf := make([]byte, 8)
+	_, err := crand.Read(buf)
+	if err != nil {
+		panic(err)
+	}
+	rand.Seed(int64(binary.BigEndian.Uint64(buf) % math.MaxInt64))
+}
 
 const maxCompressionOffset = 2 << 13 // We have 14 bits for the compression pointer
 
@@ -1911,7 +1924,7 @@ func compressionLenSearchType(c map[string]int, r RR) (int, bool) {
 // id returns a 16 bits random number to be used as a
 // message id. The random provided should be good enough.
 func id() uint16 {
-	return uint16(rand.Int()) ^ uint16(time.Now().Nanosecond())
+	return uint16(rand.Uint32() % math.MaxUint16)
 }
 
 // Copy returns a new RR which is a deep-copy of r.

--- a/msg.go
+++ b/msg.go
@@ -14,7 +14,6 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
-	"log"
 	"math/big"
 	"math/rand"
 	"net"
@@ -28,9 +27,8 @@ func init() {
 	buf := make([]byte, 8)
 	_, err := crand.Read(buf)
 	if err != nil {
-		// Failed to read from cryptographic source, warn user and
-		// fallback to default initial seed (1) by returning early
-		log.Printf("Failed to seed math/rand with crypto/rand.Read for message ID generation: %s\n", err)
+		// Failed to read from cryptographic source, fallback to default initial
+		// seed (1) by returning early
 		return
 	}
 	seed := binary.BigEndian.Uint64(buf)

--- a/msg.go
+++ b/msg.go
@@ -14,7 +14,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
-	"math"
+	"log"
 	"math/big"
 	"math/rand"
 	"net"
@@ -28,9 +28,13 @@ func init() {
 	buf := make([]byte, 8)
 	_, err := crand.Read(buf)
 	if err != nil {
-		panic(err)
+		// Failed to read from cryptographic source, warn user and
+		// fallback to default initial seed (1) by returning early
+		log.Printf("Failed to seed math/rand with crypto/rand.Read for message ID generation: %s\n", err)
+		return
 	}
-	rand.Seed(int64(binary.BigEndian.Uint64(buf) % math.MaxInt64))
+	seed := binary.BigEndian.Uint64(buf)
+	rand.Seed(int64(seed))
 }
 
 const maxCompressionOffset = 2 << 13 // We have 14 bits for the compression pointer
@@ -1924,7 +1928,8 @@ func compressionLenSearchType(c map[string]int, r RR) (int, bool) {
 // id returns a 16 bits random number to be used as a
 // message id. The random provided should be good enough.
 func id() uint16 {
-	return uint16(rand.Uint32() % math.MaxUint16)
+	id32 := rand.Uint32()
+	return uint16(id32)
 }
 
 // Copy returns a new RR which is a deep-copy of r.


### PR DESCRIPTION
The performance arguments given in #48 and #102 are perfectly valid reasons to not use `crypto/rand` for every message ID but that doesn't mean you have to use the default seed ([which is literally just `1`](https://golang.org/src/math/rand/rand.go#L178)) when using `math/rand`.

This patch simply reads out a random `int64` using `crypto/rand` on package initialization and uses it to seed the default `math/rand` source. While there are obviously other more viable attacks this should make message ID spoofing/prediction much harder when using the default `Id`.

This also changes `id()` to just use a rand `int32` and bound it to the max size of a `uint16` instead of using `time.Now` since it's a relatively easy to guess variable so it shouldn't actually provide that many useful bits (since someone analyzing the messages will generally know the period the messages were generated in).