### PR TITLE
WIP: DOH helper functions

### DIFF
--- a/https.go
+++ b/https.go
@@ -1,0 +1,47 @@
+package dns
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+const mime = "application/dns-udpwireformat"
+
+// MsgToRequest wraps m in a http POST request according to the DNS over HTTPS Spec.
+func MsgToRequest(m *Msg, url string) (*http.Request, error) {
+	out, err := m.Pack()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", url, bytes.NewReader(out))
+	req.Header.Set("content-type", mime)
+	req.Header.Set("accept", mime)
+
+	return req, nil
+}
+
+// ResponseToMsg extracts a dns.Msg from the response body. The resp.Body is closed
+// after this operation.
+func ResponseToMsg(resp *http.Response) (*Msg, error) {
+	defer resp.Body.Close()
+	return msgFromReader(resp.Body)
+}
+
+// RequestToMsg extra the dns message from the request body.
+func RequestToMsg(req *http.Request) (*Msg, error) {
+	defer req.Body.Close()
+	return msgFromReader(req.Body)
+}
+
+func msgFromReader(r io.Reader) (*Msg, error) {
+	buf, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, nil
+
+	}
+	m := new(Msg)
+	err = m.Unpack(buf)
+	return m, err
+}

--- a/https.go
+++ b/https.go
@@ -16,8 +16,8 @@ func MsgToRequest(m *Msg, url string) (*http.Request, error) {
 		return nil, err
 	}
 	req, err := http.NewRequest("POST", url, bytes.NewReader(out))
-	req.Header.Set("content-type", mime)
-	req.Header.Set("accept", mime)
+	req.Header.Set("Content-Type", mime)
+	req.Header.Set("Accept", mime)
 
 	return req, nil
 }

--- a/https_test.go
+++ b/https_test.go
@@ -1,0 +1,29 @@
+package dns
+
+import (
+	"testing"
+)
+
+func TestRequest(t *testing.T) {
+	const ex = "example.org."
+
+	m := new(Msg)
+	m.SetQuestion(ex, TypeDNSKEY)
+
+	req, err := MsgToRequest(m, "https://dns.cloudflare.com:443")
+	if err != nil {
+		t.Errorf("failure to make request: %s", err)
+	}
+
+	m, err = RequestToMsg(req)
+	if err != nil {
+		t.Fatalf("failure to get message from request: %s", err)
+	}
+
+	if x := m.Question[0].Name; x != ex {
+		t.Errorf("qname expected %s, got %s", ex, x)
+	}
+	if x := m.Question[0].Qtype; x != TypeDNSKEY {
+		t.Errorf("qname expected %d, got %d", x, TypeDNSKEY)
+	}
+}


### PR DESCRIPTION
IETF hackathon

I was trying to make DNS over HTTPs a first class citizen, i.e. create a
dns.Conn and set Net to https (basically just like DNS over TLS), but
this ran into a few snags:

* http/2 has it's own socket pipelining so I can't give it a net.Conn
  and make it run with it. This breaks an assumption in this library.
* The Go http client setup has a function called client.Do which sends
  a reply and waits for a reponse, ala Exchange() in this library. But
  this library uses conn.WriteMsg and conn.ReadMsg as two calls to
  implement that - both of these are also public. So I could fake one of
  these in the case of http/2, i.e. make WriteMsg a noop and do all the
  work in ReadMsg, but I still don't have access to the conn used in the
  http/2 - so that won't fly either.

In the end I ended up with some helper functions that parse from and to
the http/2 request world, but nothing more tangible can be done in this
library. In this regard it is similar to the gRPC support we have in
CoreDNS which is also outside of this library.