### PR TITLE
README: Add Quilt to the list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://github.com/mehrdadrad/mylg
 * https://github.com/bamarni/dockness
 * https://github.com/fffaraz/microdns
+* http://quilt.io
 
 Send pull request if you want to be listed here.
 


### PR DESCRIPTION
Quilt is container orchestrator that depends on JavaScript as its
configuration mechanism.  It takes advantage of miekg/dns for name
resolution, and thus should be listed in the README.md file.