### PR TITLE
Only check last 2 records for EDNS

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -146,12 +146,15 @@ func (dns *Msg) IsTsig() *TSIG {
 // found or nil.
 func (dns *Msg) IsEdns0() *OPT {
 	// EDNS0 is at the end of the additional section, start there.
-	// We might want to change this to *only* look at the last two
-	// records. So we see TSIG and/or OPT - this a slightly bigger
-	// change though.
+	j := 0
 	for i := len(dns.Extra) - 1; i >= 0; i-- {
 		if dns.Extra[i].Header().Rrtype == TypeOPT {
 			return dns.Extra[i].(*OPT)
+		}
+		j++
+		if j > 1 {
+			// Nothing in last two records
+			return nil
 		}
 	}
 	return nil


### PR DESCRIPTION
Last records of additional section hold the OPT record. We need to check
2 because TSIG can be there as well.