### PR TITLE
Cleanup and removals

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -3,17 +3,15 @@ package dns
 import "strconv"
 
 const (
-	year68 = 1 << 31 // For RFC1982 (Serial Arithmetic) calculations in 32 bits.
-	// DefaultMsgSize is the standard default for messages larger than 512 bytes.
-	DefaultMsgSize = 4096
-	// MinMsgSize is the minimal size of a DNS packet.
-	MinMsgSize = 512
-	// MaxMsgSize is the largest possible DNS packet.
-	MaxMsgSize = 65535
-	defaultTtl = 3600 // Default internal TTL.
+	year68     = 1 << 31 // For RFC1982 (Serial Arithmetic) calculations in 32 bits.
+	defaultTtl = 3600    // Default internal TTL.
+
+	DefaultMsgSize = 4096  // DefaultMsgSize is the standard default for messages larger than 512 bytes.
+	MinMsgSize     = 512   // MinMsgSize is the minimal size of a DNS packet.
+	MaxMsgSize     = 65535 // MaxMsgSize is the largest possible DNS packet.
 )
 
-// Error represents a DNS error
+// Error represents a DNS error.
 type Error struct{ err string }
 
 func (e *Error) Error() string {
@@ -30,6 +28,7 @@ type RR interface {
 	Header() *RR_Header
 	// String returns the text representation of the resource record.
 	String() string
+
 	// copy returns a copy of the RR
 	copy() RR
 	// len returns the length (in octets) of the uncompressed RR in wire format.
@@ -44,10 +43,10 @@ type RR_Header struct {
 	Rrtype   uint16
 	Class    uint16
 	Ttl      uint32
-	Rdlength uint16 // length of data after header
+	Rdlength uint16 // Length of data after header.
 }
 
-// Header returns itself. This is here to make RR_Header implement the RR interface.
+// Header returns itself. This is here to make RR_Header implements the RR interface.
 func (h *RR_Header) Header() *RR_Header { return h }
 
 // Just to implement the RR interface.

--- a/nsecx.go
+++ b/nsecx.go
@@ -11,8 +11,7 @@ type saltWireFmt struct {
 	Salt string `dns:"size-hex"`
 }
 
-// HashName hashes a string (label) according to RFC 5155. It returns the hashed string in
-// uppercase.
+// HashName hashes a string (label) according to RFC 5155. It returns the hashed string in uppercase.
 func HashName(label string, ha uint8, iter uint16, salt string) string {
 	saltwire := new(saltWireFmt)
 	saltwire.Salt = salt

--- a/rawmsg.go
+++ b/rawmsg.go
@@ -2,6 +2,14 @@ package dns
 
 import "encoding/binary"
 
+func rawSetExtraLen(msg []byte, i uint16) bool {
+	if len(msg) < 12 {
+		return false
+	}
+	binary.BigEndian.PutUint16(msg[10:], i)
+	return true
+}
+
 // rawSetRdlength sets the rdlength in the header of
 // the RR. The offset 'off' must be positioned at the
 // start of the header of the RR, 'end' must be the

--- a/rawmsg.go
+++ b/rawmsg.go
@@ -2,14 +2,6 @@ package dns
 
 import "encoding/binary"
 
-func rawSetExtraLen(msg []byte, i uint16) bool {
-	if len(msg) < 12 {
-		return false
-	}
-	binary.BigEndian.PutUint16(msg[10:], i)
-	return true
-}
-
 // rawSetRdlength sets the rdlength in the header of
 // the RR. The offset 'off' must be positioned at the
 // start of the header of the RR, 'end' must be the

--- a/rawmsg.go
+++ b/rawmsg.go
@@ -2,54 +2,6 @@ package dns
 
 import "encoding/binary"
 
-// These raw* functions do not use reflection, they directly set the values
-// in the buffer. There are faster than their reflection counterparts.
-
-// RawSetId sets the message id in buf.
-func rawSetId(msg []byte, i uint16) bool {
-	if len(msg) < 2 {
-		return false
-	}
-	binary.BigEndian.PutUint16(msg, i)
-	return true
-}
-
-// rawSetQuestionLen sets the length of the question section.
-func rawSetQuestionLen(msg []byte, i uint16) bool {
-	if len(msg) < 6 {
-		return false
-	}
-	binary.BigEndian.PutUint16(msg[4:], i)
-	return true
-}
-
-// rawSetAnswerLen sets the length of the answer section.
-func rawSetAnswerLen(msg []byte, i uint16) bool {
-	if len(msg) < 8 {
-		return false
-	}
-	binary.BigEndian.PutUint16(msg[6:], i)
-	return true
-}
-
-// rawSetsNsLen sets the length of the authority section.
-func rawSetNsLen(msg []byte, i uint16) bool {
-	if len(msg) < 10 {
-		return false
-	}
-	binary.BigEndian.PutUint16(msg[8:], i)
-	return true
-}
-
-// rawSetExtraLen sets the length of the additional section.
-func rawSetExtraLen(msg []byte, i uint16) bool {
-	if len(msg) < 12 {
-		return false
-	}
-	binary.BigEndian.PutUint16(msg[10:], i)
-	return true
-}
-
 // rawSetRdlength sets the rdlength in the header of
 // the RR. The offset 'off' must be positioned at the
 // start of the header of the RR, 'end' must be the

--- a/tsig.go
+++ b/tsig.go
@@ -141,7 +141,9 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 		return nil, "", err
 	}
 	mbuf = append(mbuf, tbuf...)
-	rawSetExtraLen(mbuf, uint16(len(m.Extra)+1))
+	// Update the ArCount directly in the buffer.
+	binary.BigEndian.PutUint16(mbuf[10:], uint16(len(m.Extra)+1))
+
 	return mbuf, t.MAC, nil
 }
 


### PR DESCRIPTION
Gut rawmsg.go as most functions are not used. Reword some documentation.
Add more types to be checked for name compression.