### PR TITLE
Added test for DialTimeout

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -34,6 +34,21 @@ func TestDialUDP(t *testing.T) {
 	}
 }
 
+func TestDialTimeoutTCP(t *testing.T) {
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeSOA)
+
+	// insomniac.slackware.it is configured to drop connections to 5053 for this
+	// test to succeed
+	conn, err := DialTimeout("tcp", "insomniac.slackware.it:5053", time.Millisecond*100)
+	if err == nil {
+		t.Fatalf("expected timeout error, but no error returned")
+	}
+	if conn != nil {
+		t.Fatalf("expected nil value for conn, got %v instead", conn)
+	}
+}
+
 func TestClientSync(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")

--- a/client_test.go
+++ b/client_test.go
@@ -34,18 +34,23 @@ func TestDialUDP(t *testing.T) {
 	}
 }
 
-func TestDialTimeoutTCP(t *testing.T) {
+func TestDialTimeoutTCPNoTimeout(t *testing.T) {
+	// this tests the non-timeout case of a call to DialTimeout
+	s, addrstr, err := RunLocalTCPServer("[::1]:0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
 	m := new(Msg)
 	m.SetQuestion("miek.nl.", TypeSOA)
 
-	// insomniac.slackware.it is configured to drop connections to 5053 for this
-	// test to succeed
-	conn, err := DialTimeout("tcp", "insomniac.slackware.it:5053", time.Millisecond*100)
-	if err == nil {
-		t.Fatalf("expected timeout error, but no error returned")
+	conn, err := DialTimeout("tcp", addrstr, time.Millisecond*100)
+	if err != nil {
+		t.Fatalf("failed to dial with timeout: %v", err)
 	}
-	if conn != nil {
-		t.Fatalf("expected nil value for conn, got %v instead", conn)
+	if conn == nil {
+		t.Fatalf("conn is nil")
 	}
 }
 


### PR DESCRIPTION
Added test for `DialTimeout`, to address the concerns at https://github.com/miekg/dns/pull/526 .

The test currently makes a network call to a TCP port configured to drop packets, as it is not easy to simulate in an isolated manner a connection timeout on Travis-CI.