### PR TITLE
A co.Conn is not always a (*net.UDPConn) so don't convert to it.

### DIFF
--- a/client.go
+++ b/client.go
@@ -412,7 +412,7 @@ func (co *Conn) Write(p []byte) (n int, err error) {
 		n, err := io.Copy(w, bytes.NewReader(p))
 		return int(n), err
 	}
-	n, err = co.Conn.(*net.UDPConn).Write(p)
+	n, err = co.Conn.Write(p)
 	return n, err
 }
 


### PR DESCRIPTION
co.Conn is a net.Conn, and has a Write(b []byte) method on it. So this change will continue to work for net.UDPConn, but now allows for other implementations (such as a appengine.socket.Conn).