### PR TITLE
Add support for Ed25519 DNSSEC signing from RFC 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Send pull request if you want to be listed here.
     * Parsing RRs ~ 100K RR/s, that's 5M records in about 50 seconds;
 * Server side programming (mimicking the net/http package);
 * Client side programming;
-* DNSSEC: signing, validating and key generation for DSA, RSA and ECDSA;
+* DNSSEC: signing, validating and key generation for DSA, RSA, ECDSA and Ed25519;
 * EDNS0, NSID, Cookies;
 * AXFR/IXFR;
 * TSIG, SIG(0);
@@ -154,6 +154,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 7553 - URI record
 * 7858 - DNS over TLS: Initiation and Performance Considerations
 * 7873 - Domain Name System (DNS) Cookies (draft-ietf-dnsop-cookies)
+* 8080 - EdDSA for DNSSEC
 
 ## Loosely based upon
 

--- a/dnssec.go
+++ b/dnssec.go
@@ -310,6 +310,12 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 
 	switch rr.Algorithm {
 	case ED25519:
+		// ed25519 signs the raw message and performs hashing internally.
+		// All other supported signature schemes operate over the pre-hashed
+		// message, and thus ed25519 must be handled separately here.
+		//
+		// The raw message is passed directly into sign and crypto.Hash(0) is
+		// used to signal to the crypto.Signer that the data has not been hashed.
 		signature, err := sign(k, append(signdata, wire...), crypto.Hash(0), rr.Algorithm)
 		if err != nil {
 			return err

--- a/dnssec.go
+++ b/dnssec.go
@@ -19,6 +19,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // DNSSEC encryption algorithm codes.
@@ -38,6 +40,8 @@ const (
 	ECCGOST
 	ECDSAP256SHA256
 	ECDSAP384SHA384
+	ED25519
+	ED448
 	INDIRECT   uint8 = 252
 	PRIVATEDNS uint8 = 253 // Private (experimental keys)
 	PRIVATEOID uint8 = 254
@@ -56,6 +60,8 @@ var AlgorithmToString = map[uint8]string{
 	ECCGOST:          "ECC-GOST",
 	ECDSAP256SHA256:  "ECDSAP256SHA256",
 	ECDSAP384SHA384:  "ECDSAP384SHA384",
+	ED25519:          "ED25519",
+	ED448:            "ED448",
 	INDIRECT:         "INDIRECT",
 	PRIVATEDNS:       "PRIVATEDNS",
 	PRIVATEOID:       "PRIVATEOID",
@@ -73,6 +79,7 @@ var AlgorithmToHash = map[uint8]crypto.Hash{
 	ECDSAP256SHA256:  crypto.SHA256,
 	ECDSAP384SHA384:  crypto.SHA384,
 	RSASHA512:        crypto.SHA512,
+	ED25519:          crypto.Hash(0),
 }
 
 // DNSSEC hashing algorithm codes.
@@ -301,16 +308,26 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 		return ErrAlg
 	}
 
-	h := hash.New()
-	h.Write(signdata)
-	h.Write(wire)
+	switch rr.Algorithm {
+	case ED25519:
+		signature, err := sign(k, append(signdata, wire...), crypto.Hash(0), rr.Algorithm)
+		if err != nil {
+			return err
+		}
 
-	signature, err := sign(k, h.Sum(nil), hash, rr.Algorithm)
-	if err != nil {
-		return err
+		rr.Signature = toBase64(signature)
+	default:
+		h := hash.New()
+		h.Write(signdata)
+		h.Write(wire)
+
+		signature, err := sign(k, h.Sum(nil), hash, rr.Algorithm)
+		if err != nil {
+			return err
+		}
+
+		rr.Signature = toBase64(signature)
 	}
-
-	rr.Signature = toBase64(signature)
 
 	return nil
 }
@@ -352,6 +369,9 @@ func sign(k crypto.Signer, hashed []byte, hash crypto.Hash, alg uint8) ([]byte, 
 		// 	signature = append(signature, intToBytes(r1, 20)...)
 		// 	signature = append(signature, intToBytes(s1, 20)...)
 		// 	rr.Signature = signature
+
+	case ED25519:
+		return signature, nil
 	}
 
 	return nil, ErrAlg
@@ -452,6 +472,17 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 		h.Write(signeddata)
 		h.Write(wire)
 		if ecdsa.Verify(pubkey, h.Sum(nil), r, s) {
+			return nil
+		}
+		return ErrSig
+
+	case ED25519:
+		pubkey := k.publicKeyED25519()
+		if pubkey == nil {
+			return ErrKey
+		}
+
+		if ed25519.Verify(pubkey, append(signeddata, wire...), sigbuf) {
 			return nil
 		}
 		return ErrSig
@@ -576,6 +607,17 @@ func (k *DNSKEY) publicKeyDSA() *dsa.PublicKey {
 	pubkey.Parameters.G = big.NewInt(0).SetBytes(g)
 	pubkey.Y = big.NewInt(0).SetBytes(y)
 	return pubkey
+}
+
+func (k *DNSKEY) publicKeyED25519() ed25519.PublicKey {
+	keybuf, err := fromBase64([]byte(k.PublicKey))
+	if err != nil {
+		return nil
+	}
+	if len(keybuf) != ed25519.PublicKeySize {
+		return nil
+	}
+	return keybuf
 }
 
 type wireSlice [][]byte

--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -184,6 +184,15 @@ func readPrivateKeyED25519(m map[string]string) (ed25519.PrivateKey, error) {
 			if len(p1) != 32 {
 				return nil, ErrPrivKey
 			}
+			// RFC 8080 and Golang's x/crypto/ed25519 differ as to how the
+			// private keys are represented. RFC 8080 specifies that private
+			// keys be stored solely as the seed value (p1 above) while the
+			// ed25519 package represents them as the seed value concatenated
+			// to the public key, which is derived from the seed value.
+			//
+			// ed25519.GenerateKey reads exactly 32 bytes from the passed in
+			// io.Reader and uses them as the seed. It also derives the
+			// public key and produces a compatible private key.
 			_, p, err = ed25519.GenerateKey(bytes.NewReader(p1))
 			if err != nil {
 				return nil, err

--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
@@ -9,6 +10,8 @@ import (
 	"math/big"
 	"strconv"
 	"strings"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // NewPrivateKey returns a PrivateKey by parsing the string s.
@@ -86,6 +89,8 @@ func (k *DNSKEY) ReadPrivateKey(q io.Reader, file string) (crypto.PrivateKey, er
 		}
 		priv.PublicKey = *pub
 		return priv, nil
+	case ED25519:
+		return readPrivateKeyED25519(m)
 	default:
 		return nil, ErrPrivKey
 	}
@@ -159,6 +164,30 @@ func readPrivateKeyECDSA(m map[string]string) (*ecdsa.PrivateKey, error) {
 				return nil, err
 			}
 			p.D.SetBytes(v1)
+		case "created", "publish", "activate":
+			/* not used in Go (yet) */
+		}
+	}
+	return p, nil
+}
+
+func readPrivateKeyED25519(m map[string]string) (ed25519.PrivateKey, error) {
+	var p ed25519.PrivateKey
+	// TODO: validate that the required flags are present
+	for k, v := range m {
+		switch k {
+		case "privatekey":
+			p1, err := fromBase64([]byte(v))
+			if err != nil {
+				return nil, err
+			}
+			if len(p1) != 32 {
+				return nil, ErrPrivKey
+			}
+			_, p, err = ed25519.GenerateKey(bytes.NewReader(p1))
+			if err != nil {
+				return nil, err
+			}
 		case "created", "publish", "activate":
 			/* not used in Go (yet) */
 		}

--- a/dnssec_privkey.go
+++ b/dnssec_privkey.go
@@ -7,6 +7,8 @@ import (
 	"crypto/rsa"
 	"math/big"
 	"strconv"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 const format = "Private-key-format: v1.3\n"
@@ -78,6 +80,12 @@ func (r *DNSKEY) PrivateKeyString(p crypto.PrivateKey) string {
 			"Base(g): " + base + "\n" +
 			"Private_value(x): " + priv + "\n" +
 			"Public_value(y): " + pub + "\n"
+
+	case ed25519.PrivateKey:
+		private := toBase64(p[:32])
+		return format +
+			"Algorithm: " + algorithm + "\n" +
+			"PrivateKey: " + private + "\n"
 
 	default:
 		return ""

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 func getKey() *DNSKEY {
@@ -461,6 +463,55 @@ func TestSignVerifyECDSA2(t *testing.T) {
 	}
 }
 
+func TestSignVerifyEd25519(t *testing.T) {
+	srv1, err := NewRR("srv.miek.nl. IN SRV 1000 800 0 web1.miek.nl.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := srv1.(*SRV)
+
+	// With this key
+	key := new(DNSKEY)
+	key.Hdr.Rrtype = TypeDNSKEY
+	key.Hdr.Name = "miek.nl."
+	key.Hdr.Class = ClassINET
+	key.Hdr.Ttl = 14400
+	key.Flags = 256
+	key.Protocol = 3
+	key.Algorithm = ED25519
+	privkey, err := key.Generate(256)
+	if err != nil {
+		t.Fatal("failure to generate key")
+	}
+
+	// Fill in the values of the Sig, before signing
+	sig := new(RRSIG)
+	sig.Hdr = RR_Header{"miek.nl.", TypeRRSIG, ClassINET, 14400, 0}
+	sig.TypeCovered = srv.Hdr.Rrtype
+	sig.Labels = uint8(CountLabel(srv.Hdr.Name)) // works for all 3
+	sig.OrigTtl = srv.Hdr.Ttl
+	sig.Expiration = 1296534305 // date -u '+%s' -d"2011-02-01 04:25:05"
+	sig.Inception = 1293942305  // date -u '+%s' -d"2011-01-02 04:25:05"
+	sig.KeyTag = key.KeyTag()   // Get the keyfrom the Key
+	sig.SignerName = key.Hdr.Name
+	sig.Algorithm = ED25519
+
+	if sig.Sign(privkey.(ed25519.PrivateKey), []RR{srv}) != nil {
+		t.Fatal("failure to sign the record")
+	}
+
+	err = sig.Verify(key, []RR{srv})
+	if err != nil {
+		t.Logf("failure to validate:\n%s\n%s\n%s\n\n%s\n\n%v",
+			key.String(),
+			srv.String(),
+			sig.String(),
+			key.PrivateKeyString(privkey),
+			err,
+		)
+	}
+}
+
 // Here the test vectors from the relevant RFCs are checked.
 // rfc6605 6.1
 func TestRFC6605P256(t *testing.T) {
@@ -585,6 +636,144 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
 	// Signatures are randomized
 	rrRRSIG.(*RRSIG).Signature = ""
 	ourRRSIG.Signature = ""
+	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
+		t.Fatalf("RRSIG record differs:\n%v\n%v", ourRRSIG, rrRRSIG.(*RRSIG))
+	}
+}
+
+// rfc8080 6.1
+func TestRFC8080Ed25519Example1(t *testing.T) {
+	exDNSKEY := `example.com. 3600 IN DNSKEY 257 3 15 (
+             l02Woi0iS8Aa25FQkUd9RMzZHJpBoRQwAQEX1SxZJA4= )`
+	exPriv := `Private-key-format: v1.2
+Algorithm: 15 (ED25519)
+PrivateKey: ODIyNjAzODQ2MjgwODAxMjI2NDUxOTAyMDQxNDIyNjI=`
+	rrDNSKEY, err := NewRR(exDNSKEY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exDS := `example.com. 3600 IN DS 3613 15 2 (
+             3aa5ab37efce57f737fc1627013fee07bdf241bd10f3b1964ab55c78e79
+             a304b )`
+	rrDS, err := NewRR(exDS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA256)
+	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
+		t.Fatalf("DS record differs:\n%v\n%v", ourDS, rrDS.(*DS))
+	}
+
+	exMX := `example.com. 3600 IN MX 10 mail.example.com.`
+	exRRSIG := `example.com. 3600 IN RRSIG MX 15 2 3600 (
+             1440021600 1438207200 3613 example.com. (
+             oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeRAvTdszaPD+QLs3f
+             x8A4M3e23mRZ9VrbpMngwcrqNAg== ) )`
+	rrMX, err := NewRR(exMX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rrRRSIG, err := NewRR(exRRSIG)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrMX}); err != nil {
+		t.Errorf("failure to validate the spec RRSIG: %v", err)
+	}
+
+	ourRRSIG := &RRSIG{
+		Hdr: RR_Header{
+			Ttl: rrMX.Header().Ttl,
+		},
+		KeyTag:     rrDNSKEY.(*DNSKEY).KeyTag(),
+		SignerName: rrDNSKEY.(*DNSKEY).Hdr.Name,
+		Algorithm:  rrDNSKEY.(*DNSKEY).Algorithm,
+	}
+	ourRRSIG.Expiration, _ = StringToTime("20150819220000")
+	ourRRSIG.Inception, _ = StringToTime("20150729220000")
+	err = ourRRSIG.Sign(priv.(ed25519.PrivateKey), []RR{rrMX})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = ourRRSIG.Verify(rrDNSKEY.(*DNSKEY), []RR{rrMX}); err != nil {
+		t.Errorf("failure to validate our RRSIG: %v", err)
+	}
+
+	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
+		t.Fatalf("RRSIG record differs:\n%v\n%v", ourRRSIG, rrRRSIG.(*RRSIG))
+	}
+}
+
+// rfc8080 6.1
+func TestRFC8080Ed25519Example2(t *testing.T) {
+	exDNSKEY := `example.com. 3600 IN DNSKEY 257 3 15 (
+             zPnZ/QwEe7S8C5SPz2OfS5RR40ATk2/rYnE9xHIEijs= )`
+	exPriv := `Private-key-format: v1.2
+Algorithm: 15 (ED25519)
+PrivateKey: DSSF3o0s0f+ElWzj9E/Osxw8hLpk55chkmx0LYN5WiY=`
+	rrDNSKEY, err := NewRR(exDNSKEY)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exDS := `example.com. 3600 IN DS 35217 15 2 (
+             401781b934e392de492ec77ae2e15d70f6575a1c0bc59c5275c04ebe80c
+             6614c )`
+	rrDS, err := NewRR(exDS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA256)
+	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
+		t.Fatalf("DS record differs:\n%v\n%v", ourDS, rrDS.(*DS))
+	}
+
+	exMX := `example.com. 3600 IN MX 10 mail.example.com.`
+	exRRSIG := `example.com. 3600 IN RRSIG MX 15 2 3600 (
+             1440021600 1438207200 35217 example.com. (
+             zXQ0bkYgQTEFyfLyi9QoiY6D8ZdYo4wyUhVioYZXFdT410QPRITQSqJSnzQ
+             oSm5poJ7gD7AQR0O7KuI5k2pcBg== ) )`
+	rrMX, err := NewRR(exMX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rrRRSIG, err := NewRR(exRRSIG)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrMX}); err != nil {
+		t.Errorf("failure to validate the spec RRSIG: %v", err)
+	}
+
+	ourRRSIG := &RRSIG{
+		Hdr: RR_Header{
+			Ttl: rrMX.Header().Ttl,
+		},
+		KeyTag:     rrDNSKEY.(*DNSKEY).KeyTag(),
+		SignerName: rrDNSKEY.(*DNSKEY).Hdr.Name,
+		Algorithm:  rrDNSKEY.(*DNSKEY).Algorithm,
+	}
+	ourRRSIG.Expiration, _ = StringToTime("20150819220000")
+	ourRRSIG.Inception, _ = StringToTime("20150729220000")
+	err = ourRRSIG.Sign(priv.(ed25519.PrivateKey), []RR{rrMX})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = ourRRSIG.Verify(rrDNSKEY.(*DNSKEY), []RR{rrMX}); err != nil {
+		t.Errorf("failure to validate our RRSIG: %v", err)
+	}
+
 	if !reflect.DeepEqual(ourRRSIG, rrRRSIG.(*RRSIG)) {
 		t.Fatalf("RRSIG record differs:\n%v\n%v", ourRRSIG, rrRRSIG.(*RRSIG))
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -1104,6 +1104,7 @@ func TestNewPrivateKey(t *testing.T) {
 		{RSASHA1, 1024},
 		{RSASHA256, 2048},
 		{DSA, 1024},
+		{ED25519, 256},
 	}
 
 	for _, algo := range algorithms {


### PR DESCRIPTION
This pull request adds support for the Ed25519 algorithm in DNSSEC from [RFC 8080](https://tools.ietf.org/html/rfc8080). RFC 8080 also specifies the use of Ed448 but there is no standard library implementation of Ed448 so it is not included, this should not be an issue as Ed25519 will always see more use than Ed448.

I'm not sure if this pull request meets the 'Depends only on the standard library.' feature listed in the README. Ed25519 support comes from a Golang sub-repositories, in particular [golang.org/x/crypto/ed25519](https://godoc.org/golang.org/x/crypto/ed25519). The sub-repositories are described with:
> These packages are part of the Go Project but outside the main Go tree. They are developed under looser compatibility requirements than the Go core. Install them with "go get".

Note: the examples included in the RFC are invalid and were corrected in [RFC Errata Report (4935)](https://www.rfc-editor.org/errata_search.php?eid=4935).