### PR TITLE
Correctly parse omitted TTLs and relative domains

### DIFF
--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -11,7 +11,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// AddDomain adds origin to s if s is not already a FQDN.
+// AddOrigin adds origin to s if s is not already a FQDN.
 // Note that the result may not be a FQDN.  If origin does not end
 // with a ".", the result won't either.
 // This implements the zonefile convention (specified in RFC 1035,

--- a/doc.go
+++ b/doc.go
@@ -22,9 +22,9 @@ Or directly from a string:
 
      mx, err := dns.NewRR("miek.nl. 3600 IN MX 10 mx.miek.nl.")
 
-Or when the default TTL (3600) and class (IN) suit you:
+Or when the default origin (.) and TTL (3600) and class (IN) suit you:
 
-     mx, err := dns.NewRR("miek.nl. MX 10 mx.miek.nl.")
+     mx, err := dns.NewRR("miek.nl MX 10 mx.miek.nl")
 
 Or even:
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -571,83 +571,6 @@ test                          IN CNAME test.a.example.com.
 	t.Logf("%d RRs parsed in %.2f s (%.2f RR/s)", i, float32(delta)/1e9, float32(i)/(float32(delta)/1e9))
 }
 
-func ExampleParseZone() {
-	zone := `$ORIGIN .
-$TTL 3600       ; 1 hour
-name                    IN SOA  a6.nstld.com. hostmaster.nic.name. (
-                                203362132  ; serial
-                                300        ; refresh (5 minutes)
-                                300        ; retry (5 minutes)
-                                1209600    ; expire (2 weeks)
-                                300        ; minimum (5 minutes)
-                                )
-$TTL 10800      ; 3 hours
-name.	10800	IN	NS	name.
-               IN       NS      g6.nstld.com.
-               7200     NS      h6.nstld.com.
-             3600 IN    NS      j6.nstld.com.
-             IN 3600    NS      k6.nstld.com.
-                        NS      l6.nstld.com.
-                        NS      a6.nstld.com.
-                        NS      c6.nstld.com.
-                        NS      d6.nstld.com.
-                        NS      f6.nstld.com.
-                        NS      m6.nstld.com.
-(
-			NS	m7.nstld.com.
-)
-$ORIGIN name.
-0-0onlus                NS      ns7.ehiweb.it.
-                        NS      ns8.ehiweb.it.
-0-g                     MX      10 mx01.nic
-                        MX      10 mx02.nic
-                        MX      10 mx03.nic
-                        MX      10 mx04.nic
-$ORIGIN 0-g.name
-moutamassey             NS      ns01.yahoodomains.jp.
-                        NS      ns02.yahoodomains.jp.
-`
-	to := ParseZone(strings.NewReader(zone), "", "testzone")
-	for x := range to {
-		fmt.Println(x.RR)
-	}
-	// Output:
-	// name.	3600	IN	SOA	a6.nstld.com. hostmaster.nic.name. 203362132 300 300 1209600 300
-	// name.	10800	IN	NS	name.
-	// name.	10800	IN	NS	g6.nstld.com.
-	// name.	7200	IN	NS	h6.nstld.com.
-	// name.	3600	IN	NS	j6.nstld.com.
-	// name.	3600	IN	NS	k6.nstld.com.
-	// name.	10800	IN	NS	l6.nstld.com.
-	// name.	10800	IN	NS	a6.nstld.com.
-	// name.	10800	IN	NS	c6.nstld.com.
-	// name.	10800	IN	NS	d6.nstld.com.
-	// name.	10800	IN	NS	f6.nstld.com.
-	// name.	10800	IN	NS	m6.nstld.com.
-	// name.	10800	IN	NS	m7.nstld.com.
-	// 0-0onlus.name.	10800	IN	NS	ns7.ehiweb.it.
-	// 0-0onlus.name.	10800	IN	NS	ns8.ehiweb.it.
-	// 0-g.name.	10800	IN	MX	10 mx01.nic.name.
-	// 0-g.name.	10800	IN	MX	10 mx02.nic.name.
-	// 0-g.name.	10800	IN	MX	10 mx03.nic.name.
-	// 0-g.name.	10800	IN	MX	10 mx04.nic.name.
-	// moutamassey.0-g.name.name.	10800	IN	NS	ns01.yahoodomains.jp.
-	// moutamassey.0-g.name.name.	10800	IN	NS	ns02.yahoodomains.jp.
-}
-
-func ExampleHIP() {
-	h := `www.example.com     IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
-                AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p
-9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQ
-b1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D
-        rvs.example.com. )`
-	if hip, err := NewRR(h); err == nil {
-		fmt.Println(hip.String())
-	}
-	// Output:
-	// www.example.com.	3600	IN	HIP	2 200100107B1A74DF365639CC39F1D578 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p9+LrV4e19WzK00+CI6zBCQTdtWsuxKbWIy87UOoJTwkUs7lBu+Upr1gsNrut79ryra+bSRGQb1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D rvs.example.com.
-}
-
 func TestHIP(t *testing.T) {
 	h := `www.example.com.      IN  HIP ( 2 200100107B1A74DF365639CC39F1D578
                                 AwEAAbdxyhNuSutc5EMzxTs9LBPCIkOFH8cIvM4p
@@ -682,24 +605,6 @@ b1slImA8YVJyuIDsj7kwzG7jnERNqnWxZ48AWkskmdHaVDP4BcelrTI3rMXdXF5D
 			if rr.RendezvousServers[j] != s {
 				t.Fatalf("expected server %d of record %d to be %s:\n%v", j, i, s, msg)
 			}
-		}
-	}
-}
-
-func ExampleSOA() {
-	s := "example.com. 1000 SOA master.example.com. admin.example.com. 1 4294967294 4294967293 4294967295 100"
-	if soa, err := NewRR(s); err == nil {
-		fmt.Println(soa.String())
-	}
-	// Output:
-	// example.com.	1000	IN	SOA	master.example.com. admin.example.com. 1 4294967294 4294967293 4294967295 100
-}
-
-func TestLineNumberError(t *testing.T) {
-	s := "example.com. 1000 SOA master.example.com. admin.example.com. monkey 4294967294 4294967293 4294967295 100"
-	if _, err := NewRR(s); err != nil {
-		if err.Error() != "dns: bad SOA zone parameter: \"monkey\" at line: 1:68" {
-			t.Error("not expecting this error: ", err)
 		}
 	}
 }
@@ -799,28 +704,6 @@ func TestLowercaseTokens(t *testing.T) {
 			t.Errorf("failed to parse %#v, got %v", testrr, err)
 		}
 	}
-}
-
-func ExampleParseZone_generate() {
-	// From the manual: http://www.bind9.net/manual/bind/9.3.2/Bv9ARM.ch06.html#id2566761
-	zone := "$GENERATE 1-2 0 NS SERVER$.EXAMPLE.\n$GENERATE 1-8 $ CNAME $.0"
-	to := ParseZone(strings.NewReader(zone), "0.0.192.IN-ADDR.ARPA.", "")
-	for x := range to {
-		if x.Error == nil {
-			fmt.Println(x.RR.String())
-		}
-	}
-	// Output:
-	// 0.0.0.192.IN-ADDR.ARPA.	3600	IN	NS	SERVER1.EXAMPLE.
-	// 0.0.0.192.IN-ADDR.ARPA.	3600	IN	NS	SERVER2.EXAMPLE.
-	// 1.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	1.0.0.0.192.IN-ADDR.ARPA.
-	// 2.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	2.0.0.0.192.IN-ADDR.ARPA.
-	// 3.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	3.0.0.0.192.IN-ADDR.ARPA.
-	// 4.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	4.0.0.0.192.IN-ADDR.ARPA.
-	// 5.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	5.0.0.0.192.IN-ADDR.ARPA.
-	// 6.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	6.0.0.0.192.IN-ADDR.ARPA.
-	// 7.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	7.0.0.0.192.IN-ADDR.ARPA.
-	// 8.0.0.192.IN-ADDR.ARPA.	3600	IN	CNAME	8.0.0.0.192.IN-ADDR.ARPA.
 }
 
 func TestSRVPacking(t *testing.T) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -617,7 +617,7 @@ func TestRelativeNameErrors(t *testing.T) {
 		{
 			"relative owner name without origin",
 			"example.com 3600 IN SOA ns.example.com. hostmaster.example.com. 1 86400 60 86400 3600",
-			"relative domain name without origin",
+			"bad owner name",
 		},
 		{
 			"relative owner name in RDATA",
@@ -627,17 +627,17 @@ func TestRelativeNameErrors(t *testing.T) {
 		{
 			"origin reference without origin",
 			"@ 3600 IN SOA ns.example.com. hostmaster.example.com. 1 86400 60 86400 3600",
-			"origin reference without origin",
+			"bad owner name",
 		},
 		{
 			"relative owner name in $INCLUDE",
 			"$INCLUDE file.db example.com",
-			"relative domain name without origin",
+			"bad origin name",
 		},
 		{
 			"relative owner name in $ORIGIN",
 			"$ORIGIN example.com",
-			"relative domain name without origin",
+			"bad origin name",
 		},
 	}
 	for _, errorCase := range badZones {

--- a/parse_test.go
+++ b/parse_test.go
@@ -578,14 +578,15 @@ $ORIGIN example.com.
 example.com. 42 IN SOA ns1.example.com. hostmaster.example.com. 1 86400 60 86400 3600 ; TTL=42 SOA
 example.com.        NS 2 ; TTL=42 absolute owner name
 @                   MD 3 ; TTL=42 current-origin owner name
-	                MF 4 ; TTL=42 leading-space implied owner name
-	MB 5 ; TTL=42 leading-tab implied owner name
+                    MF 4 ; TTL=42 leading-space implied owner name
+	43 TYPE65280 \# 1 05 ; TTL=43 implied owner name explicit TTL
+	          MB 6       ; TTL=43 leading-tab implied owner name
 $TTL 1337
-example.com. 88 MG 6 ; TTL=88 explicit TTL
-example.com.    MR 7 ; TTL=1337 after first $TTL
+example.com. 88 MG 7 ; TTL=88 explicit TTL
+example.com.    MR 8 ; TTL=1337 after first $TTL
 $TTL 314
-example.com. 0 TXT 8 ; TTL=0 explicit TTL
-example.com.   DNAME 9 ; TTL=314 after second $TTL
+             1 TXT 9 ; TTL=1 implied owner name explicit TTL
+example.com.   DNAME 10 ; TTL=314 after second $TTL
 `
 	reCaseFromComment := regexp.MustCompile(`TTL=(\d+)\s+(.*)`)
 	records := ParseZone(strings.NewReader(zone), "", "")
@@ -603,7 +604,7 @@ example.com.   DNAME 9 ; TTL=314 after second $TTL
 			t.Errorf("%s: expected TTL %d, got %d", expected[2], expectedTTL, ttl)
 		}
 	}
-	if i != 9 {
+	if i != 10 {
 		t.Errorf("expected %d records, got %d", 5, i)
 	}
 }

--- a/privaterr_test.go
+++ b/privaterr_test.go
@@ -143,7 +143,7 @@ func (rd *VERSION) Len() int {
 }
 
 var smallzone = `$ORIGIN example.org.
-@ SOA	sns.dns.icann.org. noc.dns.icann.org. (
+@ 3600 IN SOA	sns.dns.icann.org. noc.dns.icann.org. (
 		2014091518 7200 3600 1209600 3600
 )
     A   1.2.3.4

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -167,8 +167,8 @@ func setNS(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad NS Ns", l}, ""
 	}
 	rr.Ns = name
@@ -185,8 +185,8 @@ func setPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad PTR Ptr", l}, ""
 	}
 	rr.Ptr = name
@@ -203,8 +203,8 @@ func setNSAPPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) 
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad NSAP-PTR Ptr", l}, ""
 	}
 	rr.Ptr = name
@@ -221,8 +221,8 @@ func setRP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	mbox, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	mbox, mboxOk := toAbsoluteName(l.token, o)
+	if l.err || !mboxOk {
 		return nil, &ParseError{f, "bad RP Mbox", l}, ""
 	}
 	rr.Mbox = mbox
@@ -231,8 +231,8 @@ func setRP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c
 	rr.Txt = l.token
 
-	txt, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	txt, txtOk := toAbsoluteName(l.token, o)
+	if l.err || !txtOk {
 		return nil, &ParseError{f, "bad RP Txt", l}, ""
 	}
 	rr.Txt = txt
@@ -250,8 +250,8 @@ func setMR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad MR Mr", l}, ""
 	}
 	rr.Mr = name
@@ -268,8 +268,8 @@ func setMB(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad MB Mb", l}, ""
 	}
 	rr.Mb = name
@@ -286,8 +286,8 @@ func setMG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad MG Mg", l}, ""
 	}
 	rr.Mg = name
@@ -330,8 +330,8 @@ func setMINFO(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	rmail, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	rmail, rmailOk := toAbsoluteName(l.token, o)
+	if l.err || !rmailOk {
 		return nil, &ParseError{f, "bad MINFO Rmail", l}, ""
 	}
 	rr.Rmail = rmail
@@ -340,8 +340,8 @@ func setMINFO(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c
 	rr.Email = l.token
 
-	email, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	email, emailOk := toAbsoluteName(l.token, o)
+	if l.err || !emailOk {
 		return nil, &ParseError{f, "bad MINFO Email", l}, ""
 	}
 	rr.Email = email
@@ -359,8 +359,8 @@ func setMF(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad MF Mf", l}, ""
 	}
 	rr.Mf = name
@@ -377,8 +377,8 @@ func setMD(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad MD Md", l}, ""
 	}
 	rr.Md = name
@@ -404,8 +404,8 @@ func setMX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	rr.Mx = l.token
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad MX Mx", l}, ""
 	}
 	rr.Mx = name
@@ -432,8 +432,8 @@ func setRT(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	rr.Host = l.token
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad RT Host", l}, ""
 	}
 	rr.Host = name
@@ -460,8 +460,8 @@ func setAFSDB(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	rr.Hostname = l.token
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad AFSDB Hostname", l}, ""
 	}
 	rr.Hostname = name
@@ -503,8 +503,8 @@ func setKX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	rr.Exchanger = l.token
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad KX Exchanger", l}, ""
 	}
 	rr.Exchanger = name
@@ -521,8 +521,8 @@ func setCNAME(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad CNAME Target", l}, ""
 	}
 	rr.Target = name
@@ -539,8 +539,8 @@ func setDNAME(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad DNAME Target", l}, ""
 	}
 	rr.Target = name
@@ -557,8 +557,8 @@ func setSOA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	ns, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	ns, nsOk := toAbsoluteName(l.token, o)
+	if l.err || !nsOk {
 		return nil, &ParseError{f, "bad SOA Ns", l}, ""
 	}
 	rr.Ns = ns
@@ -567,8 +567,8 @@ func setSOA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c
 	rr.Mbox = l.token
 
-	mbox, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	mbox, mboxOk := toAbsoluteName(l.token, o)
+	if l.err || !mboxOk {
 		return nil, &ParseError{f, "bad SOA Mbox", l}, ""
 	}
 	rr.Mbox = mbox
@@ -652,8 +652,8 @@ func setSRV(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	rr.Target = l.token
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad SRV Target", l}, ""
 	}
 	rr.Target = name
@@ -745,8 +745,8 @@ func setNAPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c // zString
 	rr.Replacement = l.token
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad NAPTR Replacement", l}, ""
 	}
 	rr.Replacement = name
@@ -763,8 +763,8 @@ func setTALINK(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, ""
 	}
 
-	previousName, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	previousName, previousNameOk := toAbsoluteName(l.token, o)
+	if l.err || !previousNameOk {
 		return nil, &ParseError{f, "bad TALINK PreviousName", l}, ""
 	}
 	rr.PreviousName = previousName
@@ -773,8 +773,8 @@ func setTALINK(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	l = <-c
 	rr.NextName = l.token
 
-	nextName, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	nextName, nextNameOk := toAbsoluteName(l.token, o)
+	if l.err || !nextNameOk {
 		return nil, &ParseError{f, "bad TALINK NextName", l}, ""
 	}
 	rr.NextName = nextName
@@ -956,8 +956,8 @@ func setHIP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	for l.value != zNewline && l.value != zEOF {
 		switch l.value {
 		case zString:
-			name, err := nameToAbsolute(l.token, o)
-			if l.err || err != "" {
+			name, nameOk := toAbsoluteName(l.token, o)
+			if l.err || !nameOk {
 				return nil, &ParseError{f, "bad HIP RendezvousServers", l}, ""
 			}
 			xs = append(xs, name)
@@ -1116,8 +1116,8 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	<-c // zBlank
 	l = <-c
 	rr.SignerName = l.token
-	name, errStr := nameToAbsolute(l.token, o)
-	if l.err || errStr != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad RRSIG SignerName", l}, ""
 	}
 	rr.SignerName = name
@@ -1141,8 +1141,8 @@ func setNSEC(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return rr, nil, l.comment
 	}
 
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad NSEC NextDomain", l}, ""
 	}
 	rr.NextDomain = name
@@ -1882,8 +1882,8 @@ func setLP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Fqdn = l.token
-	name, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	name, nameOk := toAbsoluteName(l.token, o)
+	if l.err || !nameOk {
 		return nil, &ParseError{f, "bad LP Fqdn", l}, ""
 	}
 	rr.Fqdn = name
@@ -1982,8 +1982,8 @@ func setPX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Map822 = l.token
-	map822, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	map822, map822Ok := toAbsoluteName(l.token, o)
+	if l.err || !map822Ok {
 		return nil, &ParseError{f, "bad PX Map822", l}, ""
 	}
 	rr.Map822 = map822
@@ -1991,8 +1991,8 @@ func setPX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Mapx400 = l.token
-	mapx400, err := nameToAbsolute(l.token, o)
-	if l.err || err != "" {
+	mapx400, mapx400Ok := toAbsoluteName(l.token, o)
+	if l.err || !mapx400Ok {
 		return nil, &ParseError{f, "bad PX Mapx400", l}, ""
 	}
 	rr.Mapx400 = mapx400

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -130,9 +130,10 @@ func setA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 { // Dynamic updates.
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	rr.A = net.ParseIP(l.token)
 	if rr.A == nil || l.err {
 		return nil, &ParseError{f, "bad A A", l}, ""
@@ -145,9 +146,10 @@ func setAAAA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	rr.AAAA = net.ParseIP(l.token)
 	if rr.AAAA == nil || l.err {
 		return nil, &ParseError{f, "bad AAAA AAAA", l}, ""
@@ -161,20 +163,15 @@ func setNS(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Ns = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Ns = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad NS Ns", l}, ""
 	}
-	if rr.Ns[l.length-1] != '.' {
-		rr.Ns = appendOrigin(rr.Ns, o)
-	}
+	rr.Ns = name
 	return rr, nil, ""
 }
 
@@ -187,17 +184,12 @@ func setPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Ptr = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad PTR Ptr", l}, ""
 	}
-	if rr.Ptr[l.length-1] != '.' {
-		rr.Ptr = appendOrigin(rr.Ptr, o)
-	}
+	rr.Ptr = name
 	return rr, nil, ""
 }
 
@@ -207,20 +199,15 @@ func setNSAPPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) 
 
 	l := <-c
 	rr.Ptr = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Ptr = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad NSAP-PTR Ptr", l}, ""
 	}
-	if rr.Ptr[l.length-1] != '.' {
-		rr.Ptr = appendOrigin(rr.Ptr, o)
-	}
+	rr.Ptr = name
 	return rr, nil, ""
 }
 
@@ -230,34 +217,26 @@ func setRP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Mbox = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Mbox = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad RP Mbox", l}, ""
-		}
-		if rr.Mbox[l.length-1] != '.' {
-			rr.Mbox = appendOrigin(rr.Mbox, o)
-		}
+
+	mbox, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad RP Mbox", l}, ""
 	}
+	rr.Mbox = mbox
+
 	<-c // zBlank
 	l = <-c
 	rr.Txt = l.token
-	if l.token == "@" {
-		rr.Txt = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	txt, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad RP Txt", l}, ""
 	}
-	if rr.Txt[l.length-1] != '.' {
-		rr.Txt = appendOrigin(rr.Txt, o)
-	}
+	rr.Txt = txt
+
 	return rr, nil, ""
 }
 
@@ -267,20 +246,15 @@ func setMR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Mr = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Mr = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MR Mr", l}, ""
 	}
-	if rr.Mr[l.length-1] != '.' {
-		rr.Mr = appendOrigin(rr.Mr, o)
-	}
+	rr.Mr = name
 	return rr, nil, ""
 }
 
@@ -290,20 +264,15 @@ func setMB(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Mb = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Mb = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MB Mb", l}, ""
 	}
-	if rr.Mb[l.length-1] != '.' {
-		rr.Mb = appendOrigin(rr.Mb, o)
-	}
+	rr.Mb = name
 	return rr, nil, ""
 }
 
@@ -313,20 +282,15 @@ func setMG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Mg = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Mg = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MG Mg", l}, ""
 	}
-	if rr.Mg[l.length-1] != '.' {
-		rr.Mg = appendOrigin(rr.Mg, o)
-	}
+	rr.Mg = name
 	return rr, nil, ""
 }
 
@@ -362,34 +326,26 @@ func setMINFO(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Rmail = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Rmail = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad MINFO Rmail", l}, ""
-		}
-		if rr.Rmail[l.length-1] != '.' {
-			rr.Rmail = appendOrigin(rr.Rmail, o)
-		}
+
+	rmail, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad MINFO Rmail", l}, ""
 	}
+	rr.Rmail = rmail
+
 	<-c // zBlank
 	l = <-c
 	rr.Email = l.token
-	if l.token == "@" {
-		rr.Email = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	email, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MINFO Email", l}, ""
 	}
-	if rr.Email[l.length-1] != '.' {
-		rr.Email = appendOrigin(rr.Email, o)
-	}
+	rr.Email = email
+
 	return rr, nil, ""
 }
 
@@ -399,20 +355,15 @@ func setMF(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Mf = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Mf = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MF Mf", l}, ""
 	}
-	if rr.Mf[l.length-1] != '.' {
-		rr.Mf = appendOrigin(rr.Mf, o)
-	}
+	rr.Mf = name
 	return rr, nil, ""
 }
 
@@ -422,20 +373,15 @@ func setMD(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Md = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Md = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MD Md", l}, ""
 	}
-	if rr.Md[l.length-1] != '.' {
-		rr.Md = appendOrigin(rr.Md, o)
-	}
+	rr.Md = name
 	return rr, nil, ""
 }
 
@@ -444,57 +390,54 @@ func setMX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad MX Pref", l}, ""
 	}
 	rr.Preference = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Mx = l.token
-	if l.token == "@" {
-		rr.Mx = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad MX Mx", l}, ""
 	}
-	if rr.Mx[l.length-1] != '.' {
-		rr.Mx = appendOrigin(rr.Mx, o)
-	}
+	rr.Mx = name
+
 	return rr, nil, ""
 }
 
 func setRT(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(RT)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil {
 		return nil, &ParseError{f, "bad RT Preference", l}, ""
 	}
 	rr.Preference = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Host = l.token
-	if l.token == "@" {
-		rr.Host = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad RT Host", l}, ""
 	}
-	if rr.Host[l.length-1] != '.' {
-		rr.Host = appendOrigin(rr.Host, o)
-	}
+	rr.Host = name
+
 	return rr, nil, ""
 }
 
@@ -503,28 +446,25 @@ func setAFSDB(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad AFSDB Subtype", l}, ""
 	}
 	rr.Subtype = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Hostname = l.token
-	if l.token == "@" {
-		rr.Hostname = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad AFSDB Hostname", l}, ""
 	}
-	if rr.Hostname[l.length-1] != '.' {
-		rr.Hostname = appendOrigin(rr.Hostname, o)
-	}
+	rr.Hostname = name
 	return rr, nil, ""
 }
 
@@ -533,9 +473,10 @@ func setX25(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	if l.err {
 		return nil, &ParseError{f, "bad X25 PSDNAddress", l}, ""
 	}
@@ -548,28 +489,25 @@ func setKX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad KX Pref", l}, ""
 	}
 	rr.Preference = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Exchanger = l.token
-	if l.token == "@" {
-		rr.Exchanger = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad KX Exchanger", l}, ""
 	}
-	if rr.Exchanger[l.length-1] != '.' {
-		rr.Exchanger = appendOrigin(rr.Exchanger, o)
-	}
+	rr.Exchanger = name
 	return rr, nil, ""
 }
 
@@ -579,20 +517,15 @@ func setCNAME(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Target = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Target = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad CNAME Target", l}, ""
 	}
-	if rr.Target[l.length-1] != '.' {
-		rr.Target = appendOrigin(rr.Target, o)
-	}
+	rr.Target = name
 	return rr, nil, ""
 }
 
@@ -602,20 +535,15 @@ func setDNAME(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Target = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.Target = o
-		return rr, nil, ""
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad DNAME Target", l}, ""
 	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
-		return nil, &ParseError{f, "bad CNAME Target", l}, ""
-	}
-	if rr.Target[l.length-1] != '.' {
-		rr.Target = appendOrigin(rr.Target, o)
-	}
+	rr.Target = name
 	return rr, nil, ""
 }
 
@@ -625,35 +553,26 @@ func setSOA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.Ns = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	<-c // zBlank
-	if l.token == "@" {
-		rr.Ns = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad SOA Ns", l}, ""
-		}
-		if rr.Ns[l.length-1] != '.' {
-			rr.Ns = appendOrigin(rr.Ns, o)
-		}
-	}
 
+	ns, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad SOA Ns", l}, ""
+	}
+	rr.Ns = ns
+
+	<-c // zBlank
 	l = <-c
 	rr.Mbox = l.token
-	if l.token == "@" {
-		rr.Mbox = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad SOA Mbox", l}, ""
-		}
-		if rr.Mbox[l.length-1] != '.' {
-			rr.Mbox = appendOrigin(rr.Mbox, o)
-		}
+
+	mbox, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad SOA Mbox", l}, ""
 	}
+	rr.Mbox = mbox
+
 	<-c // zBlank
 
 	var (
@@ -667,9 +586,10 @@ func setSOA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		}
 		if j, e := strconv.ParseUint(l.token, 10, 32); e != nil {
 			if i == 0 {
-				// Serial should be a number
+				// Serial must be a number
 				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
 			}
+			// We allow other fields to be unitful duration strings
 			if v, ok = stringToTtl(l.token); !ok {
 				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
 
@@ -702,14 +622,16 @@ func setSRV(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SRV Priority", l}, ""
 	}
 	rr.Priority = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	i, e = strconv.ParseUint(l.token, 10, 16)
@@ -717,6 +639,7 @@ func setSRV(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad SRV Weight", l}, ""
 	}
 	rr.Weight = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	i, e = strconv.ParseUint(l.token, 10, 16)
@@ -724,20 +647,16 @@ func setSRV(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad SRV Port", l}, ""
 	}
 	rr.Port = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Target = l.token
-	if l.token == "@" {
-		rr.Target = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad SRV Target", l}, ""
 	}
-	if rr.Target[l.length-1] != '.' {
-		rr.Target = appendOrigin(rr.Target, o)
-	}
+	rr.Target = name
 	return rr, nil, ""
 }
 
@@ -746,14 +665,16 @@ func setNAPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NAPTR Order", l}, ""
 	}
 	rr.Order = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	i, e = strconv.ParseUint(l.token, 10, 16)
@@ -761,6 +682,7 @@ func setNAPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad NAPTR Preference", l}, ""
 	}
 	rr.Preference = uint16(i)
+
 	// Flags
 	<-c     // zBlank
 	l = <-c // _QUOTE
@@ -817,21 +739,17 @@ func setNAPTR(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	} else {
 		return nil, &ParseError{f, "bad NAPTR Regexp", l}, ""
 	}
+
 	// After quote no space??
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Replacement = l.token
-	if l.token == "@" {
-		rr.Replacement = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad NAPTR Replacement", l}, ""
 	}
-	if rr.Replacement[l.length-1] != '.' {
-		rr.Replacement = appendOrigin(rr.Replacement, o)
-	}
+	rr.Replacement = name
 	return rr, nil, ""
 }
 
@@ -841,34 +759,26 @@ func setTALINK(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.PreviousName = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
-	if l.token == "@" {
-		rr.PreviousName = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad TALINK PreviousName", l}, ""
-		}
-		if rr.PreviousName[l.length-1] != '.' {
-			rr.PreviousName = appendOrigin(rr.PreviousName, o)
-		}
+
+	previousName, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad TALINK PreviousName", l}, ""
 	}
+	rr.PreviousName = previousName
+
 	<-c // zBlank
 	l = <-c
 	rr.NextName = l.token
-	if l.token == "@" {
-		rr.NextName = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+
+	nextName, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad TALINK NextName", l}, ""
 	}
-	if rr.NextName[l.length-1] != '.' {
-		rr.NextName = appendOrigin(rr.NextName, o)
-	}
+	rr.NextName = nextName
+
 	return rr, nil, ""
 }
 
@@ -880,9 +790,10 @@ func setLOC(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.VertPre = 162  // 10
 	rr.Size = 18      // 1
 	ok := false
+
 	// North
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
 	i, e := strconv.ParseUint(l.token, 10, 32)
@@ -1013,14 +924,16 @@ func setHIP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	// HitLength is not represented
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad HIP PublicKeyAlgorithm", l}, ""
 	}
 	rr.PublicKeyAlgorithm = uint8(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	if l.length == 0 || l.err {
@@ -1043,19 +956,11 @@ func setHIP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	for l.value != zNewline && l.value != zEOF {
 		switch l.value {
 		case zString:
-			if l.token == "@" {
-				xs = append(xs, o)
-				l = <-c
-				continue
-			}
-			_, ok := IsDomainName(l.token)
-			if !ok || l.length == 0 || l.err {
+			name, err := nameToAbsolute(l.token, o)
+			if l.err || err != "" {
 				return nil, &ParseError{f, "bad HIP RendezvousServers", l}, ""
 			}
-			if l.token[l.length-1] != '.' {
-				l.token = appendOrigin(l.token, o)
-			}
-			xs = append(xs, l.token)
+			xs = append(xs, name)
 		case zBlank:
 			// Ok
 		default:
@@ -1072,9 +977,10 @@ func setCERT(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	if v, ok := StringToCertType[l.token]; ok {
 		rr.Type = v
 	} else if i, e := strconv.ParseUint(l.token, 10, 16); e != nil {
@@ -1129,10 +1035,12 @@ func setSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(RRSIG)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	if t, ok := StringToType[l.tokenUpper]; !ok {
 		if strings.HasPrefix(l.tokenUpper, "TYPE") {
 			t, ok = typeToInt(l.tokenUpper)
@@ -1146,6 +1054,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	} else {
 		rr.TypeCovered = t
 	}
+
 	<-c // zBlank
 	l = <-c
 	i, err := strconv.ParseUint(l.token, 10, 8)
@@ -1153,6 +1062,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad RRSIG Algorithm", l}, ""
 	}
 	rr.Algorithm = uint8(i)
+
 	<-c // zBlank
 	l = <-c
 	i, err = strconv.ParseUint(l.token, 10, 8)
@@ -1160,6 +1070,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad RRSIG Labels", l}, ""
 	}
 	rr.Labels = uint8(i)
+
 	<-c // zBlank
 	l = <-c
 	i, err = strconv.ParseUint(l.token, 10, 32)
@@ -1167,6 +1078,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad RRSIG OrigTtl", l}, ""
 	}
 	rr.OrigTtl = uint32(i)
+
 	<-c // zBlank
 	l = <-c
 	if i, err := StringToTime(l.token); err != nil {
@@ -1180,6 +1092,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	} else {
 		rr.Expiration = i
 	}
+
 	<-c // zBlank
 	l = <-c
 	if i, err := StringToTime(l.token); err != nil {
@@ -1191,6 +1104,7 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	} else {
 		rr.Inception = i
 	}
+
 	<-c // zBlank
 	l = <-c
 	i, err = strconv.ParseUint(l.token, 10, 16)
@@ -1198,25 +1112,22 @@ func setRRSIG(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 		return nil, &ParseError{f, "bad RRSIG KeyTag", l}, ""
 	}
 	rr.KeyTag = uint16(i)
+
 	<-c // zBlank
 	l = <-c
 	rr.SignerName = l.token
-	if l.token == "@" {
-		rr.SignerName = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad RRSIG SignerName", l}, ""
-		}
-		if rr.SignerName[l.length-1] != '.' {
-			rr.SignerName = appendOrigin(rr.SignerName, o)
-		}
+	name, errStr := nameToAbsolute(l.token, o)
+	if l.err || errStr != "" {
+		return nil, &ParseError{f, "bad RRSIG SignerName", l}, ""
 	}
+	rr.SignerName = name
+
 	s, e, c1 := endingToString(c, "bad RRSIG Signature", f)
 	if e != nil {
 		return nil, e, c1
 	}
 	rr.Signature = s
+
 	return rr, nil, c1
 }
 
@@ -1226,20 +1137,15 @@ func setNSEC(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 
 	l := <-c
 	rr.NextDomain = l.token
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
-	if l.token == "@" {
-		rr.NextDomain = o
-	} else {
-		_, ok := IsDomainName(l.token)
-		if !ok || l.length == 0 || l.err {
-			return nil, &ParseError{f, "bad NSEC NextDomain", l}, ""
-		}
-		if rr.NextDomain[l.length-1] != '.' {
-			rr.NextDomain = appendOrigin(rr.NextDomain, o)
-		}
+
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
+		return nil, &ParseError{f, "bad NSEC NextDomain", l}, ""
 	}
+	rr.NextDomain = name
 
 	rr.TypeBitMap = make([]uint16, 0)
 	var (
@@ -1271,9 +1177,10 @@ func setNSEC3(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3 Hash", l}, ""
@@ -1339,9 +1246,10 @@ func setNSEC3PARAM(h RR_Header, c chan lex, o, f string) (RR, *ParseError, strin
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3PARAM Hash", l}, ""
@@ -1373,9 +1281,10 @@ func setEUI48(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	if l.length != 17 || l.err {
 		return nil, &ParseError{f, "bad EUI48 Address", l}, ""
 	}
@@ -1405,9 +1314,10 @@ func setEUI64(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	if l.length != 23 || l.err {
 		return nil, &ParseError{f, "bad EUI64 Address", l}, ""
 	}
@@ -1437,9 +1347,10 @@ func setSSHFP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SSHFP Algorithm", l}, ""
@@ -1466,9 +1377,10 @@ func setDNSKEYs(h RR_Header, c chan lex, o, f, typ string) (RR, *ParseError, str
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " Flags", l}, ""
@@ -1522,9 +1434,10 @@ func setRKEY(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad RKEY Flags", l}, ""
@@ -1577,10 +1490,12 @@ func setNIMLOC(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setGPOS(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(GPOS)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	_, e := strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad GPOS Longitude", l}, ""
@@ -1606,10 +1521,12 @@ func setGPOS(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setDSs(h RR_Header, c chan lex, o, f, typ string) (RR, *ParseError, string) {
 	rr := new(DS)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " KeyTag", l}, ""
@@ -1665,10 +1582,12 @@ func setCDS(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setTA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(TA)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TA KeyTag", l}, ""
@@ -1703,10 +1622,12 @@ func setTA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setTLSA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(TLSA)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TLSA Usage", l}, ""
@@ -1738,10 +1659,12 @@ func setTLSA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setSMIMEA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(SMIMEA)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SMIMEA Usage", l}, ""
@@ -1773,10 +1696,12 @@ func setSMIMEA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setRFC3597(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(RFC3597)
 	rr.Hdr = h
+
 	l := <-c
 	if l.token != "\\#" {
 		return nil, &ParseError{f, "bad RFC3597 Rdata", l}, ""
 	}
+
 	<-c // zBlank
 	l = <-c
 	rdlength, e := strconv.Atoi(l.token)
@@ -1850,7 +1775,7 @@ func setURI(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 { // Dynamic updates.
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
 
@@ -1897,9 +1822,10 @@ func setNID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NID Preference", l}, ""
@@ -1920,9 +1846,10 @@ func setL32(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad L32 Preference", l}, ""
@@ -1942,31 +1869,25 @@ func setLP(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad LP Preference", l}, ""
 	}
 	rr.Preference = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Fqdn = l.token
-	if l.length == 0 {
-		return rr, nil, ""
-	}
-	if l.token == "@" {
-		rr.Fqdn = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+	name, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad LP Fqdn", l}, ""
 	}
-	if rr.Fqdn[l.length-1] != '.' {
-		rr.Fqdn = appendOrigin(rr.Fqdn, o)
-	}
+	rr.Fqdn = name
+
 	return rr, nil, ""
 }
 
@@ -1975,9 +1896,10 @@ func setL64(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad L64 Preference", l}, ""
@@ -1996,10 +1918,12 @@ func setL64(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setUID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(UID)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad UID Uid", l}, ""
@@ -2011,10 +1935,12 @@ func setUID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setGID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(GID)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 32)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad GID Gid", l}, ""
@@ -2026,6 +1952,7 @@ func setGID(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 func setUINFO(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(UINFO)
 	rr.Hdr = h
+
 	s, e, c1 := endingToTxtSlice(c, "bad UINFO Uinfo", f)
 	if e != nil {
 		return nil, e, c1
@@ -2042,55 +1969,46 @@ func setPX(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr.Hdr = h
 
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, ""
 	}
+
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad PX Preference", l}, ""
 	}
 	rr.Preference = uint16(i)
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Map822 = l.token
-	if l.length == 0 {
-		return rr, nil, ""
-	}
-	if l.token == "@" {
-		rr.Map822 = o
-		return rr, nil, ""
-	}
-	_, ok := IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+	map822, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad PX Map822", l}, ""
 	}
-	if rr.Map822[l.length-1] != '.' {
-		rr.Map822 = appendOrigin(rr.Map822, o)
-	}
+	rr.Map822 = map822
+
 	<-c     // zBlank
 	l = <-c // zString
 	rr.Mapx400 = l.token
-	if l.token == "@" {
-		rr.Mapx400 = o
-		return rr, nil, ""
-	}
-	_, ok = IsDomainName(l.token)
-	if !ok || l.length == 0 || l.err {
+	mapx400, err := nameToAbsolute(l.token, o)
+	if l.err || err != "" {
 		return nil, &ParseError{f, "bad PX Mapx400", l}, ""
 	}
-	if rr.Mapx400[l.length-1] != '.' {
-		rr.Mapx400 = appendOrigin(rr.Mapx400, o)
-	}
+	rr.Mapx400 = mapx400
+
 	return rr, nil, ""
 }
 
 func setCAA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	rr := new(CAA)
 	rr.Hdr = h
+
 	l := <-c
-	if l.length == 0 {
+	if l.length == 0 { // dynamic update rr.
 		return rr, nil, l.comment
 	}
+
 	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
 		return nil, &ParseError{f, "bad CAA Flag", l}, ""


### PR DESCRIPTION
Per [RFC 1035](https://tools.ietf.org/html/rfc1035#section-5.1) as updated by [RFC 2308](https://tools.ietf.org/html/rfc2308#section-4):
* Omitted RR TTL values "default to the last explicitly stated values" (unless a $TTL directive has been specified).
* "A relative name is an error when no origin is available"

Fixes #484