### PR TITLE
Provide configured string in callback function

### DIFF
--- a/server.go
+++ b/server.go
@@ -63,12 +63,12 @@ type response struct {
 // is also registered), otherwise the child gets the query.
 // ServeMux is also safe for concurrent access from multiple goroutines.
 type ServeMux struct {
-	z map[string]Handler
+	z map[string]interface{}
 	m *sync.RWMutex
 }
 
 // NewServeMux allocates and returns a new ServeMux.
-func NewServeMux() *ServeMux { return &ServeMux{z: make(map[string]Handler), m: new(sync.RWMutex)} }
+func NewServeMux() *ServeMux { return &ServeMux{z: make(map[string]interface{}), m: new(sync.RWMutex)} }
 
 // DefaultServeMux is the default ServeMux used by Serve.
 var DefaultServeMux = NewServeMux()
@@ -84,6 +84,14 @@ func (f HandlerFunc) ServeDNS(w ResponseWriter, r *Msg) {
 	f(w, r)
 }
 
+type CallbackContext struct {
+	w ResponseWriter
+	r *Msg
+	pattern string
+}
+
+type HandlerContext func(*CallbackContext)
+
 // HandleFailed returns a HandlerFunc that returns SERVFAIL for every request it gets.
 func HandleFailed(w ResponseWriter, r *Msg) {
 	m := new(Msg)
@@ -91,8 +99,6 @@ func HandleFailed(w ResponseWriter, r *Msg) {
 	// does not matter if this write fails
 	w.WriteMsg(m)
 }
-
-func failedHandler() Handler { return HandlerFunc(HandleFailed) }
 
 // ListenAndServe Starts a server on address and network specified Invoke handler
 // for incoming queries.
@@ -132,10 +138,10 @@ func ActivateAndServe(l net.Listener, p net.PacketConn, handler Handler) error {
 	return server.ActivateAndServe()
 }
 
-func (mux *ServeMux) match(q string, t uint16) Handler {
+func (mux *ServeMux) match(q string, t uint16) (interface{}, string) {
 	mux.m.RLock()
 	defer mux.m.RUnlock()
-	var handler Handler
+	var handler interface{}
 	b := make([]byte, len(q)) // worst case, one label of length q
 	off := 0
 	end := false
@@ -149,7 +155,7 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 		}
 		if h, ok := mux.z[string(b[:l])]; ok { // causes garbage, might want to change the map key
 			if t != TypeDS {
-				return h
+				return h, string(b[:l])
 			}
 			// Continue for DS to see if we have a parent too, if so delegeate to the parent
 			handler = h
@@ -161,13 +167,13 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 	}
 	// Wildcard match, if we have found nothing try the root zone as a last resort.
 	if h, ok := mux.z["."]; ok {
-		return h
+		return h, "."
 	}
-	return handler
+	return handler, ""
 }
 
 // Handle adds a handler to the ServeMux for pattern.
-func (mux *ServeMux) Handle(pattern string, handler Handler) {
+func (mux *ServeMux) Handle(pattern string, handler interface{}) {
 	if pattern == "" {
 		panic("dns: invalid pattern " + pattern)
 	}
@@ -177,8 +183,8 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 }
 
 // HandleFunc adds a handler function to the ServeMux for pattern.
-func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
-	mux.Handle(pattern, HandlerFunc(handler))
+func (mux *ServeMux) HandleFunc(pattern string, handler interface{}) {
+	mux.Handle(pattern, handler)
 }
 
 // HandleRemove deregistrars the handler specific for pattern from the ServeMux.
@@ -199,15 +205,18 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 // If the request message does not have exactly one question in the
 // question section a SERVFAIL is returned, unlesss Unsafe is true.
 func (mux *ServeMux) ServeDNS(w ResponseWriter, request *Msg) {
-	var h Handler
-	if len(request.Question) < 1 { // allow more than one question
-		h = failedHandler()
-	} else {
-		if h = mux.match(request.Question[0].Name, request.Question[0].Qtype); h == nil {
-			h = failedHandler()
-		}
+	var h interface{}
+	var matched string
+	if len(request.Question) >= 1 { // make sure there is more than one question
+		h, matched = mux.match(request.Question[0].Name, request.Question[0].Qtype)
 	}
-	h.ServeDNS(w, request)
+	if handler, ok := h.(HandlerFunc); ok {
+		handler.ServeDNS(w, request)
+	} else if handler, ok := h.(HandlerContext); ok {
+		handler(&CallbackContext{w: w, r: request, pattern: matched})
+	} else {
+		HandleFailed(w, request)
+	}
 }
 
 // Handle registers the handler with the given pattern
@@ -221,7 +230,7 @@ func HandleRemove(pattern string) { DefaultServeMux.HandleRemove(pattern) }
 
 // HandleFunc registers the handler function with the given pattern
 // in the DefaultServeMux.
-func HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
+func HandleFunc(pattern string, handler HandlerFunc) {
 	DefaultServeMux.HandleFunc(pattern, handler)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -391,22 +391,22 @@ func TestDotAsCatchAllWildcard(t *testing.T) {
 	mux.Handle(".", HandlerFunc(HelloServer))
 	mux.Handle("example.com.", HandlerFunc(AnotherHelloServer))
 
-	handler := mux.match("www.miek.nl.", TypeTXT)
+	handler, _ := mux.match("www.miek.nl.", TypeTXT)
 	if handler == nil {
 		t.Error("wildcard match failed")
 	}
 
-	handler = mux.match("www.example.com.", TypeTXT)
+	handler, _ = mux.match("www.example.com.", TypeTXT)
 	if handler == nil {
 		t.Error("example.com match failed")
 	}
 
-	handler = mux.match("a.www.example.com.", TypeTXT)
+	handler, _ = mux.match("a.www.example.com.", TypeTXT)
 	if handler == nil {
 		t.Error("a.www.example.com match failed")
 	}
 
-	handler = mux.match("boe.", TypeTXT)
+	handler, _ = mux.match("boe.", TypeTXT)
 	if handler == nil {
 		t.Error("boe. match failed")
 	}
@@ -416,12 +416,12 @@ func TestCaseFolding(t *testing.T) {
 	mux := NewServeMux()
 	mux.Handle("_udp.example.com.", HandlerFunc(HelloServer))
 
-	handler := mux.match("_dns._udp.example.com.", TypeSRV)
+	handler, _ := mux.match("_dns._udp.example.com.", TypeSRV)
 	if handler == nil {
 		t.Error("case sensitive characters folded")
 	}
 
-	handler = mux.match("_DNS._UDP.EXAMPLE.COM.", TypeSRV)
+	handler, _ = mux.match("_DNS._UDP.EXAMPLE.COM.", TypeSRV)
 	if handler == nil {
 		t.Error("case insensitive characters not folded")
 	}
@@ -431,7 +431,7 @@ func TestRootServer(t *testing.T) {
 	mux := NewServeMux()
 	mux.Handle(".", HandlerFunc(HelloServer))
 
-	handler := mux.match(".", TypeNS)
+	handler, _ := mux.match(".", TypeNS)
 	if handler == nil {
 		t.Error("root match failed")
 	}
@@ -628,7 +628,7 @@ func TestHandlerCloseTCP(t *testing.T) {
 	}()
 	server.ActivateAndServe()
 	if !triggered.Get() {
-		t.Fatalf("handler never called")
+		t.Fatal("handler never called")
 	}
 }
 


### PR DESCRIPTION
When using this package to run a DNS server, users of the package provide callback routines to be called when certain FQDN strings/patterns are matched during a DNS query.  For users adding intelligence to these callbacks it can be very useful to also be given in the callback what the configured pattern was, particularly if they are managing any context in other data structures outside of this library.  For example, a lookup of www.foobar.com could have been enabled by a configured pattern of www.foobar.com, foobar.com, or com.  It doesn't make sense to duplicate the logic of finding the longest matching pattern when it already exists in this package.

A private fork achieved this in a non-backwards compatible manner and this is a first attempt to get the same functionality in the upstream library in a backwards compatible manner.  I don't love the implementation but it does maintain backwards compatibility.  In addition, it adds this functionality by returning a struct and should assist similar changes in the future because it will be possible to add a single field to the struct.

Open to another method to achieve this if anyone has ideas, tried a variadic solution but because the typing is so strong it still requires at least one new argument.