### PR TITLE
Improve test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: go
 sudo: false
 go:
-  - 1.5
   - 1.6
+  - 1.7
+
+before_install:
+  # don't use the miekg/dns when testing forks
+  - mkdir -p $GOPATH/src/github.com/miekg
+  - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
+
 script:
   - go test -race -v -bench=.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/miekg/dns.svg?branch=master)](https://travis-ci.org/miekg/dns) [![](https://godoc.org/github.com/miekg/dns?status.svg)](https://godoc.org/github.com/miekg/dns)
+[![Build Status](https://travis-ci.org/miekg/dns.svg?branch=master)](https://travis-ci.org/miekg/dns)
+[![](https://godoc.org/github.com/miekg/dns?status.svg)](https://godoc.org/github.com/miekg/dns)
 
 # Alternative (more granular) approach to a DNS library
 
@@ -12,7 +13,7 @@ can build servers and resolvers with it.
 
 We try to keep the "master" branch as sane as possible and at the bleeding edge
 of standards, avoiding breaking changes wherever reasonable. We support the last
-two versions of Go, currently: 1.5 and 1.6.
+two versions of Go, currently: 1.6 and 1.7.
 
 # Goals
 


### PR DESCRIPTION
- Test Go 1.7 instead of 1.5
- Don't use miekg/dns when testing forks