### PR TITLE
Cleanup: gofmt -w -s *.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,6 +78,7 @@ func (c *Client) writeTimeout() time.Duration {
 	return dnsTimeout
 }
 
+// Dial connects to the address on the named network.
 func (c *Client) Dial(address string) (conn *Conn, err error) {
 	// create a new dialer with the appropriate timeout
 	var d net.Dialer

--- a/dns.go
+++ b/dns.go
@@ -6,9 +6,12 @@ const (
 	year68     = 1 << 31 // For RFC1982 (Serial Arithmetic) calculations in 32 bits.
 	defaultTtl = 3600    // Default internal TTL.
 
-	DefaultMsgSize = 4096  // DefaultMsgSize is the standard default for messages larger than 512 bytes.
-	MinMsgSize     = 512   // MinMsgSize is the minimal size of a DNS packet.
-	MaxMsgSize     = 65535 // MaxMsgSize is the largest possible DNS packet.
+	// DefaultMsgSize is the standard default for messages larger than 512 bytes.
+	DefaultMsgSize = 4096
+	// MinMsgSize is the minimal size of a DNS packet.
+	MinMsgSize = 512
+	// MaxMsgSize is the largest possible DNS packet.
+	MaxMsgSize = 65535
 )
 
 // Error represents a DNS error.

--- a/labels_test.go
+++ b/labels_test.go
@@ -85,19 +85,19 @@ func TestPrevLabel(t *testing.T) {
 		int
 	}
 	prever := map[prev]int{
-		prev{"www.miek.nl.", 0}: 12,
-		prev{"www.miek.nl.", 1}: 9,
-		prev{"www.miek.nl.", 2}: 4,
+		{"www.miek.nl.", 0}: 12,
+		{"www.miek.nl.", 1}: 9,
+		{"www.miek.nl.", 2}: 4,
 
-		prev{"www.miek.nl", 0}: 11,
-		prev{"www.miek.nl", 1}: 9,
-		prev{"www.miek.nl", 2}: 4,
+		{"www.miek.nl", 0}: 11,
+		{"www.miek.nl", 1}: 9,
+		{"www.miek.nl", 2}: 4,
 
-		prev{"www.miek.nl.", 5}: 0,
-		prev{"www.miek.nl", 5}:  0,
+		{"www.miek.nl.", 5}: 0,
+		{"www.miek.nl", 5}:  0,
 
-		prev{"www.miek.nl.", 3}: 0,
-		prev{"www.miek.nl", 3}:  0,
+		{"www.miek.nl.", 3}: 0,
+		{"www.miek.nl", 3}:  0,
 	}
 	for s, i := range prever {
 		x, ok := PrevLabel(s.string, s.int)

--- a/msg.go
+++ b/msg.go
@@ -26,6 +26,7 @@ const (
 	maxDomainNameWireOctets = 255     // See RFC 1035 section 2.3.4
 )
 
+// Errors defined in this package.
 var (
 	ErrAlg           error = &Error{err: "bad algorithm"}                  // ErrAlg indicates an error with the (DNSSEC) algorithm.
 	ErrAuth          error = &Error{err: "bad authentication"}             // ErrAuth indicates an error in the TSIG authentication.
@@ -57,7 +58,7 @@ var (
 // For instance, to make it return a static value:
 //
 //	dns.Id = func() uint16 { return 3 }
-var Id func() uint16 = id
+var Id = id
 
 var (
 	idLock sync.Mutex
@@ -360,7 +361,7 @@ Loop:
 				case '"', '\\':
 					s = append(s, '\\', b)
 					// presentation-format \X escapes add an extra byte
-					maxLen += 1
+					maxLen++
 				default:
 					if b < 32 || b >= 127 { // unprintable, use \DDD
 						var buf [3]byte

--- a/scan.go
+++ b/scan.go
@@ -38,7 +38,7 @@ const (
 	zOwner
 	zClass
 	zDirOrigin   // $ORIGIN
-	zDirTtl      // $TTL
+	zDirTTL      // $TTL
 	zDirInclude  // $INCLUDE
 	zDirGenerate // $GENERATE
 
@@ -51,13 +51,13 @@ const (
 	zExpectAny           // Expect rrtype, ttl or class
 	zExpectAnyNoClass    // Expect rrtype or ttl
 	zExpectAnyNoClassBl  // The whitespace after _EXPECT_ANY_NOCLASS
-	zExpectAnyNoTtl      // Expect rrtype or class
-	zExpectAnyNoTtlBl    // Whitespace after _EXPECT_ANY_NOTTL
+	zExpectAnyNoTTL      // Expect rrtype or class
+	zExpectAnyNoTTLBl    // Whitespace after _EXPECT_ANY_NOTTL
 	zExpectRrtype        // Expect rrtype
 	zExpectRrtypeBl      // Whitespace BEFORE rrtype
 	zExpectRdata         // The first element of the rdata
-	zExpectDirTtlBl      // Space after directive $TTL
-	zExpectDirTtl        // Directive $TTL
+	zExpectDirTTLBl      // Space after directive $TTL
+	zExpectDirTTL        // Directive $TTL
 	zExpectDirOriginBl   // Space after directive $ORIGIN
 	zExpectDirOrigin     // Directive $ORIGIN
 	zExpectDirIncludeBl  // Space after directive $INCLUDE
@@ -231,8 +231,8 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				h.Name = name
 				prevName = h.Name
 				st = zExpectOwnerBl
-			case zDirTtl:
-				st = zExpectDirTtlBl
+			case zDirTTL:
+				st = zExpectDirTTLBl
 			case zDirOrigin:
 				st = zExpectDirOriginBl
 			case zDirInclude:
@@ -251,7 +251,7 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				// Discard, can happen when there is nothing on the
 				// line except the RR type
 			case zString:
-				ttl, ok := stringToTtl(l.token)
+				ttl, ok := stringToTTL(l.token)
 				if !ok {
 					t <- &Token{Error: &ParseError{f, "not a TTL", l}}
 					return
@@ -260,7 +260,7 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				if defttl == nil || !defttl.isByDirective {
 					defttl = &ttlState{ttl, false}
 				}
-				st = zExpectAnyNoTtlBl
+				st = zExpectAnyNoTTLBl
 
 			default:
 				t <- &Token{Error: &ParseError{f, "syntax error at beginning", l}}
@@ -307,13 +307,13 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 			}
 			parseZone(r1, neworigin, defttl, l.token, t, include+1)
 			st = zExpectOwnerDir
-		case zExpectDirTtlBl:
+		case zExpectDirTTLBl:
 			if l.value != zBlank {
 				t <- &Token{Error: &ParseError{f, "no blank after $TTL-directive", l}}
 				return
 			}
-			st = zExpectDirTtl
-		case zExpectDirTtl:
+			st = zExpectDirTTL
+		case zExpectDirTTL:
 			if l.value != zString {
 				t <- &Token{Error: &ParseError{f, "expecting $TTL value, not this...", l}}
 				return
@@ -322,7 +322,7 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				t <- &Token{Error: e}
 				return
 			}
-			ttl, ok := stringToTtl(l.token)
+			ttl, ok := stringToTTL(l.token)
 			if !ok {
 				t <- &Token{Error: &ParseError{f, "expecting $TTL value, not this...", l}}
 				return
@@ -385,7 +385,7 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				h.Class = l.torc
 				st = zExpectAnyNoClassBl
 			case zString:
-				ttl, ok := stringToTtl(l.token)
+				ttl, ok := stringToTTL(l.token)
 				if !ok {
 					t <- &Token{Error: &ParseError{f, "not a TTL", l}}
 					return
@@ -394,7 +394,7 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				if defttl == nil || !defttl.isByDirective {
 					defttl = &ttlState{ttl, false}
 				}
-				st = zExpectAnyNoTtlBl
+				st = zExpectAnyNoTTLBl
 			default:
 				t <- &Token{Error: &ParseError{f, "expecting RR type, TTL or class, not this...", l}}
 				return
@@ -405,13 +405,13 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 				return
 			}
 			st = zExpectAnyNoClass
-		case zExpectAnyNoTtlBl:
+		case zExpectAnyNoTTLBl:
 			if l.value != zBlank {
 				t <- &Token{Error: &ParseError{f, "no blank before TTL", l}}
 				return
 			}
-			st = zExpectAnyNoTtl
-		case zExpectAnyNoTtl:
+			st = zExpectAnyNoTTL
+		case zExpectAnyNoTTL:
 			switch l.value {
 			case zClass:
 				h.Class = l.torc
@@ -426,7 +426,7 @@ func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *T
 		case zExpectAnyNoClass:
 			switch l.value {
 			case zString:
-				ttl, ok := stringToTtl(l.token)
+				ttl, ok := stringToTTL(l.token)
 				if !ok {
 					t <- &Token{Error: &ParseError{f, "not a TTL", l}}
 					return
@@ -539,7 +539,7 @@ func zlexer(s *scan, c chan lex) {
 				// escape $... start with a \ not a $, so this will work
 				switch l.tokenUpper {
 				case "$TTL":
-					l.value = zDirTtl
+					l.value = zDirTTL
 				case "$ORIGIN":
 					l.value = zDirOrigin
 				case "$INCLUDE":
@@ -837,8 +837,8 @@ func typeToInt(token string) (uint16, bool) {
 	return uint16(typ), true
 }
 
-// Parse things like 2w, 2m, etc, Return the time in seconds.
-func stringToTtl(token string) (uint32, bool) {
+// stringToTTL parses things like 2w, 2m, etc, and returns the time in seconds.
+func stringToTTL(token string) (uint32, bool) {
 	s := uint32(0)
 	i := uint32(0)
 	for _, c := range token {

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -590,7 +590,7 @@ func setSOA(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
 			}
 			// We allow other fields to be unitful duration strings
-			if v, ok = stringToTtl(l.token); !ok {
+			if v, ok = stringToTTL(l.token); !ok {
 				return nil, &ParseError{f, "bad SOA zone parameter", l}, ""
 
 			}


### PR DESCRIPTION
Some renames of internal names to make go lint happier.