### PR TITLE
DNS client: TCP connection reuse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tags
 test.out
 a.out
+.idea/


### PR DESCRIPTION
With this PR the DNS client can reuse TCP connections when resolving against TCP/DNS-over-TLS servers, tries to resolve #614.

This is just a very basic approach of what it may look like, I am 100% sure than can be improved in many different ways, community feedback/commits are welcome.