### PR TITLE
Unpack: return header

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -458,12 +458,12 @@ func TestTruncatedMsg(t *testing.T) {
 		t.Errorf("error should not be ErrTruncated from question cutoff unpack: %v", err)
 	}
 
-	// Finally, if we only have the header, we should still return an error
+	// Finally, if we only have the header, we don't return an error.
 	buf1 = buf[:12]
 
 	r = new(Msg)
-	if err = r.Unpack(buf1); err == nil || err != ErrTruncated {
-		t.Errorf("error not ErrTruncated from header-only unpack: %v", err)
+	if err = r.Unpack(buf1); err != nil {
+		t.Errorf("from header-only unpack should not return an error: %v", err)
 	}
 }
 

--- a/msg.go
+++ b/msg.go
@@ -811,8 +811,13 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	dns.CheckingDisabled = (dh.Bits & _CD) != 0
 	dns.Rcode = int(dh.Bits & 0xF)
 
+	// If we are at the end of the message we should return *just* the
+	// header. This can still be useful to the caller. 9.9.9.9 sends these
+	// when responding with REFUSED for instance.
 	if off == len(msg) {
-		return ErrTruncated
+		// reset sections before returning
+		dns.Question, dns.Answer, dns.Ns, dns.Extra = nil, nil, nil, nil
+		return nil
 	}
 
 	// Optimistically use the count given to us in the header


### PR DESCRIPTION
When we unpack a message and only have the header consider it a valid
message and don't return an error.