### PR TITLE
Improve DNSSEC performance by addressing some low hanging fruit.

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -208,9 +208,6 @@ func (k *DNSKEY) ToDS(h uint8) *DS {
 	// "|" denotes concatenation
 	// DNSKEY RDATA = Flags | Protocol | Algorithm | Public Key.
 
-	// digest buffer
-	digest := append(owner, wire...) // another copy
-
 	var hash crypto.Hash
 	switch h {
 	case SHA1:
@@ -226,7 +223,8 @@ func (k *DNSKEY) ToDS(h uint8) *DS {
 	}
 
 	s := hash.New()
-	s.Write(digest)
+	s.Write(owner)
+	s.Write(wire)
 	ds.Digest = hex.EncodeToString(s.Sum(nil))
 	return ds
 }
@@ -297,7 +295,6 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 	if err != nil {
 		return err
 	}
-	signdata = append(signdata, wire...)
 
 	hash, ok := AlgorithmToHash[rr.Algorithm]
 	if !ok {
@@ -306,6 +303,7 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 
 	h := hash.New()
 	h.Write(signdata)
+	h.Write(wire)
 
 	signature, err := sign(k, h.Sum(nil), hash, rr.Algorithm)
 	if err != nil {
@@ -415,7 +413,6 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 	if err != nil {
 		return err
 	}
-	signeddata = append(signeddata, wire...)
 
 	sigbuf := rr.sigBuf()           // Get the binary signature data
 	if rr.Algorithm == PRIVATEDNS { // PRIVATEOID
@@ -438,6 +435,7 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 
 		h := hash.New()
 		h.Write(signeddata)
+		h.Write(wire)
 		return rsa.VerifyPKCS1v15(pubkey, hash, h.Sum(nil), sigbuf)
 
 	case ECDSAP256SHA256, ECDSAP384SHA384:
@@ -452,6 +450,7 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 
 		h := hash.New()
 		h.Write(signeddata)
+		h.Write(wire)
 		if ecdsa.Verify(pubkey, h.Sum(nil), r, s) {
 			return nil
 		}

--- a/dnssec_keygen.go
+++ b/dnssec_keygen.go
@@ -121,17 +121,17 @@ func (k *DNSKEY) setPublicKeyDSA(_Q, _P, _G, _Y *big.Int) bool {
 // RFC 3110: Section 2. RSA Public KEY Resource Records
 func exponentToBuf(_E int) []byte {
 	var buf []byte
-	i := big.NewInt(int64(_E))
-	if len(i.Bytes()) < 256 {
-		buf = make([]byte, 1)
-		buf[0] = uint8(len(i.Bytes()))
+	i := big.NewInt(int64(_E)).Bytes()
+	if len(i) < 256 {
+		buf = make([]byte, 1, 1+len(i))
+		buf[0] = uint8(len(i))
 	} else {
-		buf = make([]byte, 3)
+		buf = make([]byte, 3, 3+len(i))
 		buf[0] = 0
-		buf[1] = uint8(len(i.Bytes()) >> 8)
-		buf[2] = uint8(len(i.Bytes()))
+		buf[1] = uint8(len(i) >> 8)
+		buf[2] = uint8(len(i))
 	}
-	buf = append(buf, i.Bytes()...)
+	buf = append(buf, i...)
 	return buf
 }
 


### PR DESCRIPTION
This pull request introduces some very minor performance improvements and reduces the garbage produced when calling several functions. I missed these when I opened #444.

The first commit reduces the amount of garbage produced when calling (*DNSKEY).ToDS, (*RRSIG).Sign and (*RRSIG).Verify. The second commit improves the performance and reduces the amount of garbage produced when calling (*DNSKEY).Generate with (*DNSKEY).Algorithm is set to an RSA\* constant.

No functionality or APIs are changed.