### PR TITLE
Fix go-routine leak

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -174,15 +174,19 @@ func parseZoneHelper(r io.Reader, origin string, defttl *ttlState, file string, 
 }
 
 func parseZone(r io.Reader, origin string, defttl *ttlState, f string, t chan *Token, include int) {
+	s := scanInit(r)
+	c := make(chan lex)
+
 	defer func() {
 		if include == 0 {
 			close(t)
 		}
+		s.setErr(true)
 	}()
-	s := scanInit(r)
-	c := make(chan lex)
+
 	// Start the lexer
 	go zlexer(s, c)
+
 	// 6 possible beginnings of a line, _ is a space
 	// 0. zRRTYPE                              -> all omitted until the rrtype
 	// 1. zOwner _ zRrtype                     -> class/ttl omitted


### PR DESCRIPTION
When and higher level (grammar or syntax) error was encountered when
parsing records from strings the routine would return, but the openend
channel would be left open and no other error would be triggered; this
means the goroutine starting z.lexer would be left hanging.

The fix is a bit of a hack; as we signal the upper error back down via
s.e and the trigger an "error" in the lexer, this at least ensure the
z.lexer function return and cleans up the goroutine.

Fixes #586
Fixes https://github.com/coredns/coredns/issues/1233