### PR TITLE
Add nil check for interface value in ActivateAndServe

### DIFF
--- a/server.go
+++ b/server.go
@@ -389,7 +389,9 @@ func (srv *Server) ActivateAndServe() error {
 		if srv.UDPSize == 0 {
 			srv.UDPSize = MinMsgSize
 		}
-		if t, ok := pConn.(*net.UDPConn); ok {
+		// Check PacketConn interface's type is valid and value
+		// is not nil
+		if t, ok := pConn.(*net.UDPConn); ok && t != nil {
 			if e := setUDPSocketOptions(t); e != nil {
 				return e
 			}


### PR DESCRIPTION
This will avoid the panic if the library user inadvertently initializes Server.PacketConn with a nil pointer

https://github.com/docker/docker/issues/28112

Signed-off-by: Santhosh Manohar <santhosh@docker.com>