### PR TITLE
Add ability to use different TSIG algorithms

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,11 +24,17 @@ const (
 	dohMimeType = "application/dns-message"
 )
 
+type TsigAlgorithm struct {
+	Generate tsigAlgorithmGenerate
+	Verify   tsigAlgorithmVerify
+}
+
 // A Conn represents a connection to a DNS server.
 type Conn struct {
-	net.Conn                         // a net.Conn holding the connection
-	UDPSize        uint16            // minimum receive buffer for UDP messages
-	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	net.Conn                              // a net.Conn holding the connection
+	UDPSize        uint16                 // minimum receive buffer for UDP messages
+	TsigSecret     map[string]interface{} // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	TsigAlgorithm  map[string]*TsigAlgorithm
 	tsigRequestMAC string
 }
 
@@ -42,12 +48,13 @@ type Client struct {
 	// WriteTimeout when non-zero. Can be overridden with net.Dialer.Timeout (see Client.ExchangeWithDialer and
 	// Client.Dialer) or context.Context.Deadline (see the deprecated ExchangeContext)
 	Timeout        time.Duration
-	DialTimeout    time.Duration     // net.DialTimeout, defaults to 2 seconds, or net.Dialer.Timeout if expiring earlier - overridden by Timeout when that value is non-zero
-	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
-	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
-	HTTPClient     *http.Client      // The http.Client to use for DNS-over-HTTPS
-	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
-	SingleInflight bool              // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
+	DialTimeout    time.Duration          // net.DialTimeout, defaults to 2 seconds, or net.Dialer.Timeout if expiring earlier - overridden by Timeout when that value is non-zero
+	ReadTimeout    time.Duration          // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
+	WriteTimeout   time.Duration          // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
+	HTTPClient     *http.Client           // The http.Client to use for DNS-over-HTTPS
+	TsigSecret     map[string]interface{} // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	TsigAlgorithm  map[string]*TsigAlgorithm
+	SingleInflight bool // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
 }
 
@@ -194,6 +201,7 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 	}
 
 	co.TsigSecret = c.TsigSecret
+	co.TsigAlgorithm = c.TsigAlgorithm
 	t := time.Now()
 	// write with the appropriate write timeout
 	co.SetWriteDeadline(t.Add(c.getTimeoutForRequest(c.writeTimeout())))
@@ -300,11 +308,20 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 		return m, err
 	}
 	if t := m.IsTsig(); t != nil {
-		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
-			return m, ErrSecret
+		if a, ok := co.TsigAlgorithm[t.Algorithm]; ok {
+			if a.Verify != nil {
+				if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
+					return m, ErrSecret
+				}
+				err = TsigVerifyByAlgorithm(p, a.Verify, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
+			}
+		} else {
+			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
+				return m, ErrSecret
+			}
+			// Need to work on the original message p, as that was used to calculate the tsig.
+			err = TsigVerify(p, co.TsigSecret[t.Hdr.Name].(string), co.tsigRequestMAC, false)
 		}
-		// Need to work on the original message p, as that was used to calculate the tsig.
-		err = TsigVerify(p, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
 	}
 	return m, err
 }
@@ -437,10 +454,19 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 	var out []byte
 	if t := m.IsTsig(); t != nil {
 		mac := ""
-		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
-			return ErrSecret
+		if a, ok := co.TsigAlgorithm[t.Algorithm]; ok {
+			if a.Generate != nil {
+				if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
+					return ErrSecret
+				}
+				out, mac, err = TsigGenerateByAlgorithm(m, a.Generate, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
+			}
+		} else {
+			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
+				return ErrSecret
+			}
+			out, mac, err = TsigGenerate(m, co.TsigSecret[t.Hdr.Name].(string), co.tsigRequestMAC, false)
 		}
-		out, mac, err = TsigGenerate(m, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
 		// Set for the next read, although only used in zone transfers
 		co.tsigRequestMAC = mac
 	} else {

--- a/tsig.go
+++ b/tsig.go
@@ -91,7 +91,7 @@ type timerWireFmt struct {
 	Fudge      uint16
 }
 
-func tsigGenerateHmac(msg []byte, algorithm string, name, secret string) ([]byte, error) {
+func tsigGenerateHmac(msg []byte, algorithm, name, secret string) ([]byte, error) {
 	rawsecret, err := fromBase64([]byte(secret))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This makes it possible to fix #549 and support GSS-TSIG (or in theory any other TSIG algorithms aside from HMAC-MD5, etc.). There is one breaking change in that the TsigSecret field is now a map of value `interface{}` rather than `string`. I've added two new functions `TsigGenerateByAlgorithm()` and `TsigVerifyByAlgorithm()` which allow an algorithm-specific callback and refactored the existing `TsigGenerate()` and `TsigVerify()` to just call these with callback functions that perform the HMAC-specific bits.

With this, GSS-TSIG can be done with something like the following:
```golang
const (
        GssTsig = "gss-tsig."
)

func main() {
        ...

        ctx, keyname, err := negotiateGssapiCtx(hostname)
        if err != nil {
                ...
        }

        client := &dns.Client{
                Net:           "tcp",
                TsigAlgorithm: map[string]*dns.TsigAlgorithm{GssTsig: {TsigGenerateGssapi, TsigVerifyGssapi}},
                TsigSecret:    map[string]interface{}{*keyname: ctx},
        }

        msg := new(dns.Msg)

        // Set dynamic DNS, etc.

        msg.SetTsig(*keyname, GssTsig, 300, time.Now().Unix())

        rr, _, err := client.Exchange(msg, net.JoinHostPort(addr, "53"))

        ...
}
```

`negotiateGssapiCtx` does the TKEY exchange to establish the GSSAPI context and my `TsigGenerateGssapi` & `TsigVerifyGssapi` are pretty much the same as in https://github.com/miekg/dns/issues/549#issuecomment-355545424 the only difference is that the generate callback is now also passed the TSIG algorithm.