### PR TITLE
util.TrimDomainName() fails when origin doesn't end in dot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,17 @@ go:
   - 1.9.x
   - tip
 
+env:
+  - TESTS="-race -v -bench=. -coverprofile=coverage.txt -covermode=atomic"
+  - TESTS="-race -v ./..."
+
 before_install:
   # don't use the miekg/dns when testing forks
   - mkdir -p $GOPATH/src/github.com/miekg
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
 
 script:
-  - go test -race -v -bench=. -coverprofile=coverage.txt -covermode=atomic
+  - go test $TESTS
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -57,8 +57,16 @@ func TrimDomainName(s, origin string) string {
 		return strings.TrimSuffix(s, origin)
 	}
 
+	//original_origin := origin
+	if !strings.HasSuffix(origin, ".") {
+		origin = origin + "."
+	}
+	original_s := s
+	if !strings.HasSuffix(s, ".") {
+		s = s + "."
+	}
 	if !dns.IsSubDomain(origin, s) {
-		return s
+		return original_s
 	}
 
 	slabels := dns.Split(s)

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -21,8 +21,8 @@ func AddOrigin(s, origin string) string {
 	// ("foo.", "origin.") -> "foo." (already a FQDN)
 	// ("foo", "origin.") -> "foo.origin."
 	// ("foo", "origin") -> "foo.origin"
-	// ("foo", ".") -> "foo."
-	// ("foo.", ".") -> "foo."
+	// ("foo", ".") -> "foo." (Same as dns.Fqdn())
+	// ("foo.", ".") -> "foo." (Same as dns.Fqdn())
 	// ("@", "origin.") -> "origin." (@ represents the apex (bare) domain)
 	// ("", "origin.") -> "origin." (not obvious)
 	// ("foo", "") -> "foo" (not obvious)
@@ -36,9 +36,8 @@ func AddOrigin(s, origin string) string {
 	if s == "@" || len(s) == 0 {
 		return origin // Expand apex.
 	}
-
 	if origin == "." {
-		return s + origin // AddOrigin(s, ".") is an easy way to add a "." without creating "..".
+		return dns.Fqdn(s)
 	}
 
 	return s + "." + origin // The simple case.
@@ -59,12 +58,12 @@ func TrimDomainName(s, origin string) string {
 		return strings.TrimSuffix(s, origin)
 	}
 
-	original_s := s
-	s = AddOrigin(s, ".")
-	origin = AddOrigin(origin, ".")
+	original := s
+	s = dns.Fqdn(s)
+	origin = dns.Fqdn(origin)
 
 	if !dns.IsSubDomain(origin, s) {
-		return original_s
+		return original
 	}
 
 	slabels := dns.Split(s)

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -20,7 +20,9 @@ import (
 func AddOrigin(s, origin string) string {
 	// ("foo.", "origin.") -> "foo." (already a FQDN)
 	// ("foo", "origin.") -> "foo.origin."
-	// ("foo"), "origin" -> "foo.origin"
+	// ("foo", "origin") -> "foo.origin"
+	// ("foo", ".") -> "foo."
+	// ("foo.", ".") -> "foo."
 	// ("@", "origin.") -> "origin." (@ represents the apex (bare) domain)
 	// ("", "origin.") -> "origin." (not obvious)
 	// ("foo", "") -> "foo" (not obvious)
@@ -36,7 +38,7 @@ func AddOrigin(s, origin string) string {
 	}
 
 	if origin == "." {
-		return s + origin // AddOrigin(s, ".") is an expensive way to add a ".".
+		return s + origin // AddOrigin(s, ".") is an easy way to add a "." without creating "..".
 	}
 
 	return s + "." + origin // The simple case.
@@ -57,13 +59,10 @@ func TrimDomainName(s, origin string) string {
 		return strings.TrimSuffix(s, origin)
 	}
 
-	if !strings.HasSuffix(origin, ".") {
-		origin = origin + "."
-	}
 	original_s := s
-	if !strings.HasSuffix(s, ".") {
-		s = s + "."
-	}
+	s = AddOrigin(s, ".")
+	origin = AddOrigin(origin, ".")
+
 	if !dns.IsSubDomain(origin, s) {
 		return original_s
 	}

--- a/dnsutil/util.go
+++ b/dnsutil/util.go
@@ -57,7 +57,6 @@ func TrimDomainName(s, origin string) string {
 		return strings.TrimSuffix(s, origin)
 	}
 
-	//original_origin := origin
 	if !strings.HasSuffix(origin, ".") {
 		origin = origin + "."
 	}

--- a/dnsutil/util_test.go
+++ b/dnsutil/util_test.go
@@ -28,7 +28,7 @@ func TestAddOrigin(t *testing.T) {
 	for _, test := range tests {
 		actual := AddOrigin(test.e1, test.e2)
 		if test.expected != actual {
-			t.Errorf("AddOrigin(%#v, %#v) expected %#v, go %#v\n", test.e1, test.e2, test.expected, actual)
+			t.Errorf("AddOrigin(%#v, %#v) expected %#v, got %#v\n", test.e1, test.e2, test.expected, actual)
 		}
 	}
 }

--- a/dnsutil/util_test.go
+++ b/dnsutil/util_test.go
@@ -10,6 +10,8 @@ func TestAddOrigin(t *testing.T) {
 		{"@", "example.com.", "example.com."},
 		{"foo", "example.com.", "foo.example.com."},
 		{"foo.", "example.com.", "foo."},
+		{"example.com", ".", "example.com."},
+		{"example.com.", ".", "example.com."},
 		// Oddball tests:
 		// In general origin should not be "" or "." but at least
 		// these tests verify we don't crash and will keep results


### PR DESCRIPTION
Fixes https://github.com/miekg/dns/issues/555