### PR TITLE
server: drop graceful handling

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -525,7 +525,7 @@ func TestTimeout(t *testing.T) {
 	length := time.Since(start)
 
 	if length > allowable {
-		t.Errorf("exchange took longer (%v) than specified Timeout (%v)", length, timeout)
+		t.Errorf("exchange took longer (%v) than specified Timeout (%v)", length, allowable)
 	}
 }
 


### PR DESCRIPTION
Drop all graceful handling. There is just too much locking in
waitgrouping going on for very little gain; deal with it.

This actually breaks a test - which I'm looking into.