### PR TITLE
adds tests for shutdown bind port

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -695,6 +695,7 @@ func testShutdownBindPort(t *testing.T, protocol string, port string) {
 	if err := s.Shutdown(); err != nil {
 		t.Fatal(err)
 	}
+	time.Sleep(500 * time.Millisecond)
 	go func() {
 		if err := s.ListenAndServe(); err != nil {
 			t.Fatal(err)

--- a/server_test.go
+++ b/server_test.go
@@ -691,17 +691,17 @@ func testShutdownBindPort(t *testing.T, protocol string, port string) {
 			t.Log(err)
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	if err := s.Shutdown(); err != nil {
 		t.Fatal(err)
 	}
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 	go func() {
 		if err := s.ListenAndServe(); err != nil {
 			t.Fatal(err)
 		}
 	}()
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 }
 
 func TestShutdownBindPortUDP(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -677,3 +677,36 @@ zDCJkckCgYEAndqM5KXGk5xYo+MAA1paZcbTUXwaWwjLU+XSRSSoyBEi5xMtfvUb
 kFsxKCqxAnBVGEWAvVZAiiTOxleQFjz5RnL0BQp9Lg2cQe+dvuUmIAA=
 -----END RSA PRIVATE KEY-----`)
 )
+
+func testShutdownBindPort(t *testing.T, protocol string, port string) {
+	handler := NewServeMux()
+	handler.HandleFunc(".", func(w ResponseWriter, r *Msg) {})
+	s := &Server{
+		Addr:    net.JoinHostPort("127.0.0.1", port),
+		Net:     protocol,
+		Handler: handler,
+	}
+	go func() {
+		if err := s.ListenAndServe(); err != nil {
+			t.Log(err)
+		}
+	}()
+	time.Sleep(500 * time.Millisecond)
+	if err := s.Shutdown(); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		if err := s.ListenAndServe(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	time.Sleep(500 * time.Millisecond)
+}
+
+func TestShutdownBindPortUDP(t *testing.T) {
+	testShutdownBindPort(t, "udp", "1153")
+}
+
+func TestShutdownBindPortTCP(t *testing.T) {
+	testShutdownBindPort(t, "tcp", "1154")
+}

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -21,6 +21,7 @@ func setUDPSocketOptions4(conn *net.UDPConn) error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_PKTINFO, 1); err != nil {
 		return err
 	}
@@ -39,6 +40,7 @@ func setUDPSocketOptions6(conn *net.UDPConn) error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_RECVPKTINFO, 1); err != nil {
 		return err
 	}
@@ -56,6 +58,7 @@ func getUDPSocketOptions6Only(conn *net.UDPConn) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	defer file.Close()
 	// dual stack. See http://stackoverflow.com/questions/1618240/how-to-support-both-ipv4-and-ipv6-connections
 	v6only, err := syscall.GetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY)
 	if err != nil {
@@ -69,5 +72,6 @@ func getUDPSocketName(conn *net.UDPConn) (syscall.Sockaddr, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
 	return syscall.Getsockname(int(file.Fd()))
 }

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -21,16 +21,18 @@ func setUDPSocketOptions4(conn *net.UDPConn) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IP, syscall.IP_PKTINFO, 1); err != nil {
+		file.Close()
 		return err
 	}
 	// Calling File() above results in the connection becoming blocking, we must fix that.
 	// See https://github.com/miekg/dns/issues/279
 	err = syscall.SetNonblock(int(file.Fd()), true)
 	if err != nil {
+		file.Close()
 		return err
 	}
+	file.Close()
 	return nil
 }
 
@@ -40,14 +42,16 @@ func setUDPSocketOptions6(conn *net.UDPConn) error {
 	if err != nil {
 		return err
 	}
-	defer file.Close()
 	if err := syscall.SetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_RECVPKTINFO, 1); err != nil {
+		file.Close()
 		return err
 	}
 	err = syscall.SetNonblock(int(file.Fd()), true)
 	if err != nil {
+		file.Close()
 		return err
 	}
+	file.Close()
 	return nil
 }
 
@@ -58,12 +62,13 @@ func getUDPSocketOptions6Only(conn *net.UDPConn) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	defer file.Close()
 	// dual stack. See http://stackoverflow.com/questions/1618240/how-to-support-both-ipv4-and-ipv6-connections
 	v6only, err := syscall.GetsockoptInt(int(file.Fd()), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY)
 	if err != nil {
+		file.Close()
 		return false, err
 	}
+	file.Close()
 	return v6only == 1, nil
 }
 


### PR DESCRIPTION
# Intro

After calling `Shutdown` of DNS server, the bound port still open. It only happens if the DNS server is running on Linux and use UDP.
