### PR TITLE
Server: drop inflight waitgroup

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -525,7 +525,7 @@ func TestTimeout(t *testing.T) {
 	length := time.Since(start)
 
 	if length > allowable {
-		t.Errorf("exchange took longer (%v) than specified Timeout (%v)", length, timeout)
+		t.Errorf("exchange took longer %v than specified Timeout %v", length, allowable)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -297,10 +297,7 @@ type Server struct {
 	// DecorateWriter is optional, allows customization of the process that writes raw DNS messages.
 	DecorateWriter DecorateWriter
 
-	// Graceful shutdown handling
-
-	inFlight sync.WaitGroup
-
+	// Shutdown handling
 	lock    sync.RWMutex
 	started bool
 }
@@ -412,10 +409,9 @@ func (srv *Server) ActivateAndServe() error {
 	return &Error{err: "bad listeners"}
 }
 
-// Shutdown gracefully shuts down a server. After a call to Shutdown, ListenAndServe and
-// ActivateAndServe will return. All in progress queries are completed before the server
-// is taken down. If the Shutdown is taking longer than the reading timeout an error
-// is returned.
+// Shutdown shuts down a server. After a call to Shutdown, ListenAndServe and
+// ActivateAndServe will return. If the Shutdown is taking longer than the
+// reading timeout an error is returned.
 func (srv *Server) Shutdown() error {
 	srv.lock.Lock()
 	if !srv.started {
@@ -434,7 +430,6 @@ func (srv *Server) Shutdown() error {
 
 	fin := make(chan bool)
 	go func() {
-		srv.inFlight.Wait()
 		fin <- true
 	}()
 
@@ -493,7 +488,6 @@ func (srv *Server) serveTCP(l net.Listener) error {
 		if err != nil {
 			continue
 		}
-		srv.inFlight.Add(1)
 		go srv.serve(rw.RemoteAddr(), handler, m, nil, nil, rw)
 	}
 }
@@ -529,15 +523,12 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 		if err != nil {
 			continue
 		}
-		srv.inFlight.Add(1)
 		go srv.serve(s.RemoteAddr(), handler, m, l, s, nil)
 	}
 }
 
 // Serve a new connection.
 func (srv *Server) serve(a net.Addr, h Handler, m []byte, u *net.UDPConn, s *SessionUDP, t net.Conn) {
-	defer srv.inFlight.Done()
-
 	w := &response{tsigSecret: srv.TsigSecret, udp: u, tcp: t, remoteAddr: a, udpSession: s}
 	if srv.DecorateWriter != nil {
 		w.writer = srv.DecorateWriter(w)

--- a/server.go
+++ b/server.go
@@ -410,8 +410,7 @@ func (srv *Server) ActivateAndServe() error {
 }
 
 // Shutdown shuts down a server. After a call to Shutdown, ListenAndServe and
-// ActivateAndServe will return. If the Shutdown is taking longer than the
-// reading timeout an error is returned.
+// ActivateAndServe will return.
 func (srv *Server) Shutdown() error {
 	srv.lock.Lock()
 	if !srv.started {
@@ -426,18 +425,6 @@ func (srv *Server) Shutdown() error {
 	}
 	if srv.Listener != nil {
 		srv.Listener.Close()
-	}
-
-	fin := make(chan bool)
-	go func() {
-		fin <- true
-	}()
-
-	select {
-	case <-time.After(srv.getReadTimeout()):
-		return &Error{err: "server shutdown is pending"}
-	case <-fin:
-		return nil
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -426,6 +426,7 @@ func (srv *Server) Shutdown() error {
 	if srv.Listener != nil {
 		srv.Listener.Close()
 	}
+	return nil
 }
 
 // getReadTimeout is a helper func to use system timeout if server did not intend to change it.

--- a/server_test.go
+++ b/server_test.go
@@ -584,6 +584,22 @@ func TestShutdownUDP(t *testing.T) {
 	}
 }
 
+func TestServerStartStopRace(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		var err error
+		s := &Server{}
+		s, _, _, err = RunLocalUDPServerWithFinChan(":0")
+		if err != nil {
+			t.Fatalf("Could not start server: %s", err)
+		}
+		go func() {
+			if err := s.Shutdown(); err != nil {
+				t.Fatalf("Could not stop server: %s", err)
+			}
+		}()
+	}
+}
+
 type ExampleFrameLengthWriter struct {
 	Writer
 }


### PR DESCRIPTION
This drops the waitgroup in Server, the suspicion is this can make the server
fail to stop; doing this make graceful shutdown not work.

Add test that tries to find a race between starting on stopping race;
there was a data race on srv.Inflight.

The coredns' TestReadme doesn't race anymore with this as it did with
the more evasive PR #546.