### PR TITLE
ClassANY: don't convert CLASS255 to ANY

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -273,13 +273,11 @@ func (t Type) String() string {
 
 // String returns the string representation for the class c.
 func (c Class) String() string {
-	if c1, ok := ClassToString[uint16(c)]; ok {
-		// Special case ANY, even though it's in the map we should not translate CLASS255 to ANY.
-		if c == 255 {
-			return "CLASS255"
+	if s, ok := ClassToString[uint16(c)]; ok {
+		// Only emit mnemonics when they are unambiguous, specically ANY is in both.
+		if _, ok := StringToType[s]; !ok {
+			return s
 		}
-
-		return c1
 	}
 	return "CLASS" + strconv.Itoa(int(c))
 }

--- a/defaults.go
+++ b/defaults.go
@@ -274,6 +274,11 @@ func (t Type) String() string {
 // String returns the string representation for the class c.
 func (c Class) String() string {
 	if c1, ok := ClassToString[uint16(c)]; ok {
+		// Special case ANY, even though it's in the map we should not translate CLASS255 to ANY.
+		if c == 255 {
+			return "CLASS255"
+		}
+
 		return c1
 	}
 	return "CLASS" + strconv.Itoa(int(c))

--- a/parse_test.go
+++ b/parse_test.go
@@ -433,6 +433,7 @@ func TestParseClass(t *testing.T) {
 		// ClassANY can not occur in zone files
 		// "t.example.com. ANY A 127.0.0.1": "t.example.com.	3600	ANY	A	127.0.0.1",
 		"t.example.com. NONE A 127.0.0.1": "t.example.com.	3600	NONE	A	127.0.0.1",
+		"t.example.com. CLASS255 A 127.0.0.1": "t.example.com.	3600	CLASS255	A	127.0.0.1",
 	}
 	for i, o := range tests {
 		rr, err := NewRR(i)

--- a/scan.go
+++ b/scan.go
@@ -577,6 +577,7 @@ func zlexer(s *scan, c chan lex) {
 								return
 							}
 							l.value = zRrtpe
+							rrtype = true
 							l.torc = t
 						}
 					}
@@ -600,7 +601,7 @@ func zlexer(s *scan, c chan lex) {
 				c <- l
 			}
 			stri = 0
-			// I reverse space stuff here
+
 			if !space && !commt {
 				l.value = zBlank
 				l.token = " "

--- a/update_test.go
+++ b/update_test.go
@@ -119,15 +119,15 @@ func TestPreReqAndRemovals(t *testing.T) {
 ;example.org.	IN	 SOA
 
 ;; ANSWER SECTION:
-name_used.	0	CLASS255	ANY
-name_not_used.	0	NONE	ANY
-rrset_used1.	0	CLASS255	A
+name_used.	0	CLASS255	ANY	
+name_not_used.	0	NONE	ANY	
+rrset_used1.	0	CLASS255	A	
 rrset_used2.	3600	IN	A	127.0.0.1
-rrset_not_used.	0	NONE	A
+rrset_not_used.	0	NONE	A	
 
 ;; AUTHORITY SECTION:
-remove1.	0	CLASS255	ANY
-remove2.	0	CLASS255	A
+remove1.	0	CLASS255	ANY	
+remove2.	0	CLASS255	A	
 remove3.	0	NONE	A	127.0.0.1
 insert.	3600	IN	A	127.0.0.1
 `

--- a/update_test.go
+++ b/update_test.go
@@ -119,15 +119,15 @@ func TestPreReqAndRemovals(t *testing.T) {
 ;example.org.	IN	 SOA
 
 ;; ANSWER SECTION:
-name_used.	0	ANY	ANY	
-name_not_used.	0	NONE	ANY	
-rrset_used1.	0	ANY	A	
+name_used.	0	CLASS255	ANY
+name_not_used.	0	NONE	ANY
+rrset_used1.	0	CLASS255	A
 rrset_used2.	3600	IN	A	127.0.0.1
-rrset_not_used.	0	NONE	A	
+rrset_not_used.	0	NONE	A
 
 ;; AUTHORITY SECTION:
-remove1.	0	ANY	ANY	
-remove2.	0	ANY	A	
+remove1.	0	CLASS255	ANY
+remove2.	0	CLASS255	A
 remove3.	0	NONE	A	127.0.0.1
 insert.	3600	IN	A	127.0.0.1
 `


### PR DESCRIPTION
Class "ANY" is wireformat only. In zonefile you can use CLASS255, but
when String-ing we convert this into "ANY" which is wrong. I.e. this
means we can't read back our own update.

Bit of a kludge to work around this, as I'm not sure we can just remove
ANY from the ClassToString map.