### PR TITLE
fix: panicing on options parsing.

### DIFF
--- a/clientconfig.go
+++ b/clientconfig.go
@@ -91,7 +91,7 @@ func ClientConfigFromReader(resolvconf io.Reader) (*ClientConfig, error) {
 						n = 1
 					}
 					c.Timeout = n
-				case len(s) >= 8 && s[:9] == "attempts:":
+				case len(s) >= 9 && s[:9] == "attempts:":
 					n, _ := strconv.Atoi(s[9:])
 					if n < 1 {
 						n = 1

--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -59,7 +59,35 @@ func TestNdots(t *testing.T) {
 			t.Errorf("Ndots not properly parsed: (Expected: %d / Was: %d)", ndotsVariants[data], cc.Ndots)
 		}
 	}
+}
 
+func TestClientConfigFromReaderAttempts(t *testing.T) {
+	testCases := []struct {
+		data     string
+		expected int
+	}{
+		{data: "options attempts:0", expected: 1},
+		{data: "options attempts:1", expected: 1},
+		{data: "options attempts:15", expected: 15},
+		{data: "options attempts:16", expected: 16},
+		{data: "options attempts:-1", expected: 1},
+		{data: "options attempt:", expected: 2},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(strings.Replace(test.data, ":", " ", -1), func(t *testing.T) {
+			t.Parallel()
+
+			cc, err := ClientConfigFromReader(strings.NewReader(test.data))
+			if err != nil {
+				t.Errorf("error parsing resolv.conf: %v", err)
+			}
+			if cc.Attempts != test.expected {
+				t.Errorf("A attempts not properly parsed: (Expected: %d / Was: %d)", test.expected, cc.Attempts)
+			}
+		})
+	}
 }
 
 func TestReadFromFile(t *testing.T) {


### PR DESCRIPTION
Fix panic when option have a len of 8 on `attempts` parsing.

```console
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
github.com/containous/traefik/vendor/github.com/miekg/dns.ClientConfigFromFile(0x211b1eb, 0x10, 0x0, 0x0, 0x0)
      /go/src/github.com/containous/traefik/vendor/github.com/miekg/dns/clientconfig.go:86 +0xad6
github.com/containous/traefik/vendor/github.com/xenolf/lego/acme.getNameservers(0x211b1eb, 0x10, 0x32e9920, 0x2, 0x2, 0x92d9bc, 0xc4202240e0, 0x1)
      /go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/acme/dns_challenge.go:40 +0x4d
github.com/containous/traefik/vendor/github.com/xenolf/lego/acme.init()
      /go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/acme/dns_challenge.go:33 +0x12d
github.com/containous/traefik/acme.init()
      <autogenerated>:1 +0x84
main.init()
      <autogenerated>:1 +0x7f
```