### PR TITLE
Keep compatibility with go1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 sudo: false
 go:
+  - 1.6.x
   - 1.7.x
   - 1.8.x
   - tip

--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/binary"
-	"golang.org/x/net/context"
 	"io"
 	"net"
 	"strings"
@@ -419,16 +418,6 @@ func Dial(network, address string) (conn *Conn, err error) {
 	return conn, nil
 }
 
-// ExchangeContext performs a synchronous UDP query, like Exchange. It
-// additionally obeys deadlines from the passed Context.
-func ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, err error) {
-	client := Client{Net: "udp"}
-	r, _, err = client.ExchangeContext(ctx, m, a)
-	// ignorint rtt to leave the original ExchangeContext API unchanged, but
-	// this function will go away
-	return r, err
-}
-
 // ExchangeConn performs a synchronous query. It sends the message m via the connection
 // c and waits for a reply. The connection c is not closed by ExchangeConn.
 // This function is going away, but can easily be mimicked:
@@ -487,20 +476,4 @@ func DialTimeoutWithTLS(network, address string, tlsConfig *tls.Config, timeout 
 		return nil, err
 	}
 	return conn, nil
-}
-
-// ExchangeContext acts like Exchange, but honors the deadline on the provided
-// context, if present. If there is both a context deadline and a configured
-// timeout on the client, the earliest of the two takes effect.
-func (c *Client) ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, rtt time.Duration, err error) {
-	var timeout time.Duration
-	if deadline, ok := ctx.Deadline(); !ok {
-		timeout = 0
-	} else {
-		timeout = deadline.Sub(time.Now())
-	}
-	// not passing the context to the underlying calls, as the API does not support
-	// context. For timeouts you should set up Client.Dialer and call Client.Exchange.
-	c.Dialer = &net.Dialer{Timeout: timeout}
-	return c.Exchange(m, a)
 }

--- a/client.go
+++ b/client.go
@@ -4,9 +4,9 @@ package dns
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"encoding/binary"
+	"golang.org/x/net/context"
 	"io"
 	"net"
 	"strings"

--- a/client_go16.go
+++ b/client_go16.go
@@ -1,0 +1,36 @@
+// +build go1.6,!go1.7
+
+package dns
+
+import (
+	"net"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// ExchangeContext performs a synchronous UDP query, like Exchange. It
+// additionally obeys deadlines from the passed Context.
+func ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, err error) {
+	client := Client{Net: "udp"}
+	r, _, err = client.ExchangeContext(ctx, m, a)
+	// ignorint rtt to leave the original ExchangeContext API unchanged, but
+	// this function will go away
+	return r, err
+}
+
+// ExchangeContext acts like Exchange, but honors the deadline on the provided
+// context, if present. If there is both a context deadline and a configured
+// timeout on the client, the earliest of the two takes effect.
+func (c *Client) ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, rtt time.Duration, err error) {
+	var timeout time.Duration
+	if deadline, ok := ctx.Deadline(); !ok {
+		timeout = 0
+	} else {
+		timeout = deadline.Sub(time.Now())
+	}
+	// not passing the context to the underlying calls, as the API does not support
+	// context. For timeouts you should set up Client.Dialer and call Client.Exchange.
+	c.Dialer = &net.Dialer{Timeout: timeout}
+	return c.Exchange(m, a)
+}

--- a/client_go17.go
+++ b/client_go17.go
@@ -1,0 +1,35 @@
+// +build go1.7
+
+package dns
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+// ExchangeContext performs a synchronous UDP query, like Exchange. It
+// additionally obeys deadlines from the passed Context.
+func ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, err error) {
+	client := Client{Net: "udp"}
+	r, _, err = client.ExchangeContext(ctx, m, a)
+	// ignorint rtt to leave the original ExchangeContext API unchanged, but
+	// this function will go away
+	return r, err
+}
+
+// ExchangeContext acts like Exchange, but honors the deadline on the provided
+// context, if present. If there is both a context deadline and a configured
+// timeout on the client, the earliest of the two takes effect.
+func (c *Client) ExchangeContext(ctx context.Context, m *Msg, a string) (r *Msg, rtt time.Duration, err error) {
+	var timeout time.Duration
+	if deadline, ok := ctx.Deadline(); !ok {
+		timeout = 0
+	} else {
+		timeout = deadline.Sub(time.Now())
+	}
+	// not passing the context to the underlying calls, as the API does not support
+	// context. For timeouts you should set up Client.Dialer and call Client.Exchange.
+	c.Dialer = &net.Dialer{Timeout: timeout}
+	return c.Exchange(m, a)
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1,9 +1,9 @@
 package dns
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
+	"golang.org/x/net/context"
 	"net"
 	"strconv"
 	"sync"

--- a/client_test.go
+++ b/client_test.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"crypto/tls"
 	"fmt"
-	"golang.org/x/net/context"
 	"net"
 	"strconv"
 	"sync"
@@ -553,68 +552,6 @@ func TestTruncatedMsg(t *testing.T) {
 	r = new(Msg)
 	if err = r.Unpack(buf1); err == nil || err != ErrTruncated {
 		t.Errorf("error not ErrTruncated from header-only unpack: %v", err)
-	}
-}
-
-func TestTimeout(t *testing.T) {
-	// Set up a dummy UDP server that won't respond
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("unable to resolve local udp address: %v", err)
-	}
-	conn, err := net.ListenUDP("udp", addr)
-	if err != nil {
-		t.Fatalf("unable to run test server: %v", err)
-	}
-	defer conn.Close()
-	addrstr := conn.LocalAddr().String()
-
-	// Message to send
-	m := new(Msg)
-	m.SetQuestion("miek.nl.", TypeTXT)
-
-	// Use a channel + timeout to ensure we don't get stuck if the
-	// Client Timeout is not working properly
-	done := make(chan struct{}, 2)
-
-	timeout := time.Millisecond
-	allowable := timeout + (10 * time.Millisecond)
-	abortAfter := timeout + (100 * time.Millisecond)
-
-	start := time.Now()
-
-	go func() {
-		c := &Client{Timeout: timeout}
-		_, _, err := c.Exchange(m, addrstr)
-		if err == nil {
-			t.Error("no timeout using Client.Exchange")
-		}
-		done <- struct{}{}
-	}()
-
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		c := &Client{}
-		_, _, err := c.ExchangeContext(ctx, m, addrstr)
-		if err == nil {
-			t.Error("no timeout using Client.ExchangeContext")
-		}
-		done <- struct{}{}
-	}()
-
-	// Wait for both the Exchange and ExchangeContext tests to be done.
-	for i := 0; i < 2; i++ {
-		select {
-		case <-done:
-		case <-time.After(abortAfter):
-		}
-	}
-
-	length := time.Since(start)
-
-	if length > allowable {
-		t.Errorf("exchange took longer (%v) than specified Timeout (%v)", length, timeout)
 	}
 }
 

--- a/client_timeout_go16_test.go
+++ b/client_timeout_go16_test.go
@@ -1,0 +1,73 @@
+//+build go1.6,!go1.7
+
+package dns
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+func TestTimeout(t *testing.T) {
+	// Set up a dummy UDP server that won't respond
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unable to resolve local udp address: %v", err)
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer conn.Close()
+	addrstr := conn.LocalAddr().String()
+
+	// Message to send
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeTXT)
+
+	// Use a channel + timeout to ensure we don't get stuck if the
+	// Client Timeout is not working properly
+	done := make(chan struct{}, 2)
+
+	timeout := time.Millisecond
+	allowable := timeout + (10 * time.Millisecond)
+	abortAfter := timeout + (100 * time.Millisecond)
+
+	start := time.Now()
+
+	go func() {
+		c := &Client{Timeout: timeout}
+		_, _, err := c.Exchange(m, addrstr)
+		if err == nil {
+			t.Error("no timeout using Client.Exchange")
+		}
+		done <- struct{}{}
+	}()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		c := &Client{}
+		_, _, err := c.ExchangeContext(ctx, m, addrstr)
+		if err == nil {
+			t.Error("no timeout using Client.ExchangeContext")
+		}
+		done <- struct{}{}
+	}()
+
+	// Wait for both the Exchange and ExchangeContext tests to be done.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-time.After(abortAfter):
+		}
+	}
+
+	length := time.Since(start)
+
+	if length > allowable {
+		t.Errorf("exchange took longer (%v) than specified Timeout (%v)", length, timeout)
+	}
+}

--- a/client_timeout_test.go
+++ b/client_timeout_test.go
@@ -1,0 +1,72 @@
+//+build go1.7
+
+package dns
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTimeout(t *testing.T) {
+	// Set up a dummy UDP server that won't respond
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("unable to resolve local udp address: %v", err)
+	}
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer conn.Close()
+	addrstr := conn.LocalAddr().String()
+
+	// Message to send
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeTXT)
+
+	// Use a channel + timeout to ensure we don't get stuck if the
+	// Client Timeout is not working properly
+	done := make(chan struct{}, 2)
+
+	timeout := time.Millisecond
+	allowable := timeout + (10 * time.Millisecond)
+	abortAfter := timeout + (100 * time.Millisecond)
+
+	start := time.Now()
+
+	go func() {
+		c := &Client{Timeout: timeout}
+		_, _, err := c.Exchange(m, addrstr)
+		if err == nil {
+			t.Error("no timeout using Client.Exchange")
+		}
+		done <- struct{}{}
+	}()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		c := &Client{}
+		_, _, err := c.ExchangeContext(ctx, m, addrstr)
+		if err == nil {
+			t.Error("no timeout using Client.ExchangeContext")
+		}
+		done <- struct{}{}
+	}()
+
+	// Wait for both the Exchange and ExchangeContext tests to be done.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-time.After(abortAfter):
+		}
+	}
+
+	length := time.Since(start)
+
+	if length > allowable {
+		t.Errorf("exchange took longer (%v) than specified Timeout (%v)", length, timeout)
+	}
+}


### PR DESCRIPTION
Although f282f80e243cc2bf8f6410c30d821b93b794e168 removes 1.6 from travis builds, it's not clear if the intent is to completely drop support to 1.6.

Compatibility with go1.6 can be kept by simply using `golang.org/x/net/context` rather than `context`.