### PR TITLE
Modified clientconfig to match ndots0

### DIFF
--- a/clientconfig.go
+++ b/clientconfig.go
@@ -79,8 +79,10 @@ func ClientConfigFromReader(resolvconf io.Reader) (*ClientConfig, error) {
 				switch {
 				case len(s) >= 6 && s[:6] == "ndots:":
 					n, _ := strconv.Atoi(s[6:])
-					if n < 1 {
-						n = 1
+					if n < 0 {
+						n = 0
+					} else if n > 15 {
+						n = 15
 					}
 					c.Ndots = n
 				case len(s) >= 8 && s[:8] == "timeout:":

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -48,6 +48,14 @@ nameserver 11.28.10.1
 options ndots:16
 `
 
+const normalWithNdotsBelow0 string = `
+# Comment
+domain somedomain.com
+nameserver 10.28.10.2
+nameserver 11.28.10.1
+options ndots:-1
+`
+
 func testConfig(t *testing.T, data string, expectedNdots int) {
 	cc, err := ClientConfigFromReader(strings.NewReader(data))
 	if err != nil {
@@ -74,6 +82,7 @@ func TestWithOutNdots(t *testing.T)        { testConfig(t, normalWithOutNdots, 1
 func TestNdots0(t *testing.T)              { testConfig(t, normalWithNdots0, 0) }
 func TestNdots15(t *testing.T)             { testConfig(t, normalWithNdots15, 15) }
 func TestNdots16(t *testing.T)             { testConfig(t, normalWithNdots16, 15) }
+func TestNdotsBelow0(t *testing.T)         { testConfig(t, normalWithNdotsBelow0, 0) }
 
 func TestReadFromFile(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "")

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -20,43 +20,7 @@ domain somedomain.com
 nameserver 10.28.10.2
 nameserver 11.28.10.1` // <- NOTE: NO newline.
 
-const normalWithOutNdots string = `
-# Comment
-domain somedomain.com
-nameserver 10.28.10.2
-nameserver 11.28.10.1
-`
-const normalWithNdots0 string = `
-# Comment
-domain somedomain.com
-nameserver 10.28.10.2
-nameserver 11.28.10.1
-options ndots:0
-`
-const normalWithNdots15 string = `
-# Comment
-domain somedomain.com
-nameserver 10.28.10.2
-nameserver 11.28.10.1
-options ndots:15
-`
-const normalWithNdots16 string = `
-# Comment
-domain somedomain.com
-nameserver 10.28.10.2
-nameserver 11.28.10.1
-options ndots:16
-`
-
-const normalWithNdotsBelow0 string = `
-# Comment
-domain somedomain.com
-nameserver 10.28.10.2
-nameserver 11.28.10.1
-options ndots:-1
-`
-
-func testConfig(t *testing.T, data string, expectedNdots int) {
+func testConfig(t *testing.T, data string) {
 	cc, err := ClientConfigFromReader(strings.NewReader(data))
 	if err != nil {
 		t.Errorf("error parsing resolv.conf: %v", err)
@@ -71,18 +35,35 @@ func testConfig(t *testing.T, data string, expectedNdots int) {
 			t.Errorf("domain is unexpected: %v", cc.Search[0])
 		}
 	}
+}
+
+func TestNameserver(t *testing.T)          { testConfig(t, normal) }
+func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline) }
+
+func testNdotsConfig(t *testing.T, data string, expectedNdots int) {
+	cc, err := ClientConfigFromReader(strings.NewReader(data))
+	if err != nil {
+		t.Errorf("error parsing resolv.conf: %v", err)
+	}
 	if cc.Ndots != expectedNdots {
 		t.Errorf("Ndots not properly parsed: (Expected: %d / Was: %d)", expectedNdots, cc.Ndots)
 	}
 }
 
-func TestNameserver(t *testing.T)          { testConfig(t, normal, 1) }
-func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline, 1) }
-func TestWithOutNdots(t *testing.T)        { testConfig(t, normalWithOutNdots, 1) }
-func TestNdots0(t *testing.T)              { testConfig(t, normalWithNdots0, 0) }
-func TestNdots15(t *testing.T)             { testConfig(t, normalWithNdots15, 15) }
-func TestNdots16(t *testing.T)             { testConfig(t, normalWithNdots16, 15) }
-func TestNdotsBelow0(t *testing.T)         { testConfig(t, normalWithNdotsBelow0, 0) }
+func TestNdots(t *testing.T) {
+	var ndotsVariants map[string]int = make(map[string]int)
+	ndotsVariants["options ndots:0"] = 0
+	ndotsVariants["options ndots:1"] = 1
+	ndotsVariants["options ndots:15"] = 15
+	ndotsVariants["options ndots:16"] = 15
+	ndotsVariants["options ndots:-1"] = 0
+	ndotsVariants[""] = 1
+
+	for key := range ndotsVariants {
+		testNdotsConfig(t, key, ndotsVariants[key])
+	}
+
+}
 
 func TestReadFromFile(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "")

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -15,38 +15,10 @@ nameserver 10.28.10.2
 nameserver 11.28.10.1
 `
 
-const normalWNdots string = `
-# Comment
-domain somedomain.com
-nameserver 10.28.10.2
-nameserver 11.28.10.1
-options ndots0
-`
-
 const missingNewline string = `
 domain somedomain.com
 nameserver 10.28.10.2
 nameserver 11.28.10.1` // <- NOTE: NO newline.
-
-func testConfig(t *testing.T, data string) {
-	cc, err := ClientConfigFromReader(strings.NewReader(data))
-	if err != nil {
-		t.Errorf("error parsing resolv.conf: %v", err)
-	}
-	if l := len(cc.Servers); l != 2 {
-		t.Errorf("incorrect number of nameservers detected: %d", l)
-	}
-	if l := len(cc.Search); l != 1 {
-		t.Errorf("domain directive not parsed correctly: %v", cc.Search)
-	} else {
-		if cc.Search[0] != "somedomain.com" {
-			t.Errorf("domain is unexpected: %v", cc.Search[0])
-		}
-	}
-}
-
-func TestNameserver(t *testing.T)          { testConfig(t, normal) }
-func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline) }
 
 const normalWithOutNdots string = `
 # Comment
@@ -76,7 +48,7 @@ nameserver 11.28.10.1
 options ndots:16
 `
 
-func testConfigWithNdots(t *testing.T, data string, expectedNdots int) {
+func testConfig(t *testing.T, data string, expectedNdots int) {
 	cc, err := ClientConfigFromReader(strings.NewReader(data))
 	if err != nil {
 		t.Errorf("error parsing resolv.conf: %v", err)
@@ -96,10 +68,12 @@ func testConfigWithNdots(t *testing.T, data string, expectedNdots int) {
 	}
 }
 
-func TestWithOutNdots(t *testing.T) { testConfigWithNdots(t, normalWithOutNdots, 1) }
-func TestNdots0(t *testing.T)       { testConfigWithNdots(t, normalWithNdots0, 0) }
-func TestNdots15(t *testing.T)      { testConfigWithNdots(t, normalWithNdots15, 15) }
-func TestNdots16(t *testing.T)      { testConfigWithNdots(t, normalWithNdots16, 15) }
+func TestNameserver(t *testing.T)          { testConfig(t, normal, 1) }
+func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline, 1) }
+func TestWithOutNdots(t *testing.T)        { testConfig(t, normalWithOutNdots, 1) }
+func TestNdots0(t *testing.T)              { testConfig(t, normalWithNdots0, 0) }
+func TestNdots15(t *testing.T)             { testConfig(t, normalWithNdots15, 15) }
+func TestNdots16(t *testing.T)             { testConfig(t, normalWithNdots16, 15) }
 
 func TestReadFromFile(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", "")

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -40,27 +40,24 @@ func testConfig(t *testing.T, data string) {
 func TestNameserver(t *testing.T)          { testConfig(t, normal) }
 func TestMissingFinalNewLine(t *testing.T) { testConfig(t, missingNewline) }
 
-func testNdotsConfig(t *testing.T, data string, expectedNdots int) {
-	cc, err := ClientConfigFromReader(strings.NewReader(data))
-	if err != nil {
-		t.Errorf("error parsing resolv.conf: %v", err)
-	}
-	if cc.Ndots != expectedNdots {
-		t.Errorf("Ndots not properly parsed: (Expected: %d / Was: %d)", expectedNdots, cc.Ndots)
-	}
-}
-
 func TestNdots(t *testing.T) {
-	var ndotsVariants map[string]int = make(map[string]int)
-	ndotsVariants["options ndots:0"] = 0
-	ndotsVariants["options ndots:1"] = 1
-	ndotsVariants["options ndots:15"] = 15
-	ndotsVariants["options ndots:16"] = 15
-	ndotsVariants["options ndots:-1"] = 0
-	ndotsVariants[""] = 1
+	ndotsVariants := map[string]int{
+		"options ndots:0":  0,
+		"options ndots:1":  1,
+		"options ndots:15": 15,
+		"options ndots:16": 15,
+		"options ndots:-1": 0,
+		"":                 1,
+	}
 
-	for key := range ndotsVariants {
-		testNdotsConfig(t, key, ndotsVariants[key])
+	for data := range ndotsVariants {
+		cc, err := ClientConfigFromReader(strings.NewReader(data))
+		if err != nil {
+			t.Errorf("error parsing resolv.conf: %v", err)
+		}
+		if cc.Ndots != ndotsVariants[data] {
+			t.Errorf("Ndots not properly parsed: (Expected: %d / Was: %d)", ndotsVariants[data], cc.Ndots)
+		}
 	}
 
 }
@@ -92,7 +89,7 @@ func TestReadFromFile(t *testing.T) {
 	}
 }
 
-func TestNameList_Ndots1(t *testing.T) {
+func TestNameListNdots1(t *testing.T) {
 	cfg := ClientConfig{
 		Ndots: 1,
 	}
@@ -117,7 +114,7 @@ func TestNameList_Ndots1(t *testing.T) {
 		t.Errorf("NameList didn't return search last: %v", names[1])
 	}
 }
-func TestNameList_Ndots2(t *testing.T) {
+func TestNameListNdots2(t *testing.T) {
 	cfg := ClientConfig{
 		Ndots: 2,
 	}
@@ -137,7 +134,7 @@ func TestNameList_Ndots2(t *testing.T) {
 	}
 }
 
-func TestNameList_Ndots0(t *testing.T) {
+func TestNameListNdots0(t *testing.T) {
 	cfg := ClientConfig{
 		Ndots: 0,
 	}

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -67,7 +67,7 @@ func TestReadFromFile(t *testing.T) {
 	}
 }
 
-func TestNameList(t *testing.T) {
+func TestNameList_Ndots1(t *testing.T) {
 	cfg := ClientConfig{
 		Ndots: 1,
 	}
@@ -91,15 +91,41 @@ func TestNameList(t *testing.T) {
 	} else if names[1] != "miek.nl.test." {
 		t.Errorf("NameList didn't return search last: %v", names[1])
 	}
+}
+func TestNameList_Ndots2(t *testing.T) {
+	cfg := ClientConfig{
+		Ndots: 2,
+	}
 
-	cfg.Ndots = 2
 	// Sent domain has less than NDots and search
-	names = cfg.NameList("miek.nl")
+	cfg.Search = []string{
+		"test",
+	}
+	names := cfg.NameList("miek.nl")
+
 	if len(names) != 2 {
 		t.Errorf("NameList returned != 2 names: %v", names)
 	} else if names[0] != "miek.nl.test." {
 		t.Errorf("NameList didn't return search first: %v", names[0])
 	} else if names[1] != "miek.nl." {
+		t.Errorf("NameList didn't return sent domain last: %v", names[1])
+	}
+}
+
+func TestNameList_Ndots0(t *testing.T) {
+	cfg := ClientConfig{
+		Ndots: 0,
+	}
+	cfg.Search = []string{
+		"test",
+	}
+	// Sent domain has less than NDots and search
+	names := cfg.NameList("miek")
+	if len(names) != 2 {
+		t.Errorf("NameList returned != 2 names: %v", names)
+	} else if names[0] != "miek." {
+		t.Errorf("NameList didn't return search first: %v", names[0])
+	} else if names[1] != "miek.test." {
 		t.Errorf("NameList didn't return sent domain last: %v", names[1])
 	}
 }


### PR DESCRIPTION
My modifications expect that the order of NameList matches the order of requests to dns
miekg. miekg.test. 
will be queried in exact this order.

miekg should be queried before miekg.test. so the dns has got the capability to give an answer to this (as docker in swarm mode does)
