### PR TITLE
cleanup: remove debug.Printf from scanner

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1413,6 +1413,6 @@ func TestUnbalancedParens(t *testing.T) {
               x8A4M3e23mRZ9VrbpMngwcrqNAg== )`
 	_, err := NewRR(sig)
 	if err == nil {
-		t.Fatalf("Failed to detect extra opening brace")
+		t.Fatalf("failed to detect extra opening brace")
 	}
 }

--- a/server_test.go
+++ b/server_test.go
@@ -654,11 +654,11 @@ func TestServerStartStopRace(t *testing.T) {
 		s := &Server{}
 		s, _, _, err = RunLocalUDPServerWithFinChan(":0")
 		if err != nil {
-			t.Fatalf("Could not start server: %s", err)
+			t.Fatalf("could not start server: %s", err)
 		}
 		go func() {
 			if err := s.Shutdown(); err != nil {
-				t.Fatalf("Could not stop server: %s", err)
+				t.Fatalf("could not stop server: %s", err)
 			}
 		}()
 	}


### PR DESCRIPTION
Remove the debug.Printf stuff from scanner and some other style nits.