### PR TITLE
Add size-hex: modifier for len()

### DIFF
--- a/dns_test.go
+++ b/dns_test.go
@@ -422,6 +422,14 @@ func TestTKEY(t *testing.T) {
 	if unPackErr != nil {
 		t.Fatal("unable to decode TKEY RR", unPackErr)
 	}
+	// Make sure it's a TKEY record
+	if rr.Header().Rrtype != TypeTKEY {
+		t.Fatal("Unable to decode TKEY")
+	}
+	// Make sure we get back the same length
+	if rr.len() != len(tkeyBytes) {
+		t.Fatalf("Lengths don't match %d != %d", rr.len(), len(tkeyBytes))
+	}
 	// make space for it with some fudge room
 	msg := make([]byte, tkeyLen+1000)
 	offset, packErr := PackRR(rr, msg, 0, nil, false)

--- a/types_generate.go
+++ b/types_generate.go
@@ -181,6 +181,8 @@ func main() {
 				fallthrough
 			case st.Tag(i) == `dns:"base64"`:
 				o("l += base64.StdEncoding.DecodedLen(len(rr.%s))\n")
+			case strings.HasPrefix(st.Tag(i), `dns:"size-hex:`): // this has an extra field where the length is stored
+				o("l += len(rr.%s)/2\n")
 			case strings.HasPrefix(st.Tag(i), `dns:"size-hex`):
 				fallthrough
 			case st.Tag(i) == `dns:"hex"`:

--- a/ztypes.go
+++ b/ztypes.go
@@ -347,7 +347,7 @@ func (rr *HIP) len() int {
 	l++    // HitLength
 	l++    // PublicKeyAlgorithm
 	l += 2 // PublicKeyLength
-	l += len(rr.Hit)/2 + 1
+	l += len(rr.Hit) / 2
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
 	for _, x := range rr.RendezvousServers {
 		l += len(x) + 1
@@ -470,7 +470,7 @@ func (rr *NSEC3PARAM) len() int {
 	l++    // Flags
 	l += 2 // Iterations
 	l++    // SaltLength
-	l += len(rr.Salt)/2 + 1
+	l += len(rr.Salt) / 2
 	return l
 }
 func (rr *OPENPGPKEY) len() int {
@@ -591,9 +591,9 @@ func (rr *TKEY) len() int {
 	l += 2 // Mode
 	l += 2 // Error
 	l += 2 // KeySize
-	l += len(rr.Key)/2 + 1
+	l += len(rr.Key) / 2
 	l += 2 // OtherLen
-	l += len(rr.OtherData)/2 + 1
+	l += len(rr.OtherData) / 2
 	return l
 }
 func (rr *TLSA) len() int {
@@ -610,11 +610,11 @@ func (rr *TSIG) len() int {
 	l += 6 // TimeSigned
 	l += 2 // Fudge
 	l += 2 // MACSize
-	l += len(rr.MAC)/2 + 1
+	l += len(rr.MAC) / 2
 	l += 2 // OrigId
 	l += 2 // Error
 	l += 2 // OtherLen
-	l += len(rr.OtherData)/2 + 1
+	l += len(rr.OtherData) / 2
 	return l
 }
 func (rr *TXT) len() int {


### PR DESCRIPTION
This was missing and generated the wrong code for TKEY; it adds a +1 to
the amount. This should happen (technically).

I think the fallout is not super bad (of the +1) as we allocate a byte
more for when pack a message.