### PR TITLE
Make compress generate output stable and edns.go formatting

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -106,7 +106,7 @@ func (rr *OPT) SetVersion(v uint8) {
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
 func (rr *OPT) ExtendedRcode() int {
-	return int((rr.Hdr.Ttl&0xFF000000)>>24)
+	return int((rr.Hdr.Ttl & 0xFF000000) >> 24)
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.

--- a/zcompress.go
+++ b/zcompress.go
@@ -5,82 +5,79 @@ package dns
 
 func compressionLenHelperType(c map[string]int, r RR) {
 	switch x := r.(type) {
-	case *PTR:
-		compressionLenHelper(c, x.Ptr)
-	case *SOA:
-		compressionLenHelper(c, x.Ns)
-		compressionLenHelper(c, x.Mbox)
 	case *AFSDB:
 		compressionLenHelper(c, x.Hostname)
+	case *CNAME:
+		compressionLenHelper(c, x.Target)
+	case *DNAME:
+		compressionLenHelper(c, x.Target)
 	case *HIP:
 		for i := range x.RendezvousServers {
 			compressionLenHelper(c, x.RendezvousServers[i])
 		}
+	case *KX:
+		compressionLenHelper(c, x.Exchanger)
 	case *LP:
 		compressionLenHelper(c, x.Fqdn)
-	case *CNAME:
-		compressionLenHelper(c, x.Target)
 	case *MB:
 		compressionLenHelper(c, x.Mb)
+	case *MD:
+		compressionLenHelper(c, x.Md)
+	case *MF:
+		compressionLenHelper(c, x.Mf)
+	case *MG:
+		compressionLenHelper(c, x.Mg)
+	case *MINFO:
+		compressionLenHelper(c, x.Rmail)
+		compressionLenHelper(c, x.Email)
+	case *MR:
+		compressionLenHelper(c, x.Mr)
+	case *MX:
+		compressionLenHelper(c, x.Mx)
+	case *NAPTR:
+		compressionLenHelper(c, x.Replacement)
+	case *NS:
+		compressionLenHelper(c, x.Ns)
+	case *NSAPPTR:
+		compressionLenHelper(c, x.Ptr)
+	case *NSEC:
+		compressionLenHelper(c, x.NextDomain)
+	case *PTR:
+		compressionLenHelper(c, x.Ptr)
+	case *PX:
+		compressionLenHelper(c, x.Map822)
+		compressionLenHelper(c, x.Mapx400)
 	case *RP:
 		compressionLenHelper(c, x.Mbox)
 		compressionLenHelper(c, x.Txt)
 	case *RRSIG:
 		compressionLenHelper(c, x.SignerName)
-	case *MF:
-		compressionLenHelper(c, x.Mf)
-	case *MINFO:
-		compressionLenHelper(c, x.Rmail)
-		compressionLenHelper(c, x.Email)
+	case *RT:
+		compressionLenHelper(c, x.Host)
 	case *SIG:
 		compressionLenHelper(c, x.SignerName)
+	case *SOA:
+		compressionLenHelper(c, x.Ns)
+		compressionLenHelper(c, x.Mbox)
 	case *SRV:
 		compressionLenHelper(c, x.Target)
-	case *TSIG:
-		compressionLenHelper(c, x.Algorithm)
-	case *KX:
-		compressionLenHelper(c, x.Exchanger)
-	case *MG:
-		compressionLenHelper(c, x.Mg)
-	case *NSAPPTR:
-		compressionLenHelper(c, x.Ptr)
-	case *PX:
-		compressionLenHelper(c, x.Map822)
-		compressionLenHelper(c, x.Mapx400)
-	case *DNAME:
-		compressionLenHelper(c, x.Target)
-	case *MR:
-		compressionLenHelper(c, x.Mr)
-	case *MX:
-		compressionLenHelper(c, x.Mx)
-	case *TKEY:
-		compressionLenHelper(c, x.Algorithm)
-	case *NSEC:
-		compressionLenHelper(c, x.NextDomain)
 	case *TALINK:
 		compressionLenHelper(c, x.PreviousName)
 		compressionLenHelper(c, x.NextName)
-	case *MD:
-		compressionLenHelper(c, x.Md)
-	case *NAPTR:
-		compressionLenHelper(c, x.Replacement)
-	case *NS:
-		compressionLenHelper(c, x.Ns)
-	case *RT:
-		compressionLenHelper(c, x.Host)
+	case *TKEY:
+		compressionLenHelper(c, x.Algorithm)
+	case *TSIG:
+		compressionLenHelper(c, x.Algorithm)
 	}
 }
 
 func compressionLenSearchType(c map[string]int, r RR) (int, bool) {
 	switch x := r.(type) {
-	case *MG:
-		k1, ok1 := compressionLenSearch(c, x.Mg)
-		return k1, ok1
-	case *PTR:
-		k1, ok1 := compressionLenSearch(c, x.Ptr)
-		return k1, ok1
 	case *AFSDB:
 		k1, ok1 := compressionLenSearch(c, x.Hostname)
+		return k1, ok1
+	case *CNAME:
+		k1, ok1 := compressionLenSearch(c, x.Target)
 		return k1, ok1
 	case *MB:
 		k1, ok1 := compressionLenSearch(c, x.Mb)
@@ -91,18 +88,8 @@ func compressionLenSearchType(c map[string]int, r RR) (int, bool) {
 	case *MF:
 		k1, ok1 := compressionLenSearch(c, x.Mf)
 		return k1, ok1
-	case *NS:
-		k1, ok1 := compressionLenSearch(c, x.Ns)
-		return k1, ok1
-	case *RT:
-		k1, ok1 := compressionLenSearch(c, x.Host)
-		return k1, ok1
-	case *SOA:
-		k1, ok1 := compressionLenSearch(c, x.Ns)
-		k2, ok2 := compressionLenSearch(c, x.Mbox)
-		return k1 + k2, ok1 && ok2
-	case *CNAME:
-		k1, ok1 := compressionLenSearch(c, x.Target)
+	case *MG:
+		k1, ok1 := compressionLenSearch(c, x.Mg)
 		return k1, ok1
 	case *MINFO:
 		k1, ok1 := compressionLenSearch(c, x.Rmail)
@@ -114,6 +101,19 @@ func compressionLenSearchType(c map[string]int, r RR) (int, bool) {
 	case *MX:
 		k1, ok1 := compressionLenSearch(c, x.Mx)
 		return k1, ok1
+	case *NS:
+		k1, ok1 := compressionLenSearch(c, x.Ns)
+		return k1, ok1
+	case *PTR:
+		k1, ok1 := compressionLenSearch(c, x.Ptr)
+		return k1, ok1
+	case *RT:
+		k1, ok1 := compressionLenSearch(c, x.Host)
+		return k1, ok1
+	case *SOA:
+		k1, ok1 := compressionLenSearch(c, x.Ns)
+		k2, ok2 := compressionLenSearch(c, x.Mbox)
+		return k1 + k2, ok1 && ok2
 	}
 	return 0, false
 }


### PR DESCRIPTION
In preparing to remove the length-bytes from some structs (#426) I noticed the output of `compress_generate.go` isn't stable and `edns.go` needs a `go fmt`.