### PR TITLE
Improve performance by addressing some low hanging fruit.

### DIFF
--- a/dane.go
+++ b/dane.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
-	"io"
 )
 
 // CertificateToDANE converts a certificate to a hex string as used in the TLSA or SMIMEA records.
@@ -23,20 +22,20 @@ func CertificateToDANE(selector, matchingType uint8, cert *x509.Certificate) (st
 		h := sha256.New()
 		switch selector {
 		case 0:
-			io.WriteString(h, string(cert.Raw))
+			h.Write(cert.Raw)
 			return hex.EncodeToString(h.Sum(nil)), nil
 		case 1:
-			io.WriteString(h, string(cert.RawSubjectPublicKeyInfo))
+			h.Write(cert.RawSubjectPublicKeyInfo)
 			return hex.EncodeToString(h.Sum(nil)), nil
 		}
 	case 2:
 		h := sha512.New()
 		switch selector {
 		case 0:
-			io.WriteString(h, string(cert.Raw))
+			h.Write(cert.Raw)
 			return hex.EncodeToString(h.Sum(nil)), nil
 		case 1:
-			io.WriteString(h, string(cert.RawSubjectPublicKeyInfo))
+			h.Write(cert.RawSubjectPublicKeyInfo)
 			return hex.EncodeToString(h.Sum(nil)), nil
 		}
 	}

--- a/idn/punycode.go
+++ b/idn/punycode.go
@@ -242,11 +242,8 @@ func encode(input []byte) []byte {
 		t, k, cp     rune // weight and codepoint calculation
 	)
 
-	s := &bytes.Buffer{}
 	for h := basiclen; h < fulllen; n, delta = n+1, delta+1 {
 		nextltr = next(b, n)
-		s.Truncate(0)
-		s.WriteRune(nextltr)
 		delta, n = delta+(nextltr-n)*rune(h+1), nextltr
 
 		for _, ltr = range b {

--- a/nsecx.go
+++ b/nsecx.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"crypto/sha1"
 	"hash"
-	"io"
 	"strings"
 )
 
@@ -36,15 +35,15 @@ func HashName(label string, ha uint8, iter uint16, salt string) string {
 	}
 
 	// k = 0
-	name = append(name, wire...)
-	io.WriteString(s, string(name))
+	s.Write(name)
+	s.Write(wire)
 	nsec3 := s.Sum(nil)
 	// k > 0
 	for k := uint16(0); k < iter; k++ {
 		s.Reset()
-		nsec3 = append(nsec3, wire...)
-		io.WriteString(s, string(nsec3))
-		nsec3 = s.Sum(nil)
+		s.Write(nsec3)
+		s.Write(wire)
+		nsec3 = s.Sum(nsec3[:0])
 	}
 	return toBase32(nsec3)
 }

--- a/sig0.go
+++ b/sig0.go
@@ -60,16 +60,15 @@ func (rr *SIG) Sign(k crypto.Signer, m *Msg) ([]byte, error) {
 	}
 
 	rr.Signature = toBase64(signature)
-	sig := string(signature)
 
-	buf = append(buf, sig...)
+	buf = append(buf, signature...)
 	if len(buf) > int(^uint16(0)) {
 		return nil, ErrBuf
 	}
 	// Adjust sig data length
 	rdoff := len(mbuf) + 1 + 2 + 2 + 4
 	rdlen := binary.BigEndian.Uint16(buf[rdoff:])
-	rdlen += uint16(len(sig))
+	rdlen += uint16(len(signature))
 	binary.BigEndian.PutUint16(buf[rdoff:], rdlen)
 	// Adjust additional count
 	adc := binary.BigEndian.Uint16(buf[10:])

--- a/tsig.go
+++ b/tsig.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"hash"
-	"io"
 	"strconv"
 	"strings"
 	"time"
@@ -124,7 +123,7 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 	default:
 		return nil, "", ErrKeyAlg
 	}
-	io.WriteString(h, string(buf))
+	h.Write(buf)
 	t.MAC = hex.EncodeToString(h.Sum(nil))
 	t.MACSize = uint16(len(t.MAC) / 2) // Size is half!
 


### PR DESCRIPTION
This pull request introduces some very minor performance improvements and reduces the garbage produced when calling several functions.

The first commit removes an unused bytes.Buffer from dns/idn.encode. The second commit reduces the amount of garbage produced when calling CertificateToDANE, HashName, (*SIG).Sign and TsigGenerate.

No functionality or APIs are changed.