### PR TITLE
Document SetTsig() needs to be final RRset change

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -168,6 +168,11 @@ Basic use pattern when querying with a TSIG name "axfr." (note that these key na
 must be fully qualified - as they are domain names) and the base64 secret
 "so6ZGir4GPAqINNh9U5c3A==":
 
+If an incoming message contains a TSIG record it MUST be the last record in
+the additional section (RFC2845 3.2).  This means that you should make the
+call to SetTsig last, right before executing the query.  If you make any
+changes to the RRset after calling SetTsig() the signature will be incorrect.
+
 	c := new(dns.Client)
 	c.TsigSecret = map[string]string{"axfr.": "so6ZGir4GPAqINNh9U5c3A=="}
 	m := new(dns.Msg)


### PR DESCRIPTION
I spent several hours trying to figure out why my TSIG signatures were
failing on requests to a server.  I finally discovered this little
detail in the RFC which turned out to be my whole problem.  Amending the
documentation to hopefully spare others the same confusion.

    If an incoming message contains a TSIG record, it MUST be the last
    record in the additional section.

RFC2845 3.2