### PR TITLE
Replace Atoi with ParseUint where appropriate

### DIFF
--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -36,7 +36,7 @@ func (k *DNSKEY) ReadPrivateKey(q io.Reader, file string) (crypto.PrivateKey, er
 		return nil, ErrPrivKey
 	}
 	// TODO(mg): check if the pubkey matches the private key
-	algo, err := strconv.Atoi(strings.SplitN(m["algorithm"], " ", 2)[0])
+	algo, err := strconv.ParseUint(strings.SplitN(m["algorithm"], " ", 2)[0], 10, 8)
 	if err != nil {
 		return nil, ErrPrivKey
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -836,11 +836,7 @@ func TestSRVPacking(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		port := 8484
-		tmp, err := strconv.Atoi(p)
-		if err == nil {
-			port = tmp
-		}
+		port, _ := strconv.ParseUint(p, 10, 16)
 
 		rr := &SRV{
 			Hdr: RR_Header{Name: "somename.",

--- a/scan.go
+++ b/scan.go
@@ -819,8 +819,8 @@ func classToInt(token string) (uint16, bool) {
 	if len(token) < offset+1 {
 		return 0, false
 	}
-	class, ok := strconv.Atoi(token[offset:])
-	if ok != nil || class > maxUint16 {
+	class, err := strconv.ParseUint(token[offset:], 10, 16)
+	if err != nil {
 		return 0, false
 	}
 	return uint16(class), true
@@ -832,8 +832,8 @@ func typeToInt(token string) (uint16, bool) {
 	if len(token) < offset+1 {
 		return 0, false
 	}
-	typ, ok := strconv.Atoi(token[offset:])
-	if ok != nil || typ > maxUint16 {
+	typ, err := strconv.ParseUint(token[offset:], 10, 16)
+	if err != nil {
 		return 0, false
 	}
 	return uint16(typ), true

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -447,7 +447,7 @@ func setMX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad MX Pref", l}, ""
 	}
@@ -476,7 +476,7 @@ func setRT(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil {
 		return nil, &ParseError{f, "bad RT Preference", l}, ""
 	}
@@ -506,7 +506,7 @@ func setAFSDB(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad AFSDB Subtype", l}, ""
 	}
@@ -551,7 +551,7 @@ func setKX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad KX Pref", l}, ""
 	}
@@ -665,7 +665,7 @@ func setSOA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		if l.err {
 			return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
 		}
-		if j, e := strconv.Atoi(l.token); e != nil {
+		if j, e := strconv.ParseUint(l.token, 10, 32); e != nil {
 			if i == 0 {
 				// Serial should be a number
 				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
@@ -705,21 +705,21 @@ func setSRV(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SRV Priority", l}, ""
 	}
 	rr.Priority = uint16(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SRV Weight", l}, ""
 	}
 	rr.Weight = uint16(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SRV Port", l}, ""
 	}
@@ -749,14 +749,14 @@ func setNAPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NAPTR Order", l}, ""
 	}
 	rr.Order = uint16(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NAPTR Preference", l}, ""
 	}
@@ -885,7 +885,7 @@ func setLOC(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Latitude", l}, ""
 	}
@@ -897,7 +897,7 @@ func setLOC(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if rr.Latitude, ok = locCheckNorth(l.token, rr.Latitude); ok {
 		goto East
 	}
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Latitude minutes", l}, ""
 	}
@@ -923,7 +923,7 @@ East:
 	// East
 	<-c // zBlank
 	l = <-c
-	if i, e := strconv.Atoi(l.token); e != nil || l.err {
+	if i, e := strconv.ParseUint(l.token, 10, 32); e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Longitude", l}, ""
 	} else {
 		rr.Longitude = 1000 * 60 * 60 * uint32(i)
@@ -934,7 +934,7 @@ East:
 	if rr.Longitude, ok = locCheckEast(l.token, rr.Longitude); ok {
 		goto Altitude
 	}
-	if i, e := strconv.Atoi(l.token); e != nil || l.err {
+	if i, e := strconv.ParseUint(l.token, 10, 32); e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Longitude minutes", l}, ""
 	} else {
 		rr.Longitude += 1000 * 60 * uint32(i)
@@ -1016,7 +1016,7 @@ func setHIP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad HIP PublicKeyAlgorithm", l}, ""
 	}
@@ -1077,14 +1077,14 @@ func setCERT(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	}
 	if v, ok := StringToCertType[l.token]; ok {
 		rr.Type = v
-	} else if i, e := strconv.Atoi(l.token); e != nil {
+	} else if i, e := strconv.ParseUint(l.token, 10, 16); e != nil {
 		return nil, &ParseError{f, "bad CERT Type", l}, ""
 	} else {
 		rr.Type = uint16(i)
 	}
 	<-c     // zBlank
 	l = <-c // zString
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad CERT KeyTag", l}, ""
 	}
@@ -1093,7 +1093,7 @@ func setCERT(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	if v, ok := StringToAlgorithm[l.token]; ok {
 		rr.Algorithm = v
-	} else if i, e := strconv.Atoi(l.token); e != nil {
+	} else if i, e := strconv.ParseUint(l.token, 10, 8); e != nil {
 		return nil, &ParseError{f, "bad CERT Algorithm", l}, ""
 	} else {
 		rr.Algorithm = uint8(i)
@@ -1148,21 +1148,21 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	}
 	<-c // zBlank
 	l = <-c
-	i, err := strconv.Atoi(l.token)
+	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
 		return nil, &ParseError{f, "bad RRSIG Algorithm", l}, ""
 	}
 	rr.Algorithm = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, err = strconv.Atoi(l.token)
+	i, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
 		return nil, &ParseError{f, "bad RRSIG Labels", l}, ""
 	}
 	rr.Labels = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, err = strconv.Atoi(l.token)
+	i, err = strconv.ParseUint(l.token, 10, 32)
 	if err != nil || l.err {
 		return nil, &ParseError{f, "bad RRSIG OrigTtl", l}, ""
 	}
@@ -1193,7 +1193,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	}
 	<-c // zBlank
 	l = <-c
-	i, err = strconv.Atoi(l.token)
+	i, err = strconv.ParseUint(l.token, 10, 16)
 	if err != nil || l.err {
 		return nil, &ParseError{f, "bad RRSIG KeyTag", l}, ""
 	}
@@ -1274,21 +1274,21 @@ func setNSEC3(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3 Hash", l}, ""
 	}
 	rr.Hash = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3 Flags", l}, ""
 	}
 	rr.Flags = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3 Iterations", l}, ""
 	}
@@ -1342,21 +1342,21 @@ func setNSEC3PARAM(h RR_Header, c chan lex, o, f string) (RR, *ParseError, strin
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3PARAM Hash", l}, ""
 	}
 	rr.Hash = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3PARAM Flags", l}, ""
 	}
 	rr.Flags = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3PARAM Iterations", l}, ""
 	}
@@ -1440,14 +1440,14 @@ func setSSHFP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SSHFP Algorithm", l}, ""
 	}
 	rr.Algorithm = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SSHFP Type", l}, ""
 	}
@@ -1469,21 +1469,21 @@ func setDNSKEYs(h RR_Header, c chan lex, o, f, typ string) (RR, *ParseError, str
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " Flags", l}, ""
 	}
 	rr.Flags = uint16(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " Protocol", l}, ""
 	}
 	rr.Protocol = uint8(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " Algorithm", l}, ""
 	}
@@ -1525,21 +1525,21 @@ func setRKEY(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad RKEY Flags", l}, ""
 	}
 	rr.Flags = uint16(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad RKEY Protocol", l}, ""
 	}
 	rr.Protocol = uint8(i)
 	<-c     // zBlank
 	l = <-c // zString
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad RKEY Algorithm", l}, ""
 	}
@@ -1610,14 +1610,14 @@ func setDSs(h RR_Header, c chan lex, o, f, typ string) (RR, *ParseError, string)
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " KeyTag", l}, ""
 	}
 	rr.KeyTag = uint16(i)
 	<-c // zBlank
 	l = <-c
-	if i, e := strconv.Atoi(l.token); e != nil {
+	if i, e = strconv.ParseUint(l.token, 10, 8); e != nil {
 		i, ok := StringToAlgorithm[l.tokenUpper]
 		if !ok || l.err {
 			return nil, &ParseError{f, "bad " + typ + " Algorithm", l}, ""
@@ -1628,7 +1628,7 @@ func setDSs(h RR_Header, c chan lex, o, f, typ string) (RR, *ParseError, string)
 	}
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " DigestType", l}, ""
 	}
@@ -1669,14 +1669,14 @@ func setTA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TA KeyTag", l}, ""
 	}
 	rr.KeyTag = uint16(i)
 	<-c // zBlank
 	l = <-c
-	if i, e := strconv.Atoi(l.token); e != nil {
+	if i, e := strconv.ParseUint(l.token, 10, 8); e != nil {
 		i, ok := StringToAlgorithm[l.tokenUpper]
 		if !ok || l.err {
 			return nil, &ParseError{f, "bad TA Algorithm", l}, ""
@@ -1687,7 +1687,7 @@ func setTA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	}
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TA DigestType", l}, ""
 	}
@@ -1707,21 +1707,21 @@ func setTLSA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TLSA Usage", l}, ""
 	}
 	rr.Usage = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TLSA Selector", l}, ""
 	}
 	rr.Selector = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TLSA MatchingType", l}, ""
 	}
@@ -1742,21 +1742,21 @@ func setSMIMEA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SMIMEA Usage", l}, ""
 	}
 	rr.Usage = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SMIMEA Selector", l}, ""
 	}
 	rr.Selector = uint8(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SMIMEA MatchingType", l}, ""
 	}
@@ -1842,14 +1842,14 @@ func setURI(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad URI Priority", l}, ""
 	}
 	rr.Priority = uint16(i)
 	<-c // zBlank
 	l = <-c
-	i, e = strconv.Atoi(l.token)
+	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad URI Weight", l}, ""
 	}
@@ -1888,7 +1888,7 @@ func setNID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NID Preference", l}, ""
 	}
@@ -1911,7 +1911,7 @@ func setL32(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad L32 Preference", l}, ""
 	}
@@ -1933,7 +1933,7 @@ func setLP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad LP Preference", l}, ""
 	}
@@ -1966,7 +1966,7 @@ func setL64(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad L64 Preference", l}, ""
 	}
@@ -1988,7 +1988,7 @@ func setUID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad UID Uid", l}, ""
 	}
@@ -2003,7 +2003,7 @@ func setGID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad GID Gid", l}, ""
 	}
@@ -2033,7 +2033,7 @@ func setPX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, ""
 	}
-	i, e := strconv.Atoi(l.token)
+	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad PX Preference", l}, ""
 	}
@@ -2079,7 +2079,7 @@ func setCAA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 {
 		return rr, nil, l.comment
 	}
-	i, err := strconv.Atoi(l.token)
+	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
 		return nil, &ParseError{f, "bad CAA Flag", l}, ""
 	}


### PR DESCRIPTION
I came across an interesting problem where uint field parsing can exhibit some odd behavior when parsing out of bound input. This updates the various functions in `scan_rr` that parse unsigned integers to use `strconv.ParseUint` instead of `strconv.Atoi`, which returns more appropriate errors.

Below is an example highlighting some of the parsing oddities
```go
package main

import (
	"fmt"

	"github.com/miekg/dns"
)

func main() {
	input := []string{
		"example.com. 3600 IN MX -1 mail.example.com.",
		"example.com. 3600 IN MX 65536 mail.example.com.",
	}

	for _, inp := range input {
		rr, _ := dns.NewRR(inp)
		fmt.Println(rr.String())
	}
}
```

Which is accepted and yields the following output, instead of an error:
```
example.com.	3600	IN	MX	65535 mail.example.com.
example.com.	3600	IN	MX	0 mail.example.com.
```
