### PR TITLE
Fix for CVE-2017-15133 TCP DOS

### DIFF
--- a/server.go
+++ b/server.go
@@ -472,11 +472,14 @@ func (srv *Server) serveTCP(l net.Listener) error {
 			}
 			return err
 		}
-		m, err := reader.ReadTCP(rw, rtimeout)
-		if err != nil {
-			continue
-		}
-		go srv.serve(rw.RemoteAddr(), handler, m, nil, nil, rw)
+		go func() {
+			m, err := reader.ReadTCP(rw, rtimeout)
+			if err != nil {
+				rw.Close()
+				return
+			}
+			srv.serve(rw.RemoteAddr(), handler, m, nil, nil, rw)
+		}()
 	}
 }
 


### PR DESCRIPTION
serveTCP calls reader.ReadTCP in the accept loop rather than in
the per-connection goroutine. If an attacker opens a connection
and leaves it idle, this will block the accept loop until the
connection times out (2s by default). During this time no other
incoming connections will succeed, preventing legitimate queries
from being answered.

This commit moves the call to reader.ReadTCP into the per-connection
goroutine. It also adds a missing call to Close whose absence allowed
file-descirptors to leak in select cases.

This attack and fix have no impact on serving UDP queries.