### PR TITLE
Fixed len computation when size just goes beyond 14 bits

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -971,7 +971,6 @@ func compressionLenSlice(len int, c map[string]int, rs []RR) int {
 		// track this length, and the global length in len, while taking compression into account for both.
 		x := r.len()
 		l += x
-		len += x
 
 		k, ok := compressionLenSearch(c, r.Header().Name)
 		if ok {
@@ -992,6 +991,7 @@ func compressionLenSlice(len int, c map[string]int, rs []RR) int {
 		if len < maxCompressionOffset {
 			compressionLenHelperType(c, r)
 		}
+		len += x
 	}
 	return l
 }


### PR DESCRIPTION
Fixes https://github.com/miekg/dns/issues/663

Since offset of compression has to start within the first 14 bits, we don't want to take it into account before trying to compress but once the length computation has been performed