### PR TITLE
NSEC/3 Cover+Match cleanup

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -1,5 +1,7 @@
 package dns
 
+import "strings"
+
 // Holds a bunch of helper functions for dealing with labels.
 
 // SplitDomainName splits a name string into it's labels.
@@ -50,6 +52,7 @@ func SplitDomainName(s string) (labels []string) {
 //
 // s1 and s2 must be syntactically valid domain names.
 func CompareDomainName(s1, s2 string) (n int) {
+	s1, s2 = strings.ToLower(s1), strings.ToLower(s2)
 	s1 = Fqdn(s1)
 	s2 = Fqdn(s2)
 	l1 := Split(s1)

--- a/labels_test.go
+++ b/labels_test.go
@@ -33,6 +33,9 @@ func TestCompareDomainName(t *testing.T) {
 	if CompareDomainName(".", ".") != 0 {
 		t.Errorf("%s with %s should be %d", ".", ".", 0)
 	}
+	if CompareDomainName("test.com.", "TEST.COM.") != 2 {
+		t.Errorf("test.com. and TEST.COM. should be an exact match")
+	}
 }
 
 func TestSplit(t *testing.T) {

--- a/nsecx.go
+++ b/nsecx.go
@@ -52,15 +52,16 @@ func HashName(label string, ha uint8, iter uint16, salt string) string {
 func (rr *NSEC3) Cover(name string) bool {
 	nameHash := HashName(name, rr.Hash, rr.Iterations, rr.Salt)
 	owner := strings.ToUpper(rr.Hdr.Name)
-	labels := Split(owner)
-	if len(labels) < 2 {
+	parts := strings.SplitN(owner, ".", 2)
+	if len(parts) < 2 {
 		return false
 	}
-	if !strings.HasSuffix(strings.ToUpper(name), owner[labels[1]:]) { // name is outside zone
+	ownerHash := parts[0]
+	ownerZone := parts[1]
+	if !IsSubDomain(ownerZone, strings.ToUpper(name)) { // name is outside owner zone
 		return false
 	}
 
-	ownerHash := strings.TrimRight(owner[labels[0]:labels[1]], ".")
 	nextHash := rr.NextDomain
 	if ownerHash == nextHash { // empty interval
 		return false
@@ -81,15 +82,15 @@ func (rr *NSEC3) Cover(name string) bool {
 func (rr *NSEC3) Match(name string) bool {
 	nameHash := HashName(name, rr.Hash, rr.Iterations, rr.Salt)
 	owner := strings.ToUpper(rr.Hdr.Name)
-	labels := Split(owner)
-	if len(labels) < 2 {
+	parts := strings.SplitN(owner, ".", 2)
+	if len(parts) < 2 {
 		return false
 	}
-	if !strings.HasSuffix(strings.ToUpper(name), owner[labels[1]:]) {
-		// name is outside zone
+	ownerHash := parts[0]
+	ownerZone := parts[1]
+	if !IsSubDomain(ownerZone, strings.ToUpper(name)) { // name is outside owner zone
 		return false
 	}
-	ownerHash := strings.TrimRight(owner[labels[0]:labels[1]], ".")
 	if ownerHash == nameHash {
 		return true
 	}

--- a/nsecx.go
+++ b/nsecx.go
@@ -52,12 +52,12 @@ func HashName(label string, ha uint8, iter uint16, salt string) string {
 func (rr *NSEC3) Cover(name string) bool {
 	nameHash := HashName(name, rr.Hash, rr.Iterations, rr.Salt)
 	owner := strings.ToUpper(rr.Hdr.Name)
-	parts := strings.SplitN(owner, ".", 2)
-	if len(parts) < 2 {
+	labelIndices := Split(owner)
+	if len(labelIndices) < 2 {
 		return false
 	}
-	ownerHash := parts[0]
-	ownerZone := parts[1]
+	ownerHash := owner[:labelIndices[1]-1]
+	ownerZone := owner[labelIndices[1]:]
 	if !IsSubDomain(ownerZone, strings.ToUpper(name)) { // name is outside owner zone
 		return false
 	}
@@ -82,12 +82,12 @@ func (rr *NSEC3) Cover(name string) bool {
 func (rr *NSEC3) Match(name string) bool {
 	nameHash := HashName(name, rr.Hash, rr.Iterations, rr.Salt)
 	owner := strings.ToUpper(rr.Hdr.Name)
-	parts := strings.SplitN(owner, ".", 2)
-	if len(parts) < 2 {
+	labelIndices := Split(owner)
+	if len(labelIndices) < 2 {
 		return false
 	}
-	ownerHash := parts[0]
-	ownerZone := parts[1]
+	ownerHash := owner[:labelIndices[1]-1]
+	ownerZone := owner[labelIndices[1]:]
 	if !IsSubDomain(ownerZone, strings.ToUpper(name)) { // name is outside owner zone
 		return false
 	}

--- a/nsecx.go
+++ b/nsecx.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"crypto/sha1"
-	"fmt"
 	"hash"
 	"strings"
 )
@@ -57,32 +56,24 @@ func (rr *NSEC3) Cover(name string) bool {
 	if len(labels) < 2 {
 		return false
 	}
-	if !strings.HasSuffix(strings.ToUpper(name), owner[labels[1]:]) {
-		// name is outside zone
-		fmt.Println("a")
+	if !strings.HasSuffix(strings.ToUpper(name), owner[labels[1]:]) { // name is outside zone
 		return false
 	}
 
 	ownerHash := strings.TrimRight(owner[labels[0]:labels[1]], ".")
 	nextHash := rr.NextDomain
-	fmt.Println("nameHash:", nameHash, "ownerHash:", ownerHash, "nextHash:", nextHash)
 	if ownerHash == nextHash { // empty interval
-		fmt.Println("b")
 		return false
 	}
 	if ownerHash > nextHash { // end of zone
 		if nameHash > ownerHash { // covered since there is nothing after ownerHash
-			fmt.Println("c")
 			return true
 		}
-		fmt.Println("d")
 		return nameHash < nextHash // if nameHash is before beginning of zone it is covered
 	}
 	if nameHash < ownerHash { // nameHash is before ownerHash, not covered
-		fmt.Println("e")
 		return false
 	}
-	fmt.Println("f")
 	return nameHash < nextHash // if nameHash is before nextHash is it covered (between ownerHash and nextHash)
 }
 

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -19,6 +19,9 @@ func TestNsec3(t *testing.T) {
 	if !nsec3.(*NSEC3).Match("nl.") { // name hash = sk4e8fj94u78smusb40o1n0oltbblu2r
 		t.Fatal("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
 	}
+	if !nsec3.(*NSEC3).Match("NL.") { // name hash = sk4e8fj94u78smusb40o1n0oltbblu2r
+		t.Fatal("sk4e8fj94u78smusb40o1n0oltbblu2r.NL. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
+	}
 	if nsec3.(*NSEC3).Match("com.") { //
 		t.Fatal("com. is not in the zone nl.")
 	}

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -18,7 +18,7 @@ func TestPackNsec3(t *testing.T) {
 }
 
 func TestNsec3(t *testing.T) {
-	nsec3, _ = NewRR("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
+	nsec3, _ := NewRR("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
 	if !nsec3.(*NSEC3).Match("nl.") { // sk4e8fj94u78smusb40o1n0oltbblu2r.nl.
 		t.Error("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
 	}

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -1,9 +1,6 @@
 package dns
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestPackNsec3(t *testing.T) {
 	nsec3 := HashName("dnsex.nl.", SHA1, 0, "DEAD")
@@ -19,8 +16,18 @@ func TestPackNsec3(t *testing.T) {
 
 func TestNsec3(t *testing.T) {
 	nsec3, _ := NewRR("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
-	if !nsec3.(*NSEC3).Match("nl.") { // sk4e8fj94u78smusb40o1n0oltbblu2r.nl.
-		t.Error("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
+	if !nsec3.(*NSEC3).Match("nl.") { // name hash = sk4e8fj94u78smusb40o1n0oltbblu2r
+		t.Fatal("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
+	}
+	if nsec3.(*NSEC3).Match("com.") { //
+		t.Fatal("com. is not in the zone nl.")
+	}
+	if nsec3.(*NSEC3).Match("test.nl.") { // name hash = gd0ptr5bnfpimpu2d3v6gd4n0bai7s0q
+		t.Fatal("gd0ptr5bnfpimpu2d3v6gd4n0bai7s0q.nl. should not match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
+	}
+	nsec3, _ = NewRR("nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
+	if nsec3.(*NSEC3).Match("nl.") {
+		t.Fatal("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should not match a record without a owner hash")
 	}
 
 	for _, tc := range []struct {
@@ -28,20 +35,20 @@ func TestNsec3(t *testing.T) {
 		name   string
 		covers bool
 	}{
-		// good
-		{
+		// positive tests
+		{ // name hash between owner hash and next hash
 			rr: &NSEC3{
-				Hdr:        RR_Header{Name: "39p91242oslggest5e6a7cci4iaeqvnk.nl."},
+				Hdr:        RR_Header{Name: "2N1TB3VAIRUOBL6RKDVII42N9TFMIALP.com."},
 				Hash:       1,
 				Flags:      1,
 				Iterations: 5,
 				Salt:       "F10E9F7EA83FC8F3",
-				NextDomain: "39P99DCGG0MDLARTCRMCF6OFLLUL7PR6",
+				NextDomain: "PT3RON8N7PM3A0OE989IB84OOSADP7O8",
 			},
-			name:   "snasajsksasasa.nl.",
+			name:   "bsd.com.",
 			covers: true,
 		},
-		{
+		{ // end of zone, name hash is after owner hash
 			rr: &NSEC3{
 				Hdr:        RR_Header{Name: "3v62ulr0nre83v0rja2vjgtlif9v6rab.com."},
 				Hash:       1,
@@ -53,8 +60,32 @@ func TestNsec3(t *testing.T) {
 			name:   "csd.com.",
 			covers: true,
 		},
-		// bad
-		{ // out of zone
+		{ // end of zone, name hash is before beginning of zone
+			rr: &NSEC3{
+				Hdr:        RR_Header{Name: "PT3RON8N7PM3A0OE989IB84OOSADP7O8.com."},
+				Hash:       1,
+				Flags:      1,
+				Iterations: 5,
+				Salt:       "F10E9F7EA83FC8F3",
+				NextDomain: "3V62ULR0NRE83V0RJA2VJGTLIF9V6RAB",
+			},
+			name:   "asd.com.",
+			covers: true,
+		},
+		// negative tests
+		{ // too short owner name
+			rr: &NSEC3{
+				Hdr:        RR_Header{Name: "nl."},
+				Hash:       1,
+				Flags:      1,
+				Iterations: 5,
+				Salt:       "F10E9F7EA83FC8F3",
+				NextDomain: "39P99DCGG0MDLARTCRMCF6OFLLUL7PR6",
+			},
+			name:   "asd.com.",
+			covers: false,
+		},
+		{ // outside of zone
 			rr: &NSEC3{
 				Hdr:        RR_Header{Name: "39p91242oslggest5e6a7cci4iaeqvnk.nl."},
 				Hash:       1,
@@ -78,12 +109,22 @@ func TestNsec3(t *testing.T) {
 			name:   "asd.com.",
 			covers: false,
 		},
+		{ // name hash is before owner hash, not covered
+			rr: &NSEC3{
+				Hdr:        RR_Header{Name: "3V62ULR0NRE83V0RJA2VJGTLIF9V6RAB.com."},
+				Hash:       1,
+				Flags:      1,
+				Iterations: 5,
+				Salt:       "F10E9F7EA83FC8F3",
+				NextDomain: "PT3RON8N7PM3A0OE989IB84OOSADP7O8",
+			},
+			name:   "asd.com.",
+			covers: false,
+		},
 	} {
-		fmt.Println("test")
 		covers := tc.rr.Cover(tc.name)
 		if tc.covers != covers {
 			t.Fatalf("Cover failed for %s: expected %t, got %t [record: %s]", tc.name, tc.covers, covers, tc.rr)
 		}
 	}
-	fmt.Println("bsd.com.", HashName("bsd.com.", 1, 5, "F10E9F7EA83FC8F3"))
 }


### PR DESCRIPTION
Removes NSEC `Cover` + `Match` functions and the denialer interface and cleans up the same NSEC3 methods to fix all the TODOs. This is a breaking change but given that the NSEC methods were already broken (i.e. only ever returned `false`) if anyone was using them seriously their software was already broken and they should stop. Also adds a table test for `Cover` which checks each of the possible outcomes and a few more tests for `Match`.

Fixes #313.