### PR TITLE
Two changes to assist with TSIG operations

### DIFF
--- a/client.go
+++ b/client.go
@@ -348,7 +348,7 @@ func (co *Conn) Read(p []byte) (n int, err error) {
 // signature is calculated.
 func (co *Conn) WriteMsg(m *Msg) (err error) {
 	var out []byte
-	if t := m.IsTsig(); t != nil {
+	if t := m.IsTsig(); t != nil && co.TsigSecret != nil {
 		mac := ""
 		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 			return ErrSecret

--- a/client.go
+++ b/client.go
@@ -210,7 +210,7 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 		}
 		return nil, err
 	}
-	if t := m.IsTsig(); t != nil {
+	if t := m.IsTsig(); t != nil && co.TsigSecret != nil {
 		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 			return m, ErrSecret
 		}

--- a/client.go
+++ b/client.go
@@ -21,6 +21,7 @@ type Conn struct {
 	net.Conn                         // a net.Conn holding the connection
 	UDPSize        uint16            // minimum receive buffer for UDP messages
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	TsigVerifySkip bool              // Skip verifying a TSIG RR immediately at read time
 	rtt            time.Duration
 	t              time.Time
 	tsigRequestMAC string
@@ -40,6 +41,7 @@ type Client struct {
 	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	TsigVerifySkip bool              // Skip verifying a TSIG RR immediately at read time
 	SingleInflight bool              // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
 }
@@ -177,6 +179,7 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 	}
 
 	co.TsigSecret = c.TsigSecret
+	co.TsigVerifySkip = c.TsigVerifySkip
 	// write with the appropriate write timeout
 	co.SetWriteDeadline(time.Now().Add(c.getTimeoutForRequest(c.writeTimeout())))
 	if err = co.WriteMsg(m); err != nil {
@@ -210,7 +213,7 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 		}
 		return nil, err
 	}
-	if t := m.IsTsig(); t != nil {
+	if t := m.IsTsig(); t != nil && !co.TsigVerifySkip {
 		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 			return m, ErrSecret
 		}

--- a/msg.go
+++ b/msg.go
@@ -124,7 +124,6 @@ type Msg struct {
 	Answer   []RR       // Holds the RR(s) of the answer section.
 	Ns       []RR       // Holds the RR(s) of the authority section.
 	Extra    []RR       // Holds the RR(s) of the additional section.
-	RawMsg   []byte     // The original byte stream if this message was decoded from wire format
 }
 
 // ClassToString is a maps Classes to strings for each CLASS wire type.
@@ -811,7 +810,6 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	dns.AuthenticatedData = (dh.Bits & _AD) != 0
 	dns.CheckingDisabled = (dh.Bits & _CD) != 0
 	dns.Rcode = int(dh.Bits & 0xF)
-	dns.RawMsg = msg
 
 	if off == len(msg) {
 		return ErrTruncated

--- a/msg.go
+++ b/msg.go
@@ -124,6 +124,7 @@ type Msg struct {
 	Answer   []RR       // Holds the RR(s) of the answer section.
 	Ns       []RR       // Holds the RR(s) of the authority section.
 	Extra    []RR       // Holds the RR(s) of the additional section.
+	RawMsg   []byte     // The original byte stream if this message was decoded from wire format
 }
 
 // ClassToString is a maps Classes to strings for each CLASS wire type.
@@ -810,6 +811,7 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	dns.AuthenticatedData = (dh.Bits & _AD) != 0
 	dns.CheckingDisabled = (dh.Bits & _CD) != 0
 	dns.Rcode = int(dh.Bits & 0xF)
+	dns.RawMsg = msg
 
 	if off == len(msg) {
 		return ErrTruncated


### PR DESCRIPTION
Below are two changes to assist with various TSIG operations.  The first is to introduce a flag that controls whether the TSIG verification is done immediately when data is read.  In order to be backwards compatible, the logic is inverted that when you want to skip you must explicitly set it.

Also, if a dns.Msg is created by Unpack()'ing from the wire format, save the wire format for others to be able to interpret and use it later if necessary.

Noted, these operations may not be useful to all but I know at least the ability to skip TSIG verification had been mentioned.