### PR TITLE
Cover NSEC3 Salt and allow mixed case in NSEC3 NextDomain

### DIFF
--- a/issue_test.go
+++ b/issue_test.go
@@ -2,7 +2,10 @@ package dns
 
 // Tests that solve that an specific issue.
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestTCPRtt(t *testing.T) {
 	m := new(Msg)
@@ -40,5 +43,26 @@ func TestNSEC3MissingSalt(t *testing.T) {
 	out := m.Answer[0].(*NSEC3).Salt
 	if in != out {
 		t.Fatalf("expected salts to match. packed: `%s`. returned: `%s`", in, out)
+	}
+}
+
+func TestNSEC3MixedNextDomain(t *testing.T) {
+	rr, err := NewRR("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 - k8udemvp1j2f7eg6jebps17vp3n8i58h")
+	if err != nil {
+		t.Fatalf("failed to parse example rr: %s", err)
+	}
+	m := new(Msg)
+	m.Answer = []RR{rr}
+	mb, err := m.Pack()
+	if err != nil {
+		t.Fatalf("expected to pack message. err: %s", err)
+	}
+	if err := m.Unpack(mb); err != nil {
+		t.Fatalf("expected to unpack message. err: %s", err)
+	}
+	in := strings.ToUpper(rr.(*NSEC3).NextDomain)
+	out := m.Answer[0].(*NSEC3).NextDomain
+	if in != out {
+		t.Fatalf("expected round trip to produce NextDomain `%s`, instead `%s`", in, out)
 	}
 }

--- a/issue_test.go
+++ b/issue_test.go
@@ -21,3 +21,24 @@ func TestTCPRtt(t *testing.T) {
 		}
 	}
 }
+
+func TestNSEC3MissingSalt(t *testing.T) {
+	rr, err := NewRR("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 aabbccdd K8UDEMVP1J2F7EG6JEBPS17VP3N8I58H")
+	if err != nil {
+		t.Fatalf("failed to parse example rr: %s", err)
+	}
+	m := new(Msg)
+	m.Answer = []RR{rr}
+	mb, err := m.Pack()
+	if err != nil {
+		t.Fatalf("expected to pack message. err: %s", err)
+	}
+	if err := m.Unpack(mb); err != nil {
+		t.Fatalf("expected to unpack message. missing salt? err: %s", err)
+	}
+	in := rr.(*NSEC3).Salt
+	out := m.Answer[0].(*NSEC3).Salt
+	if in != out {
+		t.Fatalf("expected salts to match. packed: `%s`. returned: `%s`", in, out)
+	}
+}

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -142,6 +142,11 @@ func truncateMsgFromRdlength(msg []byte, off int, rdlength uint16) (truncmsg []b
 }
 
 func fromBase32(s []byte) (buf []byte, err error) {
+	for i, b := range s {
+		if b >= 'a' && b <= 'z' {
+			s[i] = b - 32
+		}
+	}
 	buflen := base32.HexEncoding.DecodedLen(len(s))
 	buf = make([]byte, buflen)
 	n, err := base32.HexEncoding.Decode(buf, s)


### PR DESCRIPTION
I'm not going to fix padding anytime soon so I've rebased the commit I mentioned in #426. Padding should only come in to play if another NSEC3 hash algorithm is introduced so there's no rush to fix it.