### PR TITLE
Cleanup serve function

### DIFF
--- a/server.go
+++ b/server.go
@@ -544,7 +544,7 @@ func (srv *Server) serveTCPConn(h Handler, t net.Conn) {
 			// TODO(tmthrgd): handle error
 			break
 		}
-		srv.serveDNS(m, w, h)
+		srv.serveDNS(h, m, w)
 		if w.tcp == nil {
 			break // Close() was called
 		}
@@ -565,10 +565,10 @@ func (srv *Server) serveUDPPacket(h Handler, m []byte, u *net.UDPConn, s *Sessio
 	} else {
 		w.writer = w
 	}
-	srv.serveDNS(m, w, h)
+	srv.serveDNS(h, m, w)
 }
 
-func (srv *Server) serveDNS(m []byte, w *response, h Handler) {
+func (srv *Server) serveDNS(h Handler, m []byte, w *response) {
 	req := new(Msg)
 	err := req.Unpack(m)
 	if err != nil { // Send a FormatError back

--- a/server.go
+++ b/server.go
@@ -529,7 +529,13 @@ func (srv *Server) serveTCPConn(h Handler, t net.Conn) {
 
 // Serve a new UDP request.
 func (srv *Server) serveUDPPacket(h Handler, m []byte, u *net.UDPConn, s *SessionUDP) {
-	srv.serve(s.RemoteAddr(), h, m, u, s, nil)
+	w := &response{tsigSecret: srv.TsigSecret, udp: u, remoteAddr: s.RemoteAddr(), udpSession: s}
+	if srv.DecorateWriter != nil {
+		w.writer = srv.DecorateWriter(w)
+	} else {
+		w.writer = w
+	}
+	srv.serveDNS(m, w, h)
 }
 
 // Serve a new connection.

--- a/server.go
+++ b/server.go
@@ -584,11 +584,11 @@ func (srv *Server) serveDNS(m []byte, w *response, h Handler) {
 	w.tsigStatus = nil
 	if w.tsigSecret != nil {
 		if t := req.IsTsig(); t != nil {
-			secret := t.Hdr.Name
-			if _, ok := w.tsigSecret[secret]; !ok {
-				w.tsigStatus = ErrKeyAlg
+			if secret, ok := w.tsigSecret[t.Hdr.Name]; ok {
+				w.tsigStatus = TsigVerify(m, secret, "", false)
+			} else {
+				w.tsigStatus = ErrSecret
 			}
-			w.tsigStatus = TsigVerify(m, w.tsigSecret[secret], "", false)
 			w.tsigTimersOnly = false
 			w.tsigRequestMAC = req.Extra[len(req.Extra)-1].(*TSIG).MAC
 		}

--- a/server.go
+++ b/server.go
@@ -525,6 +525,12 @@ func (srv *Server) serveTCPConn(h Handler, t net.Conn) {
 		w.writer = w
 	}
 
+	defer func() {
+		if !w.hijacked {
+			w.Close()
+		}
+	}()
+
 	idleTimeout := tcpIdleTimeout
 	if srv.IdleTimeout != nil {
 		idleTimeout = srv.IdleTimeout()
@@ -544,14 +550,12 @@ func (srv *Server) serveTCPConn(h Handler, t net.Conn) {
 			break // Close() was called
 		}
 		if w.hijacked {
-			return // client will call Close() themselves
+			break // client will call Close() themselves
 		}
 		// The first read uses the read timeout, the rest use the
 		// idle timeout.
 		timeout = idleTimeout
 	}
-
-	w.Close()
 }
 
 // Serve a new UDP request.


### PR DESCRIPTION
As part of trying to solve #646 I decided to cleanup the `(*Server).serve` function and make it more idiomatic. In doing that I split it up into separate functions for UDP and TCP, and split out the code for invoking `ServeDNS`. There should be no changes in functionality or behaviour.

This pull request is split across several commits to make it easier to follow along.