### PR TITLE
scan: Fix $INCLUDE arguments to parseZone

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -313,7 +313,7 @@ func parseZone(r io.Reader, origin, f string, t chan *Token, include int) {
 				t <- &Token{Error: &ParseError{f, "too deeply nested $INCLUDE", l}}
 				return
 			}
-			parseZone(r1, l.token, neworigin, t, include+1)
+			parseZone(r1, neworigin, l.token, t, include+1)
 			st = zExpectOwnerDir
 		case zExpectDirTtlBl:
 			if l.value != zBlank {

--- a/scan_test.go
+++ b/scan_test.go
@@ -21,12 +21,15 @@ func TestParseZoneInclude(t *testing.T) {
 		t.Fatalf("could not close tmpfile %q: %s", tmpfile.Name(), err)
 	}
 
-	zone := "$INCLUDE " + tmpfile.Name()
+	zone := "$ORIGIN example.org.\n$INCLUDE " + tmpfile.Name()
 
 	tok := ParseZone(strings.NewReader(zone), "", "")
 	for x := range tok {
 		if x.Error != nil {
 			t.Fatalf("expected no error, but got %s", x.Error)
+		}
+		if x.RR.Header().Name != "foo.example.org." {
+			t.Fatalf("expected %s, but got %s", "foo.example.org.", x.RR.Header().Name)
 		}
 	}
 


### PR DESCRIPTION
When an $INCLUDE was seen the arguments to parseZone where in the wrong
order meaning the filename was used as the `neworigin` instead of the
actual origin we need.

Extend the testcase to check for the full name of the record.