### PR TITLE
Enables checking of tranports on a per-Msg basis.

### DIFF
--- a/server.go
+++ b/server.go
@@ -40,6 +40,8 @@ type ResponseWriter interface {
 	// Hijack lets the caller take over the connection.
 	// After a call to Hijack(), the DNS package will not do anything with the connection.
 	Hijack()
+	Tcp() bool
+	Udp() bool
 }
 
 type response struct {
@@ -719,6 +721,16 @@ func (w *response) TsigTimersOnly(b bool) { w.tsigTimersOnly = b }
 
 // Hijack implements the ResponseWriter.Hijack method.
 func (w *response) Hijack() { w.hijacked = true }
+
+// Is the response being sent over TCP?
+func (w *response) Tcp() bool {
+	return w.tcp != nil
+}
+
+// Is the response being sent over UDP?
+func (w *response) Udp() bool {
+	return w.udp != nil
+}
 
 // Close implements the ResponseWriter.Close method
 func (w *response) Close() error {


### PR DESCRIPTION
In order to not be a participant of DNS amplification attacks,
one needs to limit record/response sizes for UDP connections.
One solution would be to curry the function for the Handler and pass it the listening transport,
but this would mean i need different muxes for different listeners and keep the up2date.

To avoid this uglyness, i added w.Tcp() and w.Udp() to determine
wether the writer's transport is either or, thus being able to limit
response sizes easily and conditionally.