### PR TITLE
Added NameList function to ClientConfig

### DIFF
--- a/clientconfig.go
+++ b/clientconfig.go
@@ -97,3 +97,35 @@ func ClientConfigFromFile(resolvconf string) (*ClientConfig, error) {
 	}
 	return c, nil
 }
+
+// NameList returns all of the names that should be queried based on the
+// config. It is based off of go's net/dns name building, but it does not
+// check the length of the resulting names.
+func (c *ClientConfig) NameList(name string) []string {
+	// if this domain is already fully qualified, no append needed.
+	if IsFqdn(name) {
+		return []string{name}
+	}
+
+	// Check to see if the name has more labels than Ndots. Do this before making
+	// the domain fully qualified.
+	hasNdots := CountLabel(name) > c.Ndots
+	// Make the domain fully qualified.
+	name = Fqdn(name)
+
+	// Make a list of names based off search.
+	names := []string{}
+
+	// If name has enough dots, try that first.
+	if hasNdots {
+		names = append(names, name)
+	}
+	for _, s := range c.Search {
+		names = append(names, Fqdn(name+s))
+	}
+	// If we didn't have enough dots, try after suffixes.
+	if !hasNdots {
+		names = append(names, name)
+	}
+	return names
+}

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -48,3 +48,40 @@ func testConfig(t *testing.T, data string) {
 
 func TestNameserver(t *testing.T)          { testConfig(t, normal) }
 func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline) }
+
+func TestNameList(t *testing.T) {
+	cfg := ClientConfig{
+		Ndots: 1,
+	}
+	// fqdn should be only result returned
+	names := cfg.NameList("miek.nl.")
+	if len(names) != 1 {
+		t.Errorf("NameList returned != 1 names: %v", names)
+	} else if names[0] != "miek.nl." {
+		t.Errorf("NameList didn't return sent fqdn domain: %v", names[0])
+	}
+
+	cfg.Search = []string{
+		"test",
+	}
+	// Sent domain has NDots and search
+	names = cfg.NameList("miek.nl")
+	if len(names) != 2 {
+		t.Errorf("NameList returned != 2 names: %v", names)
+	} else if names[0] != "miek.nl." {
+		t.Errorf("NameList didn't return sent domain first: %v", names[0])
+	} else if names[1] != "miek.nl.test." {
+		t.Errorf("NameList didn't return search last: %v", names[1])
+	}
+
+	cfg.Ndots = 2
+	// Sent domain has less than NDots and search
+	names = cfg.NameList("miek.nl")
+	if len(names) != 2 {
+		t.Errorf("NameList returned != 2 names: %v", names)
+	} else if names[0] != "miek.nl.test." {
+		t.Errorf("NameList didn't return search first: %v", names[0])
+	} else if names[1] != "miek.nl." {
+		t.Errorf("NameList didn't return sent domain last: %v", names[1])
+	}
+}


### PR DESCRIPTION
Instead of forcing users to build the list of queries they should make for a given name (like https://github.com/prometheus/prometheus/blob/master/discovery/dns/dns.go#L171) `ClientConfig` should have a `NameList` function much like https://github.com/golang/go/blob/master/src/net/dnsclient_unix.go#L360 to get a slice of all the given names.

This would also fix a prometheus bug where they're incorrectly looking at suffixes first instead of trying fqdn if it has ndots. I'll make a PR for that once this is fixed.