### PR TITLE
Always set tokenUpper when setting token

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -627,6 +627,7 @@ func zlexer(s *scan, c chan lex) {
 			if stri > 0 {
 				l.value = zString
 				l.token = string(str[:stri])
+				l.tokenUpper = strings.ToUpper(l.token)
 				l.length = stri
 				debug.Printf("[4 %+v]", l.token)
 				c <- l
@@ -663,6 +664,7 @@ func zlexer(s *scan, c chan lex) {
 					owner = true
 					l.value = zNewline
 					l.token = "\n"
+					l.tokenUpper = l.token
 					l.length = 1
 					l.comment = string(com[:comi])
 					debug.Printf("[3 %+v %+v]", l.token, l.comment)
@@ -696,6 +698,7 @@ func zlexer(s *scan, c chan lex) {
 				}
 				l.value = zNewline
 				l.token = "\n"
+				l.tokenUpper = l.token
 				l.length = 1
 				debug.Printf("[1 %+v]", l.token)
 				c <- l
@@ -740,6 +743,7 @@ func zlexer(s *scan, c chan lex) {
 			if stri != 0 {
 				l.value = zString
 				l.token = string(str[:stri])
+				l.tokenUpper = strings.ToUpper(l.token)
 				l.length = stri
 
 				debug.Printf("[%+v]", l.token)
@@ -750,6 +754,7 @@ func zlexer(s *scan, c chan lex) {
 			// send quote itself as separate token
 			l.value = zQuote
 			l.token = "\""
+			l.tokenUpper = l.token
 			l.length = 1
 			c <- l
 			quote = !quote
@@ -775,6 +780,7 @@ func zlexer(s *scan, c chan lex) {
 				brace--
 				if brace < 0 {
 					l.token = "extra closing brace"
+					l.tokenUpper = l.token
 					l.err = true
 					debug.Printf("[%+v]", l.token)
 					c <- l
@@ -799,6 +805,7 @@ func zlexer(s *scan, c chan lex) {
 	if stri > 0 {
 		// Send remainder
 		l.token = string(str[:stri])
+		l.tokenUpper = strings.ToUpper(l.token)
 		l.length = stri
 		l.value = zString
 		debug.Printf("[%+v]", l.token)


### PR DESCRIPTION
This fixes parsing bugs for certain records, mainly NSEC3. Previously a presentation version of the type bit map `A NS CAA` would be parsed as `A NS NS` as `tokenUpper` was not being properly set when setting `token` which mean't the previous value was used instead.