### PR TITLE
Implemented custom dialling with local address and timeout

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -30,6 +30,16 @@ func HelloServerBadID(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
+func HelloServerEchoAddrPort(w ResponseWriter, req *Msg) {
+	m := new(Msg)
+	m.SetReply(req)
+
+	remoteAddr := w.RemoteAddr().String()
+	m.Extra = make([]RR, 1)
+	m.Extra[0] = &TXT{Hdr: RR_Header{Name: m.Question[0].Name, Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{remoteAddr}}
+	w.WriteMsg(m)
+}
+
 func AnotherHelloServer(w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)


### PR DESCRIPTION
Implemented custom dialling with local address and timeout as Client attributes.

This is a slightly different implementation of https://github.com/miekg/dns/pull/471 , and enables the user to set a custom local address. E.g.:

```
msg := &dns.Msg{/* something here */}
c := new(dns.Client)
c.LocalAddr = &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345, Zone: ""}
resp, ttl, err := client.Exchange(msg, "server.example.org:53")
```

See also the related tests for usage.