### PR TITLE
Update GoDoc reference to EDNS0_SUBNET.SourceNetmask field.

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -197,7 +197,7 @@ func (e *EDNS0_NSID) String() string        { return string(e.Nsid) }
 //	e := new(dns.EDNS0_SUBNET)
 //	e.Code = dns.EDNS0SUBNET
 //	e.Family = 1	// 1 for IPv4 source address, 2 for IPv6
-//	e.SourceNetMask = 32	// 32 for IPV4, 128 for IPv6
+//	e.SourceNetmask = 32	// 32 for IPV4, 128 for IPv6
 //	e.SourceScope = 0
 //	e.Address = net.ParseIP("127.0.0.1").To4()	// for IPv4
 //	// e.Address = net.ParseIP("2001:7b8:32a::2")	// for IPV6


### PR DESCRIPTION
Hi,

I was following the example of setting edns-client-subnet option via GoDoc and noticed the struct field was misnamed:

`e.SourceNetMask undefined (type *dns.EDNS0_SUBNET has no field or method SourceNetMask, but does have SourceNetmask)`