### PR TITLE
relative include: now tested!

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -305,7 +305,7 @@ func parseZone(r io.Reader, origin, f string, defttl *ttlState, t chan *Token, i
 			}
 			r1, e1 := os.Open(includePath)
 			if e1 != nil {
-				msg := fmt.Sprintf("failed to include `%s'", l.token)
+				msg := fmt.Sprintf("failed to open `%s'", l.token)
 				if !filepath.IsAbs(l.token) {
 					msg += fmt.Sprintf(" as `%s'", includePath)
 				}

--- a/scan.go
+++ b/scan.go
@@ -303,9 +303,9 @@ func parseZone(r io.Reader, origin, f string, defttl *ttlState, t chan *Token, i
 			if !filepath.IsAbs(includePath) {
 				includePath = filepath.Join(filepath.Dir(f), includePath)
 			}
-			r1, e1 := os.Open(l.token)
+			r1, e1 := os.Open(includePath)
 			if e1 != nil {
-				msg := fmt.Sprintf("failed to open `%s'", l.token)
+				msg := fmt.Sprintf("failed to include `%s'", l.token)
 				if !filepath.IsAbs(l.token) {
 					msg += fmt.Sprintf(" as `%s'", includePath)
 				}


### PR DESCRIPTION
If you take the effort of creating includePath, actually use it when
opening the file. Now tested (again) with CoreDNS (with a zone file that
includes two others)

Failure to include leads to:

~~~
2017/12/07 16:47:00 plugin/file: /tmp/example.org: dns: failed to include `a/1include1.org' as `/tmp/a/1include1.org': "a/1include1.org" at line: 15:24
~~~