### PR TITLE
Allow parsing resolv.conf from io.Reader

### DIFF
--- a/clientconfig.go
+++ b/clientconfig.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -25,8 +26,13 @@ func ClientConfigFromFile(resolvconf string) (*ClientConfig, error) {
 		return nil, err
 	}
 	defer file.Close()
+	return ClientConfigFromReader(file)
+}
+
+// ClientConfigFromReader works like ClientConfigFromFile but takes an io.Reader as argument
+func ClientConfigFromReader(resolvconf io.Reader) (*ClientConfig, error) {
 	c := new(ClientConfig)
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(resolvconf)
 	c.Servers = make([]string, 0)
 	c.Search = make([]string, 0)
 	c.Port = "53"

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -1,10 +1,10 @@
 package dns
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -21,7 +21,7 @@ nameserver 10.28.10.2
 nameserver 11.28.10.1` // <- NOTE: NO newline.
 
 func testConfig(t *testing.T, data string) {
-	cc, err := ClientConfigFromReader(bytes.NewBufferString(data))
+	cc, err := ClientConfigFromReader(strings.NewReader(data))
 	if err != nil {
 		t.Errorf("error parsing resolv.conf: %v", err)
 	}

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -20,17 +21,7 @@ nameserver 10.28.10.2
 nameserver 11.28.10.1` // <- NOTE: NO newline.
 
 func testConfig(t *testing.T, data string) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("tempDir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	path := filepath.Join(tempDir, "resolv.conf")
-	if err := ioutil.WriteFile(path, []byte(data), 0644); err != nil {
-		t.Fatalf("writeFile: %v", err)
-	}
-	cc, err := ClientConfigFromFile(path)
+	cc, err := ClientConfigFromReader(bytes.NewBufferString(data))
 	if err != nil {
 		t.Errorf("error parsing resolv.conf: %v", err)
 	}
@@ -48,6 +39,33 @@ func testConfig(t *testing.T, data string) {
 
 func TestNameserver(t *testing.T)          { testConfig(t, normal) }
 func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline) }
+
+func TestReadFromFile(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("tempDir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	path := filepath.Join(tempDir, "resolv.conf")
+	if err := ioutil.WriteFile(path, []byte(normal), 0644); err != nil {
+		t.Fatalf("writeFile: %v", err)
+	}
+	cc, err := ClientConfigFromFile(path)
+	if err != nil {
+		t.Errorf("error parsing resolv.conf: %v", err)
+	}
+	if l := len(cc.Servers); l != 2 {
+		t.Errorf("incorrect number of nameservers detected: %d", l)
+	}
+	if l := len(cc.Search); l != 1 {
+		t.Errorf("domain directive not parsed correctly: %v", cc.Search)
+	} else {
+		if cc.Search[0] != "somedomain.com" {
+			t.Errorf("domain is unexpected: %v", cc.Search[0])
+		}
+	}
+}
 
 func TestNameList(t *testing.T) {
 	cfg := ClientConfig{


### PR DESCRIPTION
This allows projects that use this parser to write unit tests without
writing temporary files to the filesystem.