### PR TITLE
Only pack NSEC3/NSEC3PARAM salt when it is not empty

### DIFF
--- a/msg_generate.go
+++ b/msg_generate.go
@@ -142,7 +142,14 @@ return off, err
 			case strings.HasPrefix(st.Tag(i), `dns:"size-hex:SaltLength`):
 				// directly write instead of using o() so we get the error check in the correct place
 				field := st.Field(i).Name()
-				fmt.Fprintf(b, "// Only pack salt if value is not \"-\", i.e. empty\nif rr.%s != \"-\" {\noff, err = packStringHex(rr.%s, msg, off)\nif err != nil {\nreturn off, err\n}\n}\n", field, field)
+				fmt.Fprintf(b, `// Only pack salt if value is not "-", i.e. empty
+if rr.%s != "-" {
+  off, err = packStringHex(rr.%s, msg, off)
+  if err != nil {
+    return off, err
+  }
+}
+`, field, field)
 				continue
 			case strings.HasPrefix(st.Tag(i), `dns:"size-hex`): // size-hex can be packed just like hex
 				fallthrough

--- a/zmsg.go
+++ b/zmsg.go
@@ -801,10 +801,12 @@ func (rr *NSEC3) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	if rr.Salt == "-" { /* do nothing, empty salt */
-	}
-	if err != nil {
-		return off, err
+	// Only pack salt if value is not "-", i.e. empty
+	if rr.Salt != "-" {
+		off, err = packStringHex(rr.Salt, msg, off)
+		if err != nil {
+			return off, err
+		}
 	}
 	off, err = packUint8(rr.HashLength, msg, off)
 	if err != nil {
@@ -844,10 +846,12 @@ func (rr *NSEC3PARAM) pack(msg []byte, off int, compression map[string]int, comp
 	if err != nil {
 		return off, err
 	}
-	if rr.Salt == "-" { /* do nothing, empty salt */
-	}
-	if err != nil {
-		return off, err
+	// Only pack salt if value is not "-", i.e. empty
+	if rr.Salt != "-" {
+		off, err = packStringHex(rr.Salt, msg, off)
+		if err != nil {
+			return off, err
+		}
 	}
 	rr.Header().Rdlength = uint16(off - headerEnd)
 	return off, nil


### PR DESCRIPTION
Instead of just not doing it at all.

Fixes #473.