### PR TITLE
Implement CSYNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 6975 - Algorithm Understanding in DNSSEC
 * 7043 - EUI48/EUI64 records
 * 7314 - DNS (EDNS) EXPIRE Option
+* 7477 - CSYNC RR
 * 7828 - edns-tcp-keepalive EDNS0 Option
 * 7553 - URI record
 * 7858 - DNS over TLS: Initiation and Performance Considerations

--- a/parse_test.go
+++ b/parse_test.go
@@ -1406,6 +1406,22 @@ func TestParseAVC(t *testing.T) {
 	}
 }
 
+func TestParseCSYNC(t *testing.T) {
+	syncs := map[string]string{
+		`example.com. 3600 IN CSYNC 66 3 A NS AAAA`: `example.com.	3600	IN	CSYNC	66 3 A NS AAAA`,
+	}
+	for s, o := range syncs {
+		rr, err := NewRR(s)
+		if err != nil {
+			t.Error("failed to parse RR: ", err)
+			continue
+		}
+		if rr.String() != o {
+			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'", s, o, rr.String())
+		}
+	}
+}
+
 func TestParseBadNAPTR(t *testing.T) {
 	// Should look like: mplus.ims.vodafone.com.	3600	IN	NAPTR	10 100 "S" "SIP+D2U" "" _sip._udp.mplus.ims.vodafone.com.
 	naptr := `mplus.ims.vodafone.com.	3600	IN	NAPTR	10 100 S SIP+D2U  _sip._udp.mplus.ims.vodafone.com.`

--- a/types.go
+++ b/types.go
@@ -78,6 +78,7 @@ const (
 	TypeCDS        uint16 = 59
 	TypeCDNSKEY    uint16 = 60
 	TypeOPENPGPKEY uint16 = 61
+	TypeCSYNC      uint16 = 62
 	TypeSPF        uint16 = 99
 	TypeUINFO      uint16 = 100
 	TypeUID        uint16 = 101
@@ -1266,6 +1267,36 @@ type OPENPGPKEY struct {
 }
 
 func (rr *OPENPGPKEY) String() string { return rr.Hdr.String() + rr.PublicKey }
+
+// CSYNC RR. See RFC 7477.
+type CSYNC struct {
+	Hdr        RR_Header
+	Serial     uint32
+	Flags      uint16
+	TypeBitMap []uint16 `dns:"nsec"`
+}
+
+func (rr *CSYNC) String() string {
+	s := rr.Hdr.String() + strconv.FormatInt(int64(rr.Serial), 10) + " " + strconv.Itoa(int(rr.Flags))
+
+	for i := 0; i < len(rr.TypeBitMap); i++ {
+		s += " " + Type(rr.TypeBitMap[i]).String()
+	}
+	return s
+}
+
+func (rr *CSYNC) len() int {
+	l := rr.Hdr.len() + 4 + 2
+	lastwindow := uint32(2 ^ 32 + 1)
+	for _, t := range rr.TypeBitMap {
+		window := t / 256
+		if uint32(window) != lastwindow {
+			l += 1 + 32
+		}
+		lastwindow = uint32(window)
+	}
+	return l
+}
 
 // TimeToString translates the RRSIG's incep. and expir. times to the
 // string representation used when printing the record.

--- a/types_generate.go
+++ b/types_generate.go
@@ -23,6 +23,7 @@ var skipLen = map[string]struct{}{
 	"NSEC":  {},
 	"NSEC3": {},
 	"OPT":   {},
+	"CSYNC": {},
 }
 
 var packageHdr = `

--- a/ztypes.go
+++ b/ztypes.go
@@ -20,6 +20,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeCDS:        func() RR { return new(CDS) },
 	TypeCERT:       func() RR { return new(CERT) },
 	TypeCNAME:      func() RR { return new(CNAME) },
+	TypeCSYNC:      func() RR { return new(CSYNC) },
 	TypeDHCID:      func() RR { return new(DHCID) },
 	TypeDLV:        func() RR { return new(DLV) },
 	TypeDNAME:      func() RR { return new(DNAME) },
@@ -94,6 +95,7 @@ var TypeToString = map[uint16]string{
 	TypeCDS:        "CDS",
 	TypeCERT:       "CERT",
 	TypeCNAME:      "CNAME",
+	TypeCSYNC:      "CSYNC",
 	TypeDHCID:      "DHCID",
 	TypeDLV:        "DLV",
 	TypeDNAME:      "DNAME",
@@ -173,6 +175,7 @@ func (rr *CDNSKEY) Header() *RR_Header    { return &rr.Hdr }
 func (rr *CDS) Header() *RR_Header        { return &rr.Hdr }
 func (rr *CERT) Header() *RR_Header       { return &rr.Hdr }
 func (rr *CNAME) Header() *RR_Header      { return &rr.Hdr }
+func (rr *CSYNC) Header() *RR_Header      { return &rr.Hdr }
 func (rr *DHCID) Header() *RR_Header      { return &rr.Hdr }
 func (rr *DLV) Header() *RR_Header        { return &rr.Hdr }
 func (rr *DNAME) Header() *RR_Header      { return &rr.Hdr }
@@ -671,6 +674,11 @@ func (rr *CERT) copy() RR {
 }
 func (rr *CNAME) copy() RR {
 	return &CNAME{*rr.Hdr.copyHeader(), rr.Target}
+}
+func (rr *CSYNC) copy() RR {
+	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
+	copy(TypeBitMap, rr.TypeBitMap)
+	return &CSYNC{*rr.Hdr.copyHeader(), rr.Serial, rr.Flags, TypeBitMap}
 }
 func (rr *DHCID) copy() RR {
 	return &DHCID{*rr.Hdr.copyHeader(), rr.Digest}


### PR DESCRIPTION
Implement the CSYNC record.

Fixes #290

Long overdue, lets add this record. Similar in vain as NSEC/NSEC3, we
need to implement len() our selves. Presentation format parsing and
tests are done as well.

This is CoreDNS running with CSYNC support, `dig` doesn't support this
at the moment, so:

~~~
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 40323
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 2, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;csync.example.org.		IN	TYPE62

;; ANSWER SECTION:
csync.example.org.	10	IN	TYPE62	\# 12 000335240042000460000008

;; AUTHORITY SECTION:
example.org.		10	IN	NS	a.iana-servers.net.
example.org.		10	IN	NS	b.iana-servers.net.
~~~