### PR TITLE
Push test coverage profile to Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,17 @@ sudo: false
 go:
   - 1.5
   - 1.6
+  - 1.7
+
+before_install:
+  - go get github.com/mattn/goveralls
+
+  # don't use the miekg/dns when testing forks
+  - mkdir -p $GOPATH/src/github.com/miekg
+  - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
+
 script:
-  - go test -race -v -bench=.
+  # run tests with coverage
+  - goveralls -v
+  # run benchmarks
+  - go test -v -bench=. -run=^$

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/miekg/dns.svg?branch=master)](https://travis-ci.org/miekg/dns) [![](https://godoc.org/github.com/miekg/dns?status.svg)](https://godoc.org/github.com/miekg/dns)
+[![Build Status](https://travis-ci.org/miekg/dns.svg?branch=master)](https://travis-ci.org/miekg/dns)
+[![Coverage Status](https://coveralls.io/repos/github/miekg/dns/badge.svg?branch=master)](https://coveralls.io/github/miekg/dns?branch=master)
+[![](https://godoc.org/github.com/miekg/dns?status.svg)](https://godoc.org/github.com/miekg/dns)
 
 # Alternative (more granular) approach to a DNS library
 


### PR DESCRIPTION
- Push test coverage to Coveralls
- Add coverage badge to README
- Test Go 1.7 as well
- Don't use miekg/dns when testing forks

To use the coverage badge @miekg has to sign in at https://coveralls.io/ and enable it for this repository. Example of the result: https://coveralls.io/github/corny/dns?branch=improve-tests