### PR TITLE
Previous TTL not set

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1527,3 +1527,22 @@ func TestParseAVC(t *testing.T) {
 		}
 	}
 }
+
+func TestParseNoTtl(t *testing.T) {
+	zone := `$ORIGIN example.org.
+@ IN 3700 A 192.0.2.2
+@ IN A 192.0.2.2
+	`
+
+	to := ParseZone(strings.NewReader(zone), "", "test-parse-no-ttl")
+	ttl := uint32(0)
+	for x := range to {
+		if ttl == 0 {
+			ttl = x.RR.Header().Ttl
+			continue
+		}
+		if ttl != x.RR.Header().Ttl {
+			t.Errorf("TTL for %s should be %d, but got %d", x.RR.Header().Name, ttl, x.RR.Header().Ttl)
+		}
+	}
+}


### PR DESCRIPTION
When there is no TTL set in a RR (in a zonefile) we should default to
the one of the previous record.

Add test case.