### PR TITLE
Fixes #613

### DIFF
--- a/server.go
+++ b/server.go
@@ -509,7 +509,7 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 		}
 		srv.lock.RUnlock()
 		if err != nil {
-			if opErr, ok := err.(*net.OpError); ok && opErr.Temporary() {
+			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
 				continue
 			}
 			return err

--- a/server.go
+++ b/server.go
@@ -509,7 +509,10 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 		}
 		srv.lock.RUnlock()
 		if err != nil {
-			continue
+			if opErr, ok := err.(*net.OpError); ok && opErr.Temporary() {
+				continue
+			}
+			return err
 		}
 		go srv.serve(s.RemoteAddr(), handler, m, l, s, nil)
 	}


### PR DESCRIPTION
I tested this quickly in production. Can confirm io timeout from deadlines is err.Temporary() == true and use of closed connection is not opError, so it works in prod for me.