### PR TITLE
WIP: DNS-over-HTTPS support for Client.Exchange API

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -588,3 +588,25 @@ func TestConcurrentExchanges(t *testing.T) {
 		}
 	}
 }
+
+func TestDoHExchange(t *testing.T) {
+	const addrstr = "dns.cloudflare.com:443"
+
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeSOA)
+
+	cl := &Client{Net: "https"}
+
+	r, _, err := cl.Exchange(m, addrstr)
+	if err != nil {
+		t.Fatalf("failed to exchange: %v", err)
+	}
+
+	if r == nil || r.Rcode != RcodeSuccess {
+		t.Errorf("failed to get an valid answer\n%v", r)
+	}
+
+	t.Log(r)
+
+	// TODO: proper tests for this
+}

--- a/leak_test.go
+++ b/leak_test.go
@@ -29,6 +29,7 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "closeWriteAndWait") ||
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "testing.(*T).Run(") ||
+			strings.Contains(stack, "created by net/http.(*http2Transport).newClientConn") ||
 			// These only show up with GOTRACEBACK=2; Issue 5005 (comment 28)
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "created by runtime.gc") ||


### PR DESCRIPTION
This is my third attempt at adding DNS-over-HTTPS support to `Client.`. It supersedes #647, #649 and #651.

This method provides DNS-over-HTTPS support exclusively within the `(*Client).Exchange*` APIs.

It's proving difficult to pipe cancellation and context through the `Client`, and I suspect some refactoring will be needed.

Note: when using DNS-over-HTTPS, the `Dialer`, `TLSConfig` and `*Timeout` (*todo*) fields on `Client` are ignored.