### PR TITLE
Go version bump in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 sudo: false
 go:
-  - 1.7.x
   - 1.8.x
+  - 1.9.x
   - tip
 
 before_install:


### PR DESCRIPTION
Bumped Go version to 1.8 and 1.9 to keep in line with the last two releases