### PR TITLE
Fix large RSA exponent check

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -515,7 +515,7 @@ func (k *DNSKEY) publicKeyRSA() *rsa.PublicKey {
 	}
 	// Remainder
 	expo += uint64(keybuf[keyoff])
-	if expo > 2<<31 {
+	if expo > (2<<31)+1 {
 		// Larger expo than supported.
 		// println("dns: F5 primes (or larger) are not supported")
 		return nil


### PR DESCRIPTION
The large exponent check for RSA on DNSSEC is using `(2^32)` when it should use `(2^32)+1`.

This post was used as reference: https://www.imperialviolet.org/2012/03/17/rsados.html