### PR TITLE
Add semver

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -1,0 +1,51 @@
+# Makefile for releasing.
+#
+# The release is controlled from version.go. The version found there is
+# used to tag the git repo, we're not building any artifects so there is nothing
+# to upload to github.
+#
+# * Up the version in version.go
+# * Run: make -f Makefile.release release
+#   * will *commit* your change with 'Release $VERSION'
+#   * push to github
+#
+
+define GO
+//+build ignore
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/miekg/dns"
+)
+
+func main() {
+	fmt.Println(dns.Version.String())
+}
+endef
+
+$(file > version_release.go,$(GO))
+VERSION:=$(shell go run version_release.go)
+TAG="v$(VERSION)"
+
+all:
+	@echo Use the \'release\' target to start a release $(VERSION)
+	rm -f version_release.go
+
+.PHONY: release
+release: commit push
+	@echo Released $(VERSION)
+	rm -f version_release.go
+
+.PHONY: commit
+commit:
+	@echo Committing release $(VERSION)
+	git commit -am"Release $(VERSION)"
+	git tag $(TAG)
+
+.PHONY: push
+push:
+	@echo Pushing release $(VERSION) to master
+	git push --tags

--- a/version.go
+++ b/version.go
@@ -1,0 +1,15 @@
+package dns
+
+import "fmt"
+
+// Version is current version of this library.
+var Version = V{1, 0, 0}
+
+// V holds the version of this library.
+type V struct {
+	Major, Minor, Patch int
+}
+
+func (v V) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,10 @@
+package dns
+
+import "testing"
+
+func TestVersion(t *testing.T) {
+	v := V{1, 0, 0}
+	if x := v.String(); x != "1.0.0" {
+		t.Fatalf("Failed to convert version %v, got: %s", v, x)
+	}
+}


### PR DESCRIPTION
Add a version.go that has the semver version of this libary; now at
1.0.0. Use a struct so external code can easily check the for the
version without resulting to string parsing. Add String() function if
you want to access the version string.

Fixes #592