### PR TITLE
Fix TCP Shutdown 'use of closed network connection'

### DIFF
--- a/server.go
+++ b/server.go
@@ -460,6 +460,12 @@ func (srv *Server) serveTCP(l net.Listener) error {
 	// deadline is not used here
 	for {
 		rw, err := l.Accept()
+		srv.lock.RLock()
+		if !srv.started {
+			srv.lock.RUnlock()
+			return nil
+		}
+		srv.lock.RUnlock()
 		if err != nil {
 			if neterr, ok := err.(net.Error); ok && neterr.Temporary() {
 				continue
@@ -467,12 +473,6 @@ func (srv *Server) serveTCP(l net.Listener) error {
 			return err
 		}
 		m, err := reader.ReadTCP(rw, rtimeout)
-		srv.lock.RLock()
-		if !srv.started {
-			srv.lock.RUnlock()
-			return nil
-		}
-		srv.lock.RUnlock()
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
The check for `srv.started` being false is in the wrong place, it should be after `Accept` not after `ReadTCP`. If `Shutdown` is called, `serveTCP` will currently return a 'use of closed network connection' error, which is undesired.

This commit mirrors the behaviour of `serveUDP` with respect to `Shutdown`.