### PR TITLE
Fix tcp6-tls support in (*Server).ListenAndServe().

### DIFF
--- a/server.go
+++ b/server.go
@@ -339,7 +339,7 @@ func (srv *Server) ListenAndServe() error {
 		network := "tcp"
 		if srv.Net == "tcp4-tls" {
 			network = "tcp4"
-		} else if srv.Net == "tcp6" {
+		} else if srv.Net == "tcp6-tls" {
 			network = "tcp6"
 		}
 


### PR DESCRIPTION
In the switch statement srv.Net is matched for tcp6-tls but then compared against tcp6 within the case statement. This causes tcp6-tls to be equivalent to tcp-tls and not specific to IPv6. The `network = "tcp6"` line was previously unreachable.

This change corrects this and ensures tcp6-tls listens on IPv6 only.