### PR TITLE
Handle empty salt value

### DIFF
--- a/msg_generate.go
+++ b/msg_generate.go
@@ -139,6 +139,9 @@ return off, err
 			case st.Tag(i) == `dns:"base64"`:
 				o("off, err = packStringBase64(rr.%s, msg, off)\n")
 
+			case strings.HasPrefix(st.Tag(i), `dns:"size-hex:SaltLength`): // Hack to fix empty salt length for NSEC3
+				o("if rr.%s == \"-\" { /* do nothing, empty salt */ }\n")
+				continue
 			case strings.HasPrefix(st.Tag(i), `dns:"size-hex`): // size-hex can be packed just like hex
 				fallthrough
 			case st.Tag(i) == `dns:"hex"`:
@@ -166,7 +169,7 @@ return off, err
 			}
 		}
 		// We have packed everything, only now we know the rdlength of this RR
-		fmt.Fprintln(b, "rr.Header().Rdlength = uint16(off- headerEnd)")
+		fmt.Fprintln(b, "rr.Header().Rdlength = uint16(off-headerEnd)")
 		fmt.Fprintln(b, "return off, nil }\n")
 	}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -360,6 +360,7 @@ func TestNSEC(t *testing.T) {
 		"localhost.dnssex.nl. IN NSEC www.dnssex.nl. A RRSIG NSEC":                                                                                 "localhost.dnssex.nl.\t3600\tIN\tNSEC\twww.dnssex.nl. A RRSIG NSEC",
 		"localhost.dnssex.nl. IN NSEC www.dnssex.nl. A RRSIG NSEC TYPE65534":                                                                       "localhost.dnssex.nl.\t3600\tIN\tNSEC\twww.dnssex.nl. A RRSIG NSEC TYPE65534",
 		"localhost.dnssex.nl. IN NSEC www.dnssex.nl. A RRSIG NSec Type65534":                                                                       "localhost.dnssex.nl.\t3600\tIN\tNSEC\twww.dnssex.nl. A RRSIG NSEC TYPE65534",
+		"44ohaq2njb0idnvolt9ggthvsk1e1uv8.skydns.test. NSEC3 1 0 0 - 44OHAQ2NJB0IDNVOLT9GGTHVSK1E1UVA":                                             "44ohaq2njb0idnvolt9ggthvsk1e1uv8.skydns.test.\t3600\tIN\tNSEC3\t1 0 0 - 44OHAQ2NJB0IDNVOLT9GGTHVSK1E1UVA",
 	}
 	for i, o := range nsectests {
 		rr, err := NewRR(i)

--- a/types.go
+++ b/types.go
@@ -958,7 +958,7 @@ type NSEC3PARAM struct {
 	Flags      uint8
 	Iterations uint16
 	SaltLength uint8
-	Salt       string `dns:"hex"`
+	Salt       string `dns:"size-hex:SaltLength"`
 }
 
 func (rr *NSEC3PARAM) String() string {
@@ -1219,8 +1219,7 @@ func StringToTime(s string) (uint32, error) {
 	return uint32(t.Unix() - (mod * year68)), nil
 }
 
-// saltToString converts a NSECX salt to uppercase and
-// returns "-" when it is empty
+// saltToString converts a NSECX salt to uppercase and returns "-" when it is empty.
 func saltToString(s string) string {
 	if len(s) == 0 {
 		return "-"

--- a/zmsg.go
+++ b/zmsg.go
@@ -801,7 +801,8 @@ func (rr *NSEC3) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	off, err = packStringHex(rr.Salt, msg, off)
+	if rr.Salt == "-" { /* do nothing, empty salt */
+	}
 	if err != nil {
 		return off, err
 	}
@@ -843,7 +844,8 @@ func (rr *NSEC3PARAM) pack(msg []byte, off int, compression map[string]int, comp
 	if err != nil {
 		return off, err
 	}
-	off, err = packStringHex(rr.Salt, msg, off)
+	if rr.Salt == "-" { /* do nothing, empty salt */
+	}
 	if err != nil {
 		return off, err
 	}
@@ -2567,7 +2569,7 @@ func unpackNSEC3PARAM(h RR_Header, msg []byte, off int) (RR, int, error) {
 	if off == len(msg) {
 		return rr, off, nil
 	}
-	rr.Salt, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
+	rr.Salt, off, err = unpackStringHex(msg, off, off+int(rr.SaltLength))
 	if err != nil {
 		return rr, off, err
 	}


### PR DESCRIPTION
When removing the reflection we inadvertely also removed the code for
handling empty salt values in NSEC3 and NSEC3PARAM. These are somewhat
annoying because the text representation is '-', which is not valid hex.