### PR TITLE
Simplify compressed length code

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -25,6 +25,25 @@ func BenchmarkMsgLength(b *testing.B) {
 	}
 }
 
+func BenchmarkMsgLengthNoCompression(b *testing.B) {
+	b.StopTimer()
+	makeMsg := func(question string, ans, ns, e []RR) *Msg {
+		msg := new(Msg)
+		msg.SetQuestion(Fqdn(question), TypeANY)
+		msg.Answer = append(msg.Answer, ans...)
+		msg.Ns = append(msg.Ns, ns...)
+		msg.Extra = append(msg.Extra, e...)
+		return msg
+	}
+	name1 := "12345678901234567890123456789012345.12345678.123."
+	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		msg.Len()
+	}
+}
+
 func BenchmarkMsgLengthPack(b *testing.B) {
 	makeMsg := func(question string, ans, ns, e []RR) *Msg {
 		msg := new(Msg)

--- a/msg.go
+++ b/msg.go
@@ -919,9 +919,9 @@ func compressedLen(dns *Msg, compress bool) int {
 			l += r.len()
 			compressionLenHelper(compression, r.Name)
 		}
-		l += comperssionLenSlice(compression, dns.Answer)
-		l += comperssionLenSlice(compression, dns.Ns)
-		l += comperssionLenSlice(compression, dns.Extra)
+		l += compressionLenSlice(compression, dns.Answer)
+		l += compressionLenSlice(compression, dns.Ns)
+		l += compressionLenSlice(compression, dns.Extra)
 	} else {
 		for _, r := range dns.Question {
 			l += r.len()
@@ -945,7 +945,7 @@ func compressedLen(dns *Msg, compress bool) int {
 	return l
 }
 
-func comperssionLenSlice(c map[string]int, rs []RR) int {
+func compressionLenSlice(c map[string]int, rs []RR) int {
 	var l int
 	for _, r := range rs {
 		if r == nil {

--- a/msg.go
+++ b/msg.go
@@ -913,67 +913,55 @@ func (dns *Msg) Len() int { return compressedLen(dns, dns.Compress) }
 func compressedLen(dns *Msg, compress bool) int {
 	// We always return one more than needed.
 	l := 12 // Message header is always 12 bytes
-	compression := map[string]int{}
+	if compress {
+		compression := map[string]int{}
+		for _, r := range dns.Question {
+			l += r.len()
+			compressionLenHelper(compression, r.Name)
+		}
+		l += comperssionLenSlice(compression, dns.Answer)
+		l += comperssionLenSlice(compression, dns.Ns)
+		l += comperssionLenSlice(compression, dns.Extra)
+	} else {
+		for _, r := range dns.Question {
+			l += r.len()
+		}
+		for _, r := range dns.Answer {
+			if r != nil {
+				l += r.len()
+			}
+		}
+		for _, r := range dns.Ns {
+			if r != nil {
+				l += r.len()
+			}
+		}
+		for _, r := range dns.Extra {
+			if r != nil {
+				l += r.len()
+			}
+		}
+	}
+	return l
+}
 
-	for i := 0; i < len(dns.Question); i++ {
-		l += dns.Question[i].len()
-		if compress {
-			compressionLenHelper(compression, dns.Question[i].Name)
-		}
-	}
-	for i := 0; i < len(dns.Answer); i++ {
-		if dns.Answer[i] == nil {
+func comperssionLenSlice(c map[string]int, rs []RR) int {
+	var l int
+	for _, r := range rs {
+		if r == nil {
 			continue
 		}
-		l += dns.Answer[i].len()
-		if compress {
-			k, ok := compressionLenSearch(compression, dns.Answer[i].Header().Name)
-			if ok {
-				l += 1 - k
-			}
-			compressionLenHelper(compression, dns.Answer[i].Header().Name)
-			k, ok = compressionLenSearchType(compression, dns.Answer[i])
-			if ok {
-				l += 1 - k
-			}
-			compressionLenHelperType(compression, dns.Answer[i])
+		l += r.len()
+		k, ok := compressionLenSearch(c, r.Header().Name)
+		if ok {
+			l += 1 - k
 		}
-	}
-	for i := 0; i < len(dns.Ns); i++ {
-		if dns.Ns[i] == nil {
-			continue
+		compressionLenHelper(c, r.Header().Name)
+		k, ok = compressionLenSearchType(c, r)
+		if ok {
+			l += 1 - k
 		}
-		l += dns.Ns[i].len()
-		if compress {
-			k, ok := compressionLenSearch(compression, dns.Ns[i].Header().Name)
-			if ok {
-				l += 1 - k
-			}
-			compressionLenHelper(compression, dns.Ns[i].Header().Name)
-			k, ok = compressionLenSearchType(compression, dns.Ns[i])
-			if ok {
-				l += 1 - k
-			}
-			compressionLenHelperType(compression, dns.Ns[i])
-		}
-	}
-	for i := 0; i < len(dns.Extra); i++ {
-		if dns.Extra[i] == nil {
-			continue
-		}
-		l += dns.Extra[i].len()
-		if compress {
-			k, ok := compressionLenSearch(compression, dns.Extra[i].Header().Name)
-			if ok {
-				l += 1 - k
-			}
-			compressionLenHelper(compression, dns.Extra[i].Header().Name)
-			k, ok = compressionLenSearchType(compression, dns.Extra[i])
-			if ok {
-				l += 1 - k
-			}
-			compressionLenHelperType(compression, dns.Extra[i])
-		}
+		compressionLenHelperType(c, r)
 	}
 	return l
 }


### PR DESCRIPTION
This is #519 by @rolandshoemaker with different code.

There is no difference in the speed of `msg.Len` with compression, but there is a noticeable speed up without compression.

I have no idea if this is worth merging or not, but I could see some obvious inefficiencies in that PR and I decided to address them.

```
name                      old time/op  new time/op  delta
MsgLength-8               1.65µs ± 6%  1.65µs ± 6%     ~     (p=0.968 n=10+9)
MsgLengthNoCompression-8   132ns ± 6%    15ns ± 3%  -88.61%  (p=0.000 n=10+10)
```

Original pull request (#519): "Removes a bunch of duplication in the msg.Len path ~and exposes the method used to calculate the compressed length of a RR given a provided compression map~."
