### PR TITLE
xfr: return sane error when !RcodeSuccess

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -81,6 +82,10 @@ func (t *Transfer) inAxfr(id uint16, c chan *Envelope) {
 			return
 		}
 		if first {
+			if in.Rcode != RcodeSuccess {
+				c <- &Envelope{in.Answer, &Error{err: fmt.Sprintf(errXFR, in.Rcode)}}
+				return
+			}
 			if !isSOAFirst(in) {
 				c <- &Envelope{in.Answer, ErrSoa}
 				return
@@ -126,6 +131,10 @@ func (t *Transfer) inIxfr(id uint16, c chan *Envelope) {
 			return
 		}
 		if first {
+			if in.Rcode != RcodeSuccess {
+				c <- &Envelope{in.Answer, &Error{err: fmt.Sprintf(errXFR, in.Rcode)}}
+				return
+			}
 			// A single SOA RR signals "no changes"
 			if len(in.Answer) == 1 && isSOAFirst(in) {
 				c <- &Envelope{in.Answer, nil}
@@ -242,3 +251,5 @@ func isSOALast(in *Msg) bool {
 	}
 	return false
 }
+
+const errXFR = "bad xfr rcode: %d"

--- a/xfr_test.go
+++ b/xfr_test.go
@@ -4,6 +4,7 @@ package dns
 
 import (
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -16,8 +17,7 @@ func getIP(s string) string {
 	return a[0]
 }
 
-// flaky, need to setup local server and test from
-// that.
+// flaky, need to setup local server and test from that.
 func TestAXFR_Miek(t *testing.T) {
 	// This test runs against a server maintained by Miek
 	if testing.Short() {
@@ -156,6 +156,29 @@ func testAXFRSIDN(t *testing.T, host, alg string) {
 	for e := range c {
 		if e.Error != nil {
 			t.Fatal(e.Error)
+		}
+	}
+}
+
+func TestAXFRFailNotAuth(t *testing.T) {
+	// This tests run against a server maintained by SIDN labs, see:
+	// https://workbench.sidnlabs.nl/
+	if testing.Short() {
+		return
+	}
+	x := new(Transfer)
+
+	m := new(Msg)
+	m.SetAxfr("sidnlabs.nl.")
+	c, err := x.In(m, "yadifa.sidnlabs.nl:53")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for e := range c {
+		if e.Error != nil {
+			if !strings.HasPrefix(e.Error.Error(), "dns: bad xfr rcode:") {
+				t.Fatal(e.Error)
+			}
 		}
 	}
 }


### PR DESCRIPTION
When the server returns a non succesful rcode, return that to the caller
in stead of the "bad soa" of before. "dns: bad xfr rcode: <RCODE>" is
now returned.

Fixes #467