### PR TITLE
parsing: error on unbalanced braces

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1527,3 +1527,14 @@ func TestParseAVC(t *testing.T) {
 		}
 	}
 }
+
+func TestUnbalancedParens(t *testing.T) {
+	sig := `example.com. 3600 IN RRSIG MX 15 2 3600 (
+              1440021600 1438207200 3613 example.com. (
+              oL9krJun7xfBOIWcGHi7mag5/hdZrKWw15jPGrHpjQeRAvTdszaPD+QLs3f
+              x8A4M3e23mRZ9VrbpMngwcrqNAg== )`
+	_, err := NewRR(sig)
+	if err == nil {
+		t.Fatalf("Failed to detect extra opening brace")
+	}
+}

--- a/scan.go
+++ b/scan.go
@@ -811,6 +811,12 @@ func zlexer(s *scan, c chan lex) {
 		debug.Printf("[%+v]", l.token)
 		c <- l
 	}
+	if brace != 0 {
+		l.token = "unbalanced brace"
+		l.tokenUpper = l.token
+		l.err = true
+		c <- l
+	}
 }
 
 // Extract the class number from CLASSxx


### PR DESCRIPTION
When done parsing, check if we have balanced braces, if not error out.

Fixes #488