### PR TITLE
zmsg: return empty rr with header

### DIFF
--- a/msg_generate.go
+++ b/msg_generate.go
@@ -176,16 +176,16 @@ return off, err
 		st, _ := getTypeStruct(o.Type(), scope)
 
 		fmt.Fprintf(b, "func unpack%s(h RR_Header, msg []byte, off int) (RR, int, error) {\n", name)
+		fmt.Fprintf(b, "rr := new(%s)\n", name)
+		fmt.Fprint(b, "rr.Hdr = h\n")
 		fmt.Fprint(b, `if noRdata(h) {
-return &h, off, nil
+return rr, off, nil
 	}
 var err error
 rdStart := off
 _ = rdStart
 
 `)
-		fmt.Fprintf(b, "rr := new(%s)\n", name)
-		fmt.Fprintln(b, "rr.Hdr = h\n")
 		for i := 1; i < st.NumFields(); i++ {
 			o := func(s string) {
 				fmt.Fprintf(b, s, st.Field(i).Name())

--- a/zmsg.go
+++ b/zmsg.go
@@ -1426,15 +1426,14 @@ func (rr *X25) pack(msg []byte, off int, compression map[string]int, compress bo
 // unpack*() functions
 
 func unpackA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(A)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(A)
-	rr.Hdr = h
 
 	rr.A, off, err = unpackDataA(msg, off)
 	if err != nil {
@@ -1444,15 +1443,14 @@ func unpackA(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackAAAA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(AAAA)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(AAAA)
-	rr.Hdr = h
 
 	rr.AAAA, off, err = unpackDataAAAA(msg, off)
 	if err != nil {
@@ -1462,15 +1460,14 @@ func unpackAAAA(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackAFSDB(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(AFSDB)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(AFSDB)
-	rr.Hdr = h
 
 	rr.Subtype, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1487,29 +1484,27 @@ func unpackAFSDB(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackANY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(ANY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(ANY)
-	rr.Hdr = h
 
 	return rr, off, err
 }
 
 func unpackCAA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(CAA)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(CAA)
-	rr.Hdr = h
 
 	rr.Flag, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -1533,15 +1528,14 @@ func unpackCAA(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackCDNSKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(CDNSKEY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(CDNSKEY)
-	rr.Hdr = h
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1572,15 +1566,14 @@ func unpackCDNSKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackCDS(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(CDS)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(CDS)
-	rr.Hdr = h
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1611,15 +1604,14 @@ func unpackCDS(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackCERT(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(CERT)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(CERT)
-	rr.Hdr = h
 
 	rr.Type, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1650,15 +1642,14 @@ func unpackCERT(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackCNAME(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(CNAME)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(CNAME)
-	rr.Hdr = h
 
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -1668,15 +1659,14 @@ func unpackCNAME(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackDHCID(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(DHCID)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(DHCID)
-	rr.Hdr = h
 
 	rr.Digest, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
@@ -1686,15 +1676,14 @@ func unpackDHCID(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackDLV(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(DLV)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(DLV)
-	rr.Hdr = h
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1725,15 +1714,14 @@ func unpackDLV(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackDNAME(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(DNAME)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(DNAME)
-	rr.Hdr = h
 
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -1743,15 +1731,14 @@ func unpackDNAME(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackDNSKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(DNSKEY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(DNSKEY)
-	rr.Hdr = h
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1782,15 +1769,14 @@ func unpackDNSKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackDS(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(DS)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(DS)
-	rr.Hdr = h
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -1821,15 +1807,14 @@ func unpackDS(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackEID(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(EID)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(EID)
-	rr.Hdr = h
 
 	rr.Endpoint, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
@@ -1839,15 +1824,14 @@ func unpackEID(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackEUI48(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(EUI48)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(EUI48)
-	rr.Hdr = h
 
 	rr.Address, off, err = unpackUint48(msg, off)
 	if err != nil {
@@ -1857,15 +1841,14 @@ func unpackEUI48(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackEUI64(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(EUI64)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(EUI64)
-	rr.Hdr = h
 
 	rr.Address, off, err = unpackUint64(msg, off)
 	if err != nil {
@@ -1875,15 +1858,14 @@ func unpackEUI64(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackGID(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(GID)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(GID)
-	rr.Hdr = h
 
 	rr.Gid, off, err = unpackUint32(msg, off)
 	if err != nil {
@@ -1893,15 +1875,14 @@ func unpackGID(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackGPOS(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(GPOS)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(GPOS)
-	rr.Hdr = h
 
 	rr.Longitude, off, err = unpackString(msg, off)
 	if err != nil {
@@ -1925,15 +1906,14 @@ func unpackGPOS(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackHINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(HINFO)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(HINFO)
-	rr.Hdr = h
 
 	rr.Cpu, off, err = unpackString(msg, off)
 	if err != nil {
@@ -1950,15 +1930,14 @@ func unpackHINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackHIP(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(HIP)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(HIP)
-	rr.Hdr = h
 
 	rr.HitLength, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -1997,15 +1976,14 @@ func unpackHIP(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(KEY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(KEY)
-	rr.Hdr = h
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2036,15 +2014,14 @@ func unpackKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackKX(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(KX)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(KX)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2061,15 +2038,14 @@ func unpackKX(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackL32(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(L32)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(L32)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2086,15 +2062,14 @@ func unpackL32(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackL64(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(L64)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(L64)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2111,15 +2086,14 @@ func unpackL64(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackLOC(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(LOC)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(LOC)
-	rr.Hdr = h
 
 	rr.Version, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -2171,15 +2145,14 @@ func unpackLOC(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackLP(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(LP)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(LP)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2196,15 +2169,14 @@ func unpackLP(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMB(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MB)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MB)
-	rr.Hdr = h
 
 	rr.Mb, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2214,15 +2186,14 @@ func unpackMB(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMD(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MD)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MD)
-	rr.Hdr = h
 
 	rr.Md, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2232,15 +2203,14 @@ func unpackMD(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMF(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MF)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MF)
-	rr.Hdr = h
 
 	rr.Mf, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2250,15 +2220,14 @@ func unpackMF(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMG(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MG)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MG)
-	rr.Hdr = h
 
 	rr.Mg, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2268,15 +2237,14 @@ func unpackMG(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MINFO)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MINFO)
-	rr.Hdr = h
 
 	rr.Rmail, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2293,15 +2261,14 @@ func unpackMINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMR(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MR)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MR)
-	rr.Hdr = h
 
 	rr.Mr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2311,15 +2278,14 @@ func unpackMR(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackMX(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(MX)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(MX)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2336,15 +2302,14 @@ func unpackMX(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNAPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NAPTR)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NAPTR)
-	rr.Hdr = h
 
 	rr.Order, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2389,15 +2354,14 @@ func unpackNAPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNID(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NID)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NID)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2414,15 +2378,14 @@ func unpackNID(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNIMLOC(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NIMLOC)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NIMLOC)
-	rr.Hdr = h
 
 	rr.Locator, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
@@ -2432,15 +2395,14 @@ func unpackNIMLOC(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NINFO)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NINFO)
-	rr.Hdr = h
 
 	rr.ZSData, off, err = unpackStringTxt(msg, off)
 	if err != nil {
@@ -2450,15 +2412,14 @@ func unpackNINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNS(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NS)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NS)
-	rr.Hdr = h
 
 	rr.Ns, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2468,15 +2429,14 @@ func unpackNS(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNSAPPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NSAPPTR)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NSAPPTR)
-	rr.Hdr = h
 
 	rr.Ptr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2486,15 +2446,14 @@ func unpackNSAPPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNSEC(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NSEC)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NSEC)
-	rr.Hdr = h
 
 	rr.NextDomain, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2511,15 +2470,14 @@ func unpackNSEC(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNSEC3(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NSEC3)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NSEC3)
-	rr.Hdr = h
 
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -2572,15 +2530,14 @@ func unpackNSEC3(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackNSEC3PARAM(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(NSEC3PARAM)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(NSEC3PARAM)
-	rr.Hdr = h
 
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -2618,15 +2575,14 @@ func unpackNSEC3PARAM(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackOPENPGPKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(OPENPGPKEY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(OPENPGPKEY)
-	rr.Hdr = h
 
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
@@ -2636,15 +2592,14 @@ func unpackOPENPGPKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackOPT(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(OPT)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(OPT)
-	rr.Hdr = h
 
 	rr.Option, off, err = unpackDataOpt(msg, off)
 	if err != nil {
@@ -2654,15 +2609,14 @@ func unpackOPT(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(PTR)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(PTR)
-	rr.Hdr = h
 
 	rr.Ptr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2672,15 +2626,14 @@ func unpackPTR(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackPX(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(PX)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(PX)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2704,15 +2657,14 @@ func unpackPX(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackRFC3597(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(RFC3597)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(RFC3597)
-	rr.Hdr = h
 
 	rr.Rdata, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
@@ -2722,15 +2674,14 @@ func unpackRFC3597(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackRKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(RKEY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(RKEY)
-	rr.Hdr = h
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2761,15 +2712,14 @@ func unpackRKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackRP(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(RP)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(RP)
-	rr.Hdr = h
 
 	rr.Mbox, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -2786,15 +2736,14 @@ func unpackRP(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackRRSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(RRSIG)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(RRSIG)
-	rr.Hdr = h
 
 	rr.TypeCovered, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2860,15 +2809,14 @@ func unpackRRSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackRT(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(RT)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(RT)
-	rr.Hdr = h
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2885,15 +2833,14 @@ func unpackRT(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(SIG)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(SIG)
-	rr.Hdr = h
 
 	rr.TypeCovered, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -2959,15 +2906,14 @@ func unpackSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackSOA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(SOA)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(SOA)
-	rr.Hdr = h
 
 	rr.Ns, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -3019,15 +2965,14 @@ func unpackSOA(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackSPF(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(SPF)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(SPF)
-	rr.Hdr = h
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
@@ -3037,15 +2982,14 @@ func unpackSPF(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackSRV(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(SRV)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(SRV)
-	rr.Hdr = h
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -3076,15 +3020,14 @@ func unpackSRV(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackSSHFP(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(SSHFP)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(SSHFP)
-	rr.Hdr = h
 
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -3108,15 +3051,14 @@ func unpackSSHFP(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackTA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(TA)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(TA)
-	rr.Hdr = h
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -3147,15 +3089,14 @@ func unpackTA(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackTALINK(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(TALINK)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(TALINK)
-	rr.Hdr = h
 
 	rr.PreviousName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -3172,15 +3113,14 @@ func unpackTALINK(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackTKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(TKEY)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(TKEY)
-	rr.Hdr = h
 
 	rr.Algorithm, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -3246,15 +3186,14 @@ func unpackTKEY(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackTLSA(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(TLSA)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(TLSA)
-	rr.Hdr = h
 
 	rr.Usage, off, err = unpackUint8(msg, off)
 	if err != nil {
@@ -3285,15 +3224,14 @@ func unpackTLSA(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackTSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(TSIG)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(TSIG)
-	rr.Hdr = h
 
 	rr.Algorithm, off, err = UnpackDomainName(msg, off)
 	if err != nil {
@@ -3356,15 +3294,14 @@ func unpackTSIG(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackTXT(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(TXT)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(TXT)
-	rr.Hdr = h
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
@@ -3374,15 +3311,14 @@ func unpackTXT(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackUID(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(UID)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(UID)
-	rr.Hdr = h
 
 	rr.Uid, off, err = unpackUint32(msg, off)
 	if err != nil {
@@ -3392,15 +3328,14 @@ func unpackUID(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackUINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(UINFO)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(UINFO)
-	rr.Hdr = h
 
 	rr.Uinfo, off, err = unpackString(msg, off)
 	if err != nil {
@@ -3410,15 +3345,14 @@ func unpackUINFO(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackURI(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(URI)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(URI)
-	rr.Hdr = h
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
@@ -3442,15 +3376,14 @@ func unpackURI(h RR_Header, msg []byte, off int) (RR, int, error) {
 }
 
 func unpackX25(h RR_Header, msg []byte, off int) (RR, int, error) {
+	rr := new(X25)
+	rr.Hdr = h
 	if noRdata(h) {
-		return &h, off, nil
+		return rr, off, nil
 	}
 	var err error
 	rdStart := off
 	_ = rdStart
-
-	rr := new(X25)
-	rr.Hdr = h
 
 	rr.PSDNAddress, off, err = unpackString(msg, off)
 	if err != nil {


### PR DESCRIPTION
When there is no rdata, return the newly created RR with the header
embedded in it. If we only return the header, we changed the
API for Go DNS.

Fixes #379