### PR TITLE
add use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://github.com/bamarni/dockness
 * https://github.com/fffaraz/microdns
 * http://quilt.io
+* https://github.com/ipdcode/hades (JD.COM)
 
 Send pull request if you want to be listed here.
 


### PR DESCRIPTION
thinks dns lib for help JD.COM make DNS service for kubernetes cluster