### PR TITLE
Tests updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 sudo: false
 go:
-  - 1.8.x
   - 1.9.x
   - tip
 

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ func TestDialUDP(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -38,7 +39,7 @@ func TestClientSync(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestClientLocalAddress(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServerEchoAddrPort)
 	defer HandleRemove("miek.nl.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -82,11 +83,11 @@ func TestClientLocalAddress(t *testing.T) {
 	m.SetQuestion("miek.nl.", TypeSOA)
 
 	c := new(Client)
-	laddr := net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345, Zone: ""}
+	laddr := net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: 12345, Zone: ""}
 	c.Dialer = &net.Dialer{LocalAddr: &laddr}
 	r, _, err := c.Exchange(m, addrstr)
 	if err != nil {
-		t.Errorf("failed to exchange: %v", err)
+		t.Fatalf("failed to exchange: %v", err)
 	}
 	if r != nil && r.Rcode != RcodeSuccess {
 		t.Errorf("failed to get an valid answer\n%v", r)
@@ -98,7 +99,7 @@ func TestClientLocalAddress(t *testing.T) {
 	if txt == nil {
 		t.Errorf("invalid TXT response\n%v", txt)
 	}
-	if len(txt.Txt) != 1 || txt.Txt[0] != "127.0.0.1:12345" {
+	if len(txt.Txt) != 1 || !strings.Contains(txt.Txt[0], ":12345") {
 		t.Errorf("invalid TXT response\n%v", txt.Txt)
 	}
 }
@@ -116,7 +117,7 @@ func TestClientTLSSyncV4(t *testing.T) {
 		Certificates: []tls.Certificate{cert},
 	}
 
-	s, addrstr, err := RunLocalTLSServer("127.0.0.1:0", &config)
+	s, addrstr, err := RunLocalTLSServer(":0", &config)
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestClientSyncBadID(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServerBadID)
 	defer HandleRemove("miek.nl.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -189,7 +190,7 @@ func TestClientEDNS0(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -236,7 +237,7 @@ func TestClientEDNS0Local(t *testing.T) {
 	HandleFunc("miek.nl.", handler)
 	defer HandleRemove("miek.nl.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %s", err)
 	}
@@ -286,7 +287,7 @@ func TestClientConn(t *testing.T) {
 	defer HandleRemove("miek.nl.")
 
 	// This uses TCP just to make it slightly different than TestClientSync
-	s, addrstr, err := RunLocalTCPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalTCPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -468,7 +469,7 @@ func TestTruncatedMsg(t *testing.T) {
 
 func TestTimeout(t *testing.T) {
 	// Set up a dummy UDP server that won't respond
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	addr, err := net.ResolveUDPAddr("udp", ":0")
 	if err != nil {
 		t.Fatalf("unable to resolve local udp address: %v", err)
 	}
@@ -550,7 +551,7 @@ func TestConcurrentExchanges(t *testing.T) {
 		HandleFunc("miek.nl.", handler)
 		defer HandleRemove("miek.nl.")
 
-		s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+		s, addrstr, err := RunLocalUDPServer(":0")
 		if err != nil {
 			t.Fatalf("unable to run test server: %s", err)
 		}

--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkMsgLength(b *testing.B) {
 		return msg
 	}
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -36,7 +36,7 @@ func BenchmarkMsgLengthNoCompression(b *testing.B) {
 		return msg
 	}
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -55,7 +55,7 @@ func BenchmarkMsgLengthPack(b *testing.B) {
 		return msg
 	}
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -96,11 +96,11 @@ func BenchmarkCopy(b *testing.B) {
 	b.ReportAllocs()
 	m := new(Msg)
 	m.SetQuestion("miek.nl.", TypeA)
-	rr, _ := NewRR("miek.nl. 2311 IN A 127.0.0.1")
+	rr := testRR("miek.nl. 2311 IN A 127.0.0.1")
 	m.Answer = []RR{rr}
-	rr, _ = NewRR("miek.nl. 2311 IN NS 127.0.0.1")
+	rr = testRR("miek.nl. 2311 IN NS 127.0.0.1")
 	m.Ns = []RR{rr}
-	rr, _ = NewRR("miek.nl. 2311 IN A 127.0.0.1")
+	rr = testRR("miek.nl. 2311 IN A 127.0.0.1")
 	m.Extra = []RR{rr}
 
 	b.ResetTimer()
@@ -158,7 +158,7 @@ func BenchmarkUnpackMX(b *testing.B) {
 }
 
 func BenchmarkPackAAAAA(b *testing.B) {
-	aaaa, _ := NewRR(". IN A ::1")
+	aaaa := testRR(". IN A ::1")
 
 	buf := make([]byte, aaaa.len())
 	b.ReportAllocs()
@@ -169,7 +169,7 @@ func BenchmarkPackAAAAA(b *testing.B) {
 }
 
 func BenchmarkUnpackAAAA(b *testing.B) {
-	aaaa, _ := NewRR(". IN A ::1")
+	aaaa := testRR(". IN A ::1")
 
 	buf := make([]byte, aaaa.len())
 	PackRR(aaaa, buf, 0, nil, false)
@@ -192,7 +192,7 @@ func BenchmarkPackMsg(b *testing.B) {
 		return msg
 	}
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
 	buf := make([]byte, 512)
 	b.ReportAllocs()
@@ -213,7 +213,7 @@ func BenchmarkUnpackMsg(b *testing.B) {
 		return msg
 	}
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
 	msgBuf, _ := msg.Pack()
 	b.ReportAllocs()

--- a/dns_test.go
+++ b/dns_test.go
@@ -126,53 +126,13 @@ func TestBailiwick(t *testing.T) {
 	}
 }
 
-func TestPack(t *testing.T) {
-	rr := []string{"US.    86400	IN	NSEC	0-.us. NS SOA RRSIG NSEC DNSKEY TYPE65534"}
-	m := new(Msg)
-	var err error
-	m.Answer = make([]RR, 1)
-	for _, r := range rr {
-		m.Answer[0], err = NewRR(r)
-		if err != nil {
-			t.Errorf("failed to create RR: %v", err)
-			continue
-		}
-		if _, err := m.Pack(); err != nil {
-			t.Errorf("packing failed: %v", err)
-		}
-	}
-	x := new(Msg)
-	ns, _ := NewRR("pool.ntp.org.   390 IN  NS  a.ntpns.org")
-	ns.(*NS).Ns = "a.ntpns.org"
-	x.Ns = append(m.Ns, ns)
-	x.Ns = append(m.Ns, ns)
-	x.Ns = append(m.Ns, ns)
-	// This crashes due to the fact the a.ntpns.org isn't a FQDN
-	// How to recover() from a remove panic()?
-	if _, err := x.Pack(); err == nil {
-		t.Error("packing should fail")
-	}
-	x.Answer = make([]RR, 1)
-	if x.Answer[0], err = NewRR(rr[0]); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := x.Pack(); err == nil {
-		t.Error("packing should fail")
-	}
-	x.Question = make([]Question, 1)
-	x.Question[0] = Question{";sd#eddddséâèµâââ¥âxzztsestxssweewwsssstx@s@Zåµe@cn.pool.ntp.org.", TypeA, ClassINET}
-	if _, err := x.Pack(); err == nil {
-		t.Error("packing should fail")
-	}
-}
-
 func TestPackNAPTR(t *testing.T) {
 	for _, n := range []string{
 		`apple.com. IN NAPTR   100 50 "se" "SIP+D2U" "" _sip._udp.apple.com.`,
 		`apple.com. IN NAPTR   90 50 "se" "SIP+D2T" "" _sip._tcp.apple.com.`,
 		`apple.com. IN NAPTR   50 50 "se" "SIPS+D2T" "" _sips._tcp.apple.com.`,
 	} {
-		rr, _ := NewRR(n)
+		rr := testRR(n)
 		msg := make([]byte, rr.len())
 		if off, err := PackRR(rr, msg, 0, nil, false); err != nil {
 			t.Errorf("packing failed: %v", err)
@@ -204,8 +164,8 @@ func TestMsgCompressLength(t *testing.T) {
 	}
 
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrA, _ := NewRR(name1 + " 3600 IN A 192.0.2.1")
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrA := testRR(name1 + " 3600 IN A 192.0.2.1")
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	tests := []*Msg{
 		makeMsg(name1, []RR{rrA}, nil, nil),
 		makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)}
@@ -234,8 +194,8 @@ func TestMsgLength(t *testing.T) {
 	}
 
 	name1 := "12345678901234567890123456789012345.12345678.123."
-	rrA, _ := NewRR(name1 + " 3600 IN A 192.0.2.1")
-	rrMx, _ := NewRR(name1 + " 3600 IN MX 10 " + name1)
+	rrA := testRR(name1 + " 3600 IN A 192.0.2.1")
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	tests := []*Msg{
 		makeMsg(name1, []RR{rrA}, nil, nil),
 		makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)}
@@ -328,14 +288,14 @@ func TestMsgCompressLength2(t *testing.T) {
 }
 
 func TestToRFC3597(t *testing.T) {
-	a, _ := NewRR("miek.nl. IN A 10.0.1.1")
+	a := testRR("miek.nl. IN A 10.0.1.1")
 	x := new(RFC3597)
 	x.ToRFC3597(a)
 	if x.String() != `miek.nl.	3600	CLASS1	TYPE1	\# 4 0a000101` {
 		t.Errorf("string mismatch, got: %s", x)
 	}
 
-	b, _ := NewRR("miek.nl. IN MX 10 mx.miek.nl.")
+	b := testRR("miek.nl. IN MX 10 mx.miek.nl.")
 	x.ToRFC3597(b)
 	if x.String() != `miek.nl.	3600	CLASS1	TYPE15	\# 14 000a026d78046d69656b026e6c00` {
 		t.Errorf("string mismatch, got: %s", x)
@@ -392,7 +352,7 @@ func TestRdataOverflow(t *testing.T) {
 }
 
 func TestCopy(t *testing.T) {
-	rr, _ := NewRR("miek.nl. 2311 IN A 127.0.0.1") // Weird TTL to avoid catching TTL
+	rr := testRR("miek.nl. 2311 IN A 127.0.0.1") // Weird TTL to avoid catching TTL
 	rr1 := Copy(rr)
 	if rr.String() != rr1.String() {
 		t.Fatalf("Copy() failed %s != %s", rr.String(), rr1.String())
@@ -402,9 +362,9 @@ func TestCopy(t *testing.T) {
 func TestMsgCopy(t *testing.T) {
 	m := new(Msg)
 	m.SetQuestion("miek.nl.", TypeA)
-	rr, _ := NewRR("miek.nl. 2311 IN A 127.0.0.1")
+	rr := testRR("miek.nl. 2311 IN A 127.0.0.1")
 	m.Answer = []RR{rr}
-	rr, _ = NewRR("miek.nl. 2311 IN NS 127.0.0.1")
+	rr = testRR("miek.nl. 2311 IN NS 127.0.0.1")
 	m.Ns = []RR{rr}
 
 	m1 := m.Copy()
@@ -412,12 +372,12 @@ func TestMsgCopy(t *testing.T) {
 		t.Fatalf("Msg.Copy() failed %s != %s", m.String(), m1.String())
 	}
 
-	m1.Answer[0], _ = NewRR("somethingelse.nl. 2311 IN A 127.0.0.1")
+	m1.Answer[0] = testRR("somethingelse.nl. 2311 IN A 127.0.0.1")
 	if m.String() == m1.String() {
 		t.Fatalf("Msg.Copy() failed; change to copy changed template %s", m.String())
 	}
 
-	rr, _ = NewRR("miek.nl. 2311 IN A 127.0.0.2")
+	rr = testRR("miek.nl. 2311 IN A 127.0.0.2")
 	m1.Answer = append(m1.Answer, rr)
 	if m1.Ns[0].String() == m1.Answer[1].String() {
 		t.Fatalf("Msg.Copy() failed; append changed underlying array %s", m1.Ns[0].String())

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -327,7 +327,7 @@ Created: 20110302104537
 Publish: 20110302104537
 Activate: 20110302104537`
 
-	xk, _ := NewRR(pub)
+	xk := testRR(pub)
 	k := xk.(*DNSKEY)
 	p, err := k.NewPrivateKey(priv)
 	if err != nil {
@@ -378,10 +378,7 @@ func TestSignVerifyECDSA(t *testing.T) {
 Algorithm: 14 (ECDSAP384SHA384)
 PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
 
-	eckey, err := NewRR(pub)
-	if err != nil {
-		t.Fatal(err)
-	}
+	eckey := testRR(pub)
 	privkey, err := eckey.(*DNSKEY).NewPrivateKey(priv)
 	if err != nil {
 		t.Fatal(err)
@@ -394,7 +391,7 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
 	if ds.Digest != "72d7b62976ce06438e9c0bf319013cf801f09ecc84b8d7e9495f27e305c6a9b0563a9b5f4d288405c3008a946df983d6" {
 		t.Fatal("wrong DS Digest")
 	}
-	a, _ := NewRR("www.example.net. 3600 IN A 192.0.2.1")
+	a := testRR("www.example.net. 3600 IN A 192.0.2.1")
 	sig := new(RRSIG)
 	sig.Hdr = RR_Header{"example.net.", TypeRRSIG, ClassINET, 14400, 0}
 	sig.Expiration, _ = StringToTime("20100909102025")
@@ -419,10 +416,7 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
 }
 
 func TestSignVerifyECDSA2(t *testing.T) {
-	srv1, err := NewRR("srv.miek.nl. IN SRV 1000 800 0 web1.miek.nl.")
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv1 := testRR("srv.miek.nl. IN SRV 1000 800 0 web1.miek.nl.")
 	srv := srv1.(*SRV)
 
 	// With this key
@@ -476,10 +470,7 @@ func TestRFC6605P256(t *testing.T) {
 	exPriv := `Private-key-format: v1.2
 Algorithm: 13 (ECDSAP256SHA256)
 PrivateKey: GU6SnQ/Ou+xC5RumuIUIuJZteXT2z0O/ok1s38Et6mQ=`
-	rrDNSKEY, err := NewRR(exDNSKEY)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rrDNSKEY := testRR(exDNSKEY)
 	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
 	if err != nil {
 		t.Fatal(err)
@@ -488,10 +479,7 @@ PrivateKey: GU6SnQ/Ou+xC5RumuIUIuJZteXT2z0O/ok1s38Et6mQ=`
 	exDS := `example.net. 3600 IN DS 55648 13 2 (
              b4c8c1fe2e7477127b27115656ad6256f424625bf5c1
              e2770ce6d6e37df61d17 )`
-	rrDS, err := NewRR(exDS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rrDS := testRR(exDS)
 	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA256)
 	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
 		t.Errorf("DS record differs:\n%v\n%v", ourDS, rrDS.(*DS))
@@ -502,15 +490,9 @@ PrivateKey: GU6SnQ/Ou+xC5RumuIUIuJZteXT2z0O/ok1s38Et6mQ=`
                 20100909100439 20100812100439 55648 example.net.
                 qx6wLYqmh+l9oCKTN6qIc+bw6ya+KJ8oMz0YP107epXA
                 yGmt+3SNruPFKG7tZoLBLlUzGGus7ZwmwWep666VCw== )`
-	rrA, err := NewRR(exA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rrRRSIG, err := NewRR(exRRSIG)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
+	rrA := testRR(exA)
+	rrRRSIG := testRR(exRRSIG)
+	if err := rrRRSIG.(*RRSIG).Verify(rrDNSKEY.(*DNSKEY), []RR{rrA}); err != nil {
 		t.Errorf("failure to validate the spec RRSIG: %v", err)
 	}
 
@@ -550,10 +532,7 @@ func TestRFC6605P384(t *testing.T) {
 	exPriv := `Private-key-format: v1.2
 Algorithm: 14 (ECDSAP384SHA384)
 PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
-	rrDNSKEY, err := NewRR(exDNSKEY)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rrDNSKEY := testRR(exDNSKEY)
 	priv, err := rrDNSKEY.(*DNSKEY).NewPrivateKey(exPriv)
 	if err != nil {
 		t.Fatal(err)
@@ -563,10 +542,7 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
            72d7b62976ce06438e9c0bf319013cf801f09ecc84b8
            d7e9495f27e305c6a9b0563a9b5f4d288405c3008a94
            6df983d6 )`
-	rrDS, err := NewRR(exDS)
-	if err != nil {
-		t.Fatal(err)
-	}
+	rrDS := testRR(exDS)
 	ourDS := rrDNSKEY.(*DNSKEY).ToDS(SHA384)
 	if !reflect.DeepEqual(ourDS, rrDS.(*DS)) {
 		t.Fatalf("DS record differs:\n%v\n%v", ourDS, rrDS.(*DS))
@@ -578,11 +554,8 @@ PrivateKey: WURgWHCcYIYUPWgeLmiPY2DJJk02vgrmTfitxgqcL4vwW7BOrbawVmVe0d9V94SR`
            /L5hDKIvGDyI1fcARX3z65qrmPsVz73QD1Mr5CEqOiLP
            95hxQouuroGCeZOvzFaxsT8Glr74hbavRKayJNuydCuz
            WTSSPdz7wnqXL5bdcJzusdnI0RSMROxxwGipWcJm )`
-	rrA, err := NewRR(exA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rrRRSIG, err := NewRR(exRRSIG)
+	rrA := testRR(exA)
+	rrRRSIG := testRR(exRRSIG)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -43,21 +43,20 @@ func AddOrigin(s, origin string) string {
 }
 
 // TrimDomainName trims origin from s if s is a subdomain.
-// This function will never return "", but returns "@" instead (@ represents the apex (bare) domain).
+// This function will never return "", but returns "@" instead (@ represents the apex domain).
 func TrimDomainName(s, origin string) string {
 	// An apex (bare) domain is always returned as "@".
 	// If the return value ends in a ".", the domain was not the suffix.
 	// origin can end in "." or not. Either way the results should be the same.
 
 	if len(s) == 0 {
-		return "@" // Return the apex (@) rather than "".
+		return "@"
 	}
 	// Someone is using TrimDomainName(s, ".") to remove a dot if it exists.
 	if origin == "." {
 		return strings.TrimSuffix(s, origin)
 	}
 
-	// Dude, you aren't even if the right subdomain!
 	if !dns.IsSubDomain(origin, s) {
 		return s
 	}

--- a/dnsutil/util_test.go
+++ b/dnsutil/util_test.go
@@ -32,10 +32,9 @@ func TestAddOrigin(t *testing.T) {
 }
 
 func TestTrimDomainName(t *testing.T) {
-
 	// Basic tests.
 	// Try trimming "example.com" and "example.com." from typical use cases.
-	var tests_examplecom = []struct{ experiment, expected string }{
+	testsEx := []struct{ experiment, expected string }{
 		{"foo.example.com", "foo"},
 		{"foo.example.com.", "foo"},
 		{".foo.example.com", ".foo"},
@@ -51,10 +50,10 @@ func TestTrimDomainName(t *testing.T) {
 		{".foo.ronco.com.", ".foo.ronco.com."},
 	}
 	for _, dom := range []string{"example.com", "example.com."} {
-		for i, test := range tests_examplecom {
+		for i, test := range testsEx {
 			actual := TrimDomainName(test.experiment, dom)
 			if test.expected != actual {
-				t.Errorf("%d TrimDomainName(%#v, %#v): expected (%v) got (%v)\n", i, test.experiment, dom, test.expected, actual)
+				t.Errorf("%d TrimDomainName(%#v, %#v): expected %v, got %v\n", i, test.experiment, dom, test.expected, actual)
 			}
 		}
 	}
@@ -63,7 +62,7 @@ func TestTrimDomainName(t *testing.T) {
 	// These test shouldn't be needed but I was weary of off-by-one errors.
 	// In theory, these can't happen because there are no single-letter TLDs,
 	// but it is good to exercize the code this way.
-	var tests = []struct{ experiment, expected string }{
+	tests := []struct{ experiment, expected string }{
 		{"", "@"},
 		{".", "."},
 		{"a.b.c.d.e.f.", "a.b.c.d.e"},
@@ -105,7 +104,7 @@ func TestTrimDomainName(t *testing.T) {
 		for i, test := range tests {
 			actual := TrimDomainName(test.experiment, dom)
 			if test.expected != actual {
-				t.Errorf("%d TrimDomainName(%#v, %#v): expected (%v) got (%v)\n", i, test.experiment, dom, test.expected, actual)
+				t.Errorf("%d TrimDomainName(%#v, %#v): expected %v, got %v\n", i, test.experiment, dom, test.expected, actual)
 			}
 		}
 	}
@@ -123,8 +122,7 @@ func TestTrimDomainName(t *testing.T) {
 	for i, test := range testsWild {
 		actual := TrimDomainName(test.e1, test.e2)
 		if test.expected != actual {
-			t.Errorf("%d TrimDomainName(%#v, %#v): expected (%v) got (%v)\n", i, test.e1, test.e2, test.expected, actual)
+			t.Errorf("%d TrimDomainName(%#v, %#v): expected %v, got %v\n", i, test.e1, test.e2, test.expected, actual)
 		}
 	}
-
 }

--- a/issue_test.go
+++ b/issue_test.go
@@ -26,10 +26,7 @@ func TestTCPRtt(t *testing.T) {
 }
 
 func TestNSEC3MissingSalt(t *testing.T) {
-	rr, err := NewRR("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 aabbccdd K8UDEMVP1J2F7EG6JEBPS17VP3N8I58H")
-	if err != nil {
-		t.Fatalf("failed to parse example rr: %s", err)
-	}
+	rr := testRR("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 aabbccdd K8UDEMVP1J2F7EG6JEBPS17VP3N8I58H")
 	m := new(Msg)
 	m.Answer = []RR{rr}
 	mb, err := m.Pack()
@@ -47,10 +44,7 @@ func TestNSEC3MissingSalt(t *testing.T) {
 }
 
 func TestNSEC3MixedNextDomain(t *testing.T) {
-	rr, err := NewRR("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 - k8udemvp1j2f7eg6jebps17vp3n8i58h")
-	if err != nil {
-		t.Fatalf("failed to parse example rr: %s", err)
-	}
+	rr := testRR("ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 - k8udemvp1j2f7eg6jebps17vp3n8i58h")
 	m := new(Msg)
 	m.Answer = []RR{rr}
 	mb, err := m.Pack()

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -15,7 +15,7 @@ func TestPackNsec3(t *testing.T) {
 }
 
 func TestNsec3(t *testing.T) {
-	nsec3, _ := NewRR("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
+	nsec3 := testRR("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
 	if !nsec3.(*NSEC3).Match("nl.") { // name hash = sk4e8fj94u78smusb40o1n0oltbblu2r
 		t.Fatal("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
 	}
@@ -28,7 +28,7 @@ func TestNsec3(t *testing.T) {
 	if nsec3.(*NSEC3).Match("test.nl.") { // name hash = gd0ptr5bnfpimpu2d3v6gd4n0bai7s0q
 		t.Fatal("gd0ptr5bnfpimpu2d3v6gd4n0bai7s0q.nl. should not match sk4e8fj94u78smusb40o1n0oltbblu2r.nl.")
 	}
-	nsec3, _ = NewRR("nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
+	nsec3 = testRR("nl. IN NSEC3 1 1 5 F10E9F7EA83FC8F3 SK4F38CQ0ATIEI8MH3RGD0P5I4II6QAN NS SOA TXT RRSIG DNSKEY NSEC3PARAM")
 	if nsec3.(*NSEC3).Match("nl.") {
 		t.Fatal("sk4e8fj94u78smusb40o1n0oltbblu2r.nl. should not match a record without a owner hash")
 	}

--- a/rr_test.go
+++ b/rr_test.go
@@ -1,0 +1,7 @@
+package dns
+
+// testRR returns the RR from string s. The error is thrown away.
+func testRR(s string) RR {
+	r, _ := NewRR(s)
+	return r
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -3,37 +3,36 @@ package dns
 import "testing"
 
 func TestDedup(t *testing.T) {
-	// make it []string
 	testcases := map[[3]RR][]string{
 		[...]RR{
-			newRR(t, "mIek.nl. IN A 127.0.0.1"),
-			newRR(t, "mieK.nl. IN A 127.0.0.1"),
-			newRR(t, "miek.Nl. IN A 127.0.0.1"),
+			testRR("mIek.nl. IN A 127.0.0.1"),
+			testRR("mieK.nl. IN A 127.0.0.1"),
+			testRR("miek.Nl. IN A 127.0.0.1"),
 		}: {"mIek.nl.\t3600\tIN\tA\t127.0.0.1"},
 		[...]RR{
-			newRR(t, "miEk.nl. 2000 IN A 127.0.0.1"),
-			newRR(t, "mieK.Nl. 1000 IN A 127.0.0.1"),
-			newRR(t, "Miek.nL. 500 IN A 127.0.0.1"),
+			testRR("miEk.nl. 2000 IN A 127.0.0.1"),
+			testRR("mieK.Nl. 1000 IN A 127.0.0.1"),
+			testRR("Miek.nL. 500 IN A 127.0.0.1"),
 		}: {"miEk.nl.\t500\tIN\tA\t127.0.0.1"},
 		[...]RR{
-			newRR(t, "miek.nl. IN A 127.0.0.1"),
-			newRR(t, "miek.nl. CH A 127.0.0.1"),
-			newRR(t, "miek.nl. IN A 127.0.0.1"),
+			testRR("miek.nl. IN A 127.0.0.1"),
+			testRR("miek.nl. CH A 127.0.0.1"),
+			testRR("miek.nl. IN A 127.0.0.1"),
 		}: {"miek.nl.\t3600\tIN\tA\t127.0.0.1",
 			"miek.nl.\t3600\tCH\tA\t127.0.0.1",
 		},
 		[...]RR{
-			newRR(t, "miek.nl. CH A 127.0.0.1"),
-			newRR(t, "miek.nl. IN A 127.0.0.1"),
-			newRR(t, "miek.de. IN A 127.0.0.1"),
+			testRR("miek.nl. CH A 127.0.0.1"),
+			testRR("miek.nl. IN A 127.0.0.1"),
+			testRR("miek.de. IN A 127.0.0.1"),
 		}: {"miek.nl.\t3600\tCH\tA\t127.0.0.1",
 			"miek.nl.\t3600\tIN\tA\t127.0.0.1",
 			"miek.de.\t3600\tIN\tA\t127.0.0.1",
 		},
 		[...]RR{
-			newRR(t, "miek.de. IN A 127.0.0.1"),
-			newRR(t, "miek.nl. 200 IN A 127.0.0.1"),
-			newRR(t, "miek.nl. 300 IN A 127.0.0.1"),
+			testRR("miek.de. IN A 127.0.0.1"),
+			testRR("miek.nl. 200 IN A 127.0.0.1"),
+			testRR("miek.nl. 300 IN A 127.0.0.1"),
 		}: {"miek.de.\t3600\tIN\tA\t127.0.0.1",
 			"miek.nl.\t200\tIN\tA\t127.0.0.1",
 		},
@@ -51,9 +50,9 @@ func TestDedup(t *testing.T) {
 
 func BenchmarkDedup(b *testing.B) {
 	rrs := []RR{
-		newRR(nil, "miEk.nl. 2000 IN A 127.0.0.1"),
-		newRR(nil, "mieK.Nl. 1000 IN A 127.0.0.1"),
-		newRR(nil, "Miek.nL. 500 IN A 127.0.0.1"),
+		testRR("miEk.nl. 2000 IN A 127.0.0.1"),
+		testRR("mieK.Nl. 1000 IN A 127.0.0.1"),
+		testRR("Miek.nL. 500 IN A 127.0.0.1"),
 	}
 	m := make(map[string]RR)
 	for i := 0; i < b.N; i++ {
@@ -63,9 +62,9 @@ func BenchmarkDedup(b *testing.B) {
 
 func TestNormalizedString(t *testing.T) {
 	tests := map[RR]string{
-		newRR(t, "mIEk.Nl. 3600 IN A 127.0.0.1"):     "miek.nl.\tIN\tA\t127.0.0.1",
-		newRR(t, "m\\ iek.nL. 3600 IN A 127.0.0.1"):  "m\\ iek.nl.\tIN\tA\t127.0.0.1",
-		newRR(t, "m\\\tIeK.nl. 3600 in A 127.0.0.1"): "m\\009iek.nl.\tIN\tA\t127.0.0.1",
+		testRR("mIEk.Nl. 3600 IN A 127.0.0.1"):     "miek.nl.\tIN\tA\t127.0.0.1",
+		testRR("m\\ iek.nL. 3600 IN A 127.0.0.1"):  "m\\ iek.nl.\tIN\tA\t127.0.0.1",
+		testRR("m\\\tIeK.nl. 3600 in A 127.0.0.1"): "m\\009iek.nl.\tIN\tA\t127.0.0.1",
 	}
 	for tc, expected := range tests {
 		n := normalizedString(tc)
@@ -73,12 +72,4 @@ func TestNormalizedString(t *testing.T) {
 			t.Errorf("expected %s, got %s", expected, n)
 		}
 	}
-}
-
-func newRR(t *testing.T, s string) RR {
-	r, err := NewRR(s)
-	if err != nil {
-		t.Errorf("newRR: %v", err)
-	}
-	return r
 }

--- a/server_test.go
+++ b/server_test.go
@@ -147,7 +147,7 @@ func TestServing(t *testing.T) {
 	defer HandleRemove("miek.nl.")
 	defer HandleRemove("example.com.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestServingTLS(t *testing.T) {
 		Certificates: []tls.Certificate{cert},
 	}
 
-	s, addrstr, err := RunLocalTLSServer("127.0.0.1:0", &config)
+	s, addrstr, err := RunLocalTLSServer(":0", &config)
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -253,7 +253,7 @@ func BenchmarkServe(b *testing.B) {
 	defer HandleRemove("miek.nl.")
 	a := runtime.GOMAXPROCS(4)
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		b.Fatalf("unable to run test server: %v", err)
 	}
@@ -306,7 +306,7 @@ func BenchmarkServeCompress(b *testing.B) {
 	HandleFunc("miek.nl.", HelloServerCompress)
 	defer HandleRemove("miek.nl.")
 	a := runtime.GOMAXPROCS(4)
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		b.Fatalf("unable to run test server: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestServingLargeResponses(t *testing.T) {
 	HandleFunc("example.", HelloServerLargeResponse)
 	defer HandleRemove("example.")
 
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestServingResponse(t *testing.T) {
 		t.Skip("skipping test in short mode.")
 	}
 	HandleFunc("miek.nl.", HelloServer)
-	s, addrstr, err := RunLocalUDPServer("127.0.0.1:0")
+	s, addrstr, err := RunLocalUDPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -467,7 +467,7 @@ func TestServingResponse(t *testing.T) {
 	}
 
 	s.Shutdown()
-	s, addrstr, err = RunLocalUDPServerUnsafe("127.0.0.1:0")
+	s, addrstr, err = RunLocalUDPServerUnsafe(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestServingResponse(t *testing.T) {
 }
 
 func TestShutdownTCP(t *testing.T) {
-	s, _, err := RunLocalTCPServer("127.0.0.1:0")
+	s, _, err := RunLocalTCPServer(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -501,7 +501,7 @@ func TestShutdownTLS(t *testing.T) {
 		Certificates: []tls.Certificate{cert},
 	}
 
-	s, _, err := RunLocalTLSServer("127.0.0.1:0", &config)
+	s, _, err := RunLocalTLSServer(":0", &config)
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -529,7 +529,7 @@ func (t *trigger) Get() bool {
 
 func TestHandlerCloseTCP(t *testing.T) {
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		panic(err)
 	}
@@ -569,7 +569,7 @@ func TestHandlerCloseTCP(t *testing.T) {
 }
 
 func TestShutdownUDP(t *testing.T) {
-	s, _, fin, err := RunLocalUDPServerWithFinChan("127.0.0.1:0")
+	s, _, fin, err := RunLocalUDPServerWithFinChan(":0")
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}
@@ -600,7 +600,7 @@ func ExampleDecorateWriter() {
 	})
 
 	// simple UDP server
-	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	pc, err := net.ListenPacket("udp", ":0")
 	if err != nil {
 		fmt.Println(err.Error())
 		return

--- a/update_test.go
+++ b/update_test.go
@@ -53,10 +53,7 @@ func TestDynamicUpdateZeroRdataUnpack(t *testing.T) {
 func TestRemoveRRset(t *testing.T) {
 	// Should add a zero data RR in Class ANY with a TTL of 0
 	// for each set mentioned in the RRs provided to it.
-	rr, err := NewRR(". 100 IN A 127.0.0.1")
-	if err != nil {
-		t.Fatalf("error constructing RR: %v", err)
-	}
+	rr := testRR(". 100 IN A 127.0.0.1")
 	m := new(Msg)
 	m.Ns = []RR{&RR_Header{Name: ".", Rrtype: TypeA, Class: ClassANY, Ttl: 0, Rdlength: 0}}
 	expectstr := m.String()
@@ -89,15 +86,15 @@ func TestPreReqAndRemovals(t *testing.T) {
 	m.Id = 1234
 
 	// Use a full set of RRs each time, so we are sure the rdata is stripped.
-	rrName1, _ := NewRR("name_used. 3600 IN A 127.0.0.1")
-	rrName2, _ := NewRR("name_not_used. 3600 IN A 127.0.0.1")
-	rrRemove1, _ := NewRR("remove1. 3600 IN A 127.0.0.1")
-	rrRemove2, _ := NewRR("remove2. 3600 IN A 127.0.0.1")
-	rrRemove3, _ := NewRR("remove3. 3600 IN A 127.0.0.1")
-	rrInsert, _ := NewRR("insert. 3600 IN A 127.0.0.1")
-	rrRrset1, _ := NewRR("rrset_used1. 3600 IN A 127.0.0.1")
-	rrRrset2, _ := NewRR("rrset_used2. 3600 IN A 127.0.0.1")
-	rrRrset3, _ := NewRR("rrset_not_used. 3600 IN A 127.0.0.1")
+	rrName1 := testRR("name_used. 3600 IN A 127.0.0.1")
+	rrName2 := testRR("name_not_used. 3600 IN A 127.0.0.1")
+	rrRemove1 := testRR("remove1. 3600 IN A 127.0.0.1")
+	rrRemove2 := testRR("remove2. 3600 IN A 127.0.0.1")
+	rrRemove3 := testRR("remove3. 3600 IN A 127.0.0.1")
+	rrInsert := testRR("insert. 3600 IN A 127.0.0.1")
+	rrRrset1 := testRR("rrset_used1. 3600 IN A 127.0.0.1")
+	rrRrset2 := testRR("rrset_used2. 3600 IN A 127.0.0.1")
+	rrRrset3 := testRR("rrset_not_used. 3600 IN A 127.0.0.1")
 
 	// Handle the prereqs.
 	m.NameUsed([]RR{rrName1})


### PR DESCRIPTION
Use :0 for loopback testing. This is more portable between testing environments.
Add testRR that calls NewRR and throws error away - apply it everywhere where needed.