### PR TITLE
dns/tcp: more robust read.

### DIFF
--- a/client.go
+++ b/client.go
@@ -300,6 +300,18 @@ func tcpMsgLen(t io.Reader) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+
+	// As seen with my local router/switch, retursn 1 byte on the above read,
+	// resulting a a ShortRead. Just write it out (instead of loop) and read the
+	// other byte.
+	if n == 1 {
+		n1, err := t.Read(p[1:])
+		if err != nil {
+			return 0, err
+		}
+		n += n1
+	}
+
 	if n != 2 {
 		return 0, ErrShortRead
 	}


### PR DESCRIPTION
My home router only return 1 byte on the initial tcp read of 2 bytes
for the size of the reply. We should read the other byte as well if this
happen.

With this fix, this:
~~~
% ./q -tcp @192.168.1.1 higgs
;; dns: short read
~~~

becomes:
~~~
% ./q -tcp @192.168.1.1 higgs
;; opcode: QUERY, status: NOERROR, id: 12968
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;higgs.	IN	 A

;; ANSWER SECTION:
higgs.	0	IN	A	192.168.1.108

;; query time: 10737 µs, server: 192.168.1.1:53(tcp), size: 44 bytes
~~~