### PR TITLE
copyHeader is redundant

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -55,16 +55,6 @@ func (h *RR_Header) Header() *RR_Header { return h }
 // Just to implement the RR interface.
 func (h *RR_Header) copy() RR { return nil }
 
-func (h *RR_Header) copyHeader() *RR_Header {
-	r := new(RR_Header)
-	r.Name = h.Name
-	r.Rrtype = h.Rrtype
-	r.Class = h.Class
-	r.Ttl = h.Ttl
-	r.Rdlength = h.Rdlength
-	return r
-}
-
 func (h *RR_Header) String() string {
 	var s string
 

--- a/dnssec.go
+++ b/dnssec.go
@@ -239,7 +239,7 @@ func (k *DNSKEY) ToDS(h uint8) *DS {
 // ToCDNSKEY converts a DNSKEY record to a CDNSKEY record.
 func (k *DNSKEY) ToCDNSKEY() *CDNSKEY {
 	c := &CDNSKEY{DNSKEY: *k}
-	c.Hdr = *k.Hdr.copyHeader()
+	c.Hdr = k.Hdr
 	c.Hdr.Rrtype = TypeCDNSKEY
 	return c
 }
@@ -247,7 +247,7 @@ func (k *DNSKEY) ToCDNSKEY() *CDNSKEY {
 // ToCDS converts a DS record to a CDS record.
 func (d *DS) ToCDS() *CDS {
 	c := &CDS{DS: *d}
-	c.Hdr = *d.Hdr.copyHeader()
+	c.Hdr = d.Hdr
 	c.Hdr.Rrtype = TypeCDS
 	return c
 }

--- a/privaterr.go
+++ b/privaterr.go
@@ -56,8 +56,7 @@ func (r *PrivateRR) len() int { return r.Hdr.len() + r.Data.Len() }
 func (r *PrivateRR) copy() RR {
 	// make new RR like this:
 	rr := mkPrivateRR(r.Hdr.Rrtype)
-	newh := r.Hdr.copyHeader()
-	rr.Hdr = *newh
+	rr.Hdr = r.Hdr
 
 	err := r.Data.Copy(rr.Data)
 	if err != nil {

--- a/types_generate.go
+++ b/types_generate.go
@@ -226,7 +226,7 @@ func main() {
 			continue
 		}
 		fmt.Fprintf(b, "func (rr *%s) copy() RR {\n", name)
-		fields := []string{"*rr.Hdr.copyHeader()"}
+		fields := []string{"rr.Hdr"}
 		for i := 1; i < st.NumFields(); i++ {
 			f := st.Field(i).Name()
 			if sl, ok := st.Field(i).Type().(*types.Slice); ok {

--- a/ztypes.go
+++ b/ztypes.go
@@ -649,215 +649,215 @@ func (rr *X25) len() int {
 
 // copy() functions
 func (rr *A) copy() RR {
-	return &A{*rr.Hdr.copyHeader(), copyIP(rr.A)}
+	return &A{rr.Hdr, copyIP(rr.A)}
 }
 func (rr *AAAA) copy() RR {
-	return &AAAA{*rr.Hdr.copyHeader(), copyIP(rr.AAAA)}
+	return &AAAA{rr.Hdr, copyIP(rr.AAAA)}
 }
 func (rr *AFSDB) copy() RR {
-	return &AFSDB{*rr.Hdr.copyHeader(), rr.Subtype, rr.Hostname}
+	return &AFSDB{rr.Hdr, rr.Subtype, rr.Hostname}
 }
 func (rr *ANY) copy() RR {
-	return &ANY{*rr.Hdr.copyHeader()}
+	return &ANY{rr.Hdr}
 }
 func (rr *AVC) copy() RR {
 	Txt := make([]string, len(rr.Txt))
 	copy(Txt, rr.Txt)
-	return &AVC{*rr.Hdr.copyHeader(), Txt}
+	return &AVC{rr.Hdr, Txt}
 }
 func (rr *CAA) copy() RR {
-	return &CAA{*rr.Hdr.copyHeader(), rr.Flag, rr.Tag, rr.Value}
+	return &CAA{rr.Hdr, rr.Flag, rr.Tag, rr.Value}
 }
 func (rr *CERT) copy() RR {
-	return &CERT{*rr.Hdr.copyHeader(), rr.Type, rr.KeyTag, rr.Algorithm, rr.Certificate}
+	return &CERT{rr.Hdr, rr.Type, rr.KeyTag, rr.Algorithm, rr.Certificate}
 }
 func (rr *CNAME) copy() RR {
-	return &CNAME{*rr.Hdr.copyHeader(), rr.Target}
+	return &CNAME{rr.Hdr, rr.Target}
 }
 func (rr *CSYNC) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
 	copy(TypeBitMap, rr.TypeBitMap)
-	return &CSYNC{*rr.Hdr.copyHeader(), rr.Serial, rr.Flags, TypeBitMap}
+	return &CSYNC{rr.Hdr, rr.Serial, rr.Flags, TypeBitMap}
 }
 func (rr *DHCID) copy() RR {
-	return &DHCID{*rr.Hdr.copyHeader(), rr.Digest}
+	return &DHCID{rr.Hdr, rr.Digest}
 }
 func (rr *DNAME) copy() RR {
-	return &DNAME{*rr.Hdr.copyHeader(), rr.Target}
+	return &DNAME{rr.Hdr, rr.Target}
 }
 func (rr *DNSKEY) copy() RR {
-	return &DNSKEY{*rr.Hdr.copyHeader(), rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
+	return &DNSKEY{rr.Hdr, rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
 }
 func (rr *DS) copy() RR {
-	return &DS{*rr.Hdr.copyHeader(), rr.KeyTag, rr.Algorithm, rr.DigestType, rr.Digest}
+	return &DS{rr.Hdr, rr.KeyTag, rr.Algorithm, rr.DigestType, rr.Digest}
 }
 func (rr *EID) copy() RR {
-	return &EID{*rr.Hdr.copyHeader(), rr.Endpoint}
+	return &EID{rr.Hdr, rr.Endpoint}
 }
 func (rr *EUI48) copy() RR {
-	return &EUI48{*rr.Hdr.copyHeader(), rr.Address}
+	return &EUI48{rr.Hdr, rr.Address}
 }
 func (rr *EUI64) copy() RR {
-	return &EUI64{*rr.Hdr.copyHeader(), rr.Address}
+	return &EUI64{rr.Hdr, rr.Address}
 }
 func (rr *GID) copy() RR {
-	return &GID{*rr.Hdr.copyHeader(), rr.Gid}
+	return &GID{rr.Hdr, rr.Gid}
 }
 func (rr *GPOS) copy() RR {
-	return &GPOS{*rr.Hdr.copyHeader(), rr.Longitude, rr.Latitude, rr.Altitude}
+	return &GPOS{rr.Hdr, rr.Longitude, rr.Latitude, rr.Altitude}
 }
 func (rr *HINFO) copy() RR {
-	return &HINFO{*rr.Hdr.copyHeader(), rr.Cpu, rr.Os}
+	return &HINFO{rr.Hdr, rr.Cpu, rr.Os}
 }
 func (rr *HIP) copy() RR {
 	RendezvousServers := make([]string, len(rr.RendezvousServers))
 	copy(RendezvousServers, rr.RendezvousServers)
-	return &HIP{*rr.Hdr.copyHeader(), rr.HitLength, rr.PublicKeyAlgorithm, rr.PublicKeyLength, rr.Hit, rr.PublicKey, RendezvousServers}
+	return &HIP{rr.Hdr, rr.HitLength, rr.PublicKeyAlgorithm, rr.PublicKeyLength, rr.Hit, rr.PublicKey, RendezvousServers}
 }
 func (rr *KX) copy() RR {
-	return &KX{*rr.Hdr.copyHeader(), rr.Preference, rr.Exchanger}
+	return &KX{rr.Hdr, rr.Preference, rr.Exchanger}
 }
 func (rr *L32) copy() RR {
-	return &L32{*rr.Hdr.copyHeader(), rr.Preference, copyIP(rr.Locator32)}
+	return &L32{rr.Hdr, rr.Preference, copyIP(rr.Locator32)}
 }
 func (rr *L64) copy() RR {
-	return &L64{*rr.Hdr.copyHeader(), rr.Preference, rr.Locator64}
+	return &L64{rr.Hdr, rr.Preference, rr.Locator64}
 }
 func (rr *LOC) copy() RR {
-	return &LOC{*rr.Hdr.copyHeader(), rr.Version, rr.Size, rr.HorizPre, rr.VertPre, rr.Latitude, rr.Longitude, rr.Altitude}
+	return &LOC{rr.Hdr, rr.Version, rr.Size, rr.HorizPre, rr.VertPre, rr.Latitude, rr.Longitude, rr.Altitude}
 }
 func (rr *LP) copy() RR {
-	return &LP{*rr.Hdr.copyHeader(), rr.Preference, rr.Fqdn}
+	return &LP{rr.Hdr, rr.Preference, rr.Fqdn}
 }
 func (rr *MB) copy() RR {
-	return &MB{*rr.Hdr.copyHeader(), rr.Mb}
+	return &MB{rr.Hdr, rr.Mb}
 }
 func (rr *MD) copy() RR {
-	return &MD{*rr.Hdr.copyHeader(), rr.Md}
+	return &MD{rr.Hdr, rr.Md}
 }
 func (rr *MF) copy() RR {
-	return &MF{*rr.Hdr.copyHeader(), rr.Mf}
+	return &MF{rr.Hdr, rr.Mf}
 }
 func (rr *MG) copy() RR {
-	return &MG{*rr.Hdr.copyHeader(), rr.Mg}
+	return &MG{rr.Hdr, rr.Mg}
 }
 func (rr *MINFO) copy() RR {
-	return &MINFO{*rr.Hdr.copyHeader(), rr.Rmail, rr.Email}
+	return &MINFO{rr.Hdr, rr.Rmail, rr.Email}
 }
 func (rr *MR) copy() RR {
-	return &MR{*rr.Hdr.copyHeader(), rr.Mr}
+	return &MR{rr.Hdr, rr.Mr}
 }
 func (rr *MX) copy() RR {
-	return &MX{*rr.Hdr.copyHeader(), rr.Preference, rr.Mx}
+	return &MX{rr.Hdr, rr.Preference, rr.Mx}
 }
 func (rr *NAPTR) copy() RR {
-	return &NAPTR{*rr.Hdr.copyHeader(), rr.Order, rr.Preference, rr.Flags, rr.Service, rr.Regexp, rr.Replacement}
+	return &NAPTR{rr.Hdr, rr.Order, rr.Preference, rr.Flags, rr.Service, rr.Regexp, rr.Replacement}
 }
 func (rr *NID) copy() RR {
-	return &NID{*rr.Hdr.copyHeader(), rr.Preference, rr.NodeID}
+	return &NID{rr.Hdr, rr.Preference, rr.NodeID}
 }
 func (rr *NIMLOC) copy() RR {
-	return &NIMLOC{*rr.Hdr.copyHeader(), rr.Locator}
+	return &NIMLOC{rr.Hdr, rr.Locator}
 }
 func (rr *NINFO) copy() RR {
 	ZSData := make([]string, len(rr.ZSData))
 	copy(ZSData, rr.ZSData)
-	return &NINFO{*rr.Hdr.copyHeader(), ZSData}
+	return &NINFO{rr.Hdr, ZSData}
 }
 func (rr *NS) copy() RR {
-	return &NS{*rr.Hdr.copyHeader(), rr.Ns}
+	return &NS{rr.Hdr, rr.Ns}
 }
 func (rr *NSAPPTR) copy() RR {
-	return &NSAPPTR{*rr.Hdr.copyHeader(), rr.Ptr}
+	return &NSAPPTR{rr.Hdr, rr.Ptr}
 }
 func (rr *NSEC) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
 	copy(TypeBitMap, rr.TypeBitMap)
-	return &NSEC{*rr.Hdr.copyHeader(), rr.NextDomain, TypeBitMap}
+	return &NSEC{rr.Hdr, rr.NextDomain, TypeBitMap}
 }
 func (rr *NSEC3) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
 	copy(TypeBitMap, rr.TypeBitMap)
-	return &NSEC3{*rr.Hdr.copyHeader(), rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt, rr.HashLength, rr.NextDomain, TypeBitMap}
+	return &NSEC3{rr.Hdr, rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt, rr.HashLength, rr.NextDomain, TypeBitMap}
 }
 func (rr *NSEC3PARAM) copy() RR {
-	return &NSEC3PARAM{*rr.Hdr.copyHeader(), rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt}
+	return &NSEC3PARAM{rr.Hdr, rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt}
 }
 func (rr *OPENPGPKEY) copy() RR {
-	return &OPENPGPKEY{*rr.Hdr.copyHeader(), rr.PublicKey}
+	return &OPENPGPKEY{rr.Hdr, rr.PublicKey}
 }
 func (rr *OPT) copy() RR {
 	Option := make([]EDNS0, len(rr.Option))
 	copy(Option, rr.Option)
-	return &OPT{*rr.Hdr.copyHeader(), Option}
+	return &OPT{rr.Hdr, Option}
 }
 func (rr *PTR) copy() RR {
-	return &PTR{*rr.Hdr.copyHeader(), rr.Ptr}
+	return &PTR{rr.Hdr, rr.Ptr}
 }
 func (rr *PX) copy() RR {
-	return &PX{*rr.Hdr.copyHeader(), rr.Preference, rr.Map822, rr.Mapx400}
+	return &PX{rr.Hdr, rr.Preference, rr.Map822, rr.Mapx400}
 }
 func (rr *RFC3597) copy() RR {
-	return &RFC3597{*rr.Hdr.copyHeader(), rr.Rdata}
+	return &RFC3597{rr.Hdr, rr.Rdata}
 }
 func (rr *RKEY) copy() RR {
-	return &RKEY{*rr.Hdr.copyHeader(), rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
+	return &RKEY{rr.Hdr, rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
 }
 func (rr *RP) copy() RR {
-	return &RP{*rr.Hdr.copyHeader(), rr.Mbox, rr.Txt}
+	return &RP{rr.Hdr, rr.Mbox, rr.Txt}
 }
 func (rr *RRSIG) copy() RR {
-	return &RRSIG{*rr.Hdr.copyHeader(), rr.TypeCovered, rr.Algorithm, rr.Labels, rr.OrigTtl, rr.Expiration, rr.Inception, rr.KeyTag, rr.SignerName, rr.Signature}
+	return &RRSIG{rr.Hdr, rr.TypeCovered, rr.Algorithm, rr.Labels, rr.OrigTtl, rr.Expiration, rr.Inception, rr.KeyTag, rr.SignerName, rr.Signature}
 }
 func (rr *RT) copy() RR {
-	return &RT{*rr.Hdr.copyHeader(), rr.Preference, rr.Host}
+	return &RT{rr.Hdr, rr.Preference, rr.Host}
 }
 func (rr *SMIMEA) copy() RR {
-	return &SMIMEA{*rr.Hdr.copyHeader(), rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
+	return &SMIMEA{rr.Hdr, rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
 }
 func (rr *SOA) copy() RR {
-	return &SOA{*rr.Hdr.copyHeader(), rr.Ns, rr.Mbox, rr.Serial, rr.Refresh, rr.Retry, rr.Expire, rr.Minttl}
+	return &SOA{rr.Hdr, rr.Ns, rr.Mbox, rr.Serial, rr.Refresh, rr.Retry, rr.Expire, rr.Minttl}
 }
 func (rr *SPF) copy() RR {
 	Txt := make([]string, len(rr.Txt))
 	copy(Txt, rr.Txt)
-	return &SPF{*rr.Hdr.copyHeader(), Txt}
+	return &SPF{rr.Hdr, Txt}
 }
 func (rr *SRV) copy() RR {
-	return &SRV{*rr.Hdr.copyHeader(), rr.Priority, rr.Weight, rr.Port, rr.Target}
+	return &SRV{rr.Hdr, rr.Priority, rr.Weight, rr.Port, rr.Target}
 }
 func (rr *SSHFP) copy() RR {
-	return &SSHFP{*rr.Hdr.copyHeader(), rr.Algorithm, rr.Type, rr.FingerPrint}
+	return &SSHFP{rr.Hdr, rr.Algorithm, rr.Type, rr.FingerPrint}
 }
 func (rr *TA) copy() RR {
-	return &TA{*rr.Hdr.copyHeader(), rr.KeyTag, rr.Algorithm, rr.DigestType, rr.Digest}
+	return &TA{rr.Hdr, rr.KeyTag, rr.Algorithm, rr.DigestType, rr.Digest}
 }
 func (rr *TALINK) copy() RR {
-	return &TALINK{*rr.Hdr.copyHeader(), rr.PreviousName, rr.NextName}
+	return &TALINK{rr.Hdr, rr.PreviousName, rr.NextName}
 }
 func (rr *TKEY) copy() RR {
-	return &TKEY{*rr.Hdr.copyHeader(), rr.Algorithm, rr.Inception, rr.Expiration, rr.Mode, rr.Error, rr.KeySize, rr.Key, rr.OtherLen, rr.OtherData}
+	return &TKEY{rr.Hdr, rr.Algorithm, rr.Inception, rr.Expiration, rr.Mode, rr.Error, rr.KeySize, rr.Key, rr.OtherLen, rr.OtherData}
 }
 func (rr *TLSA) copy() RR {
-	return &TLSA{*rr.Hdr.copyHeader(), rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
+	return &TLSA{rr.Hdr, rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
 }
 func (rr *TSIG) copy() RR {
-	return &TSIG{*rr.Hdr.copyHeader(), rr.Algorithm, rr.TimeSigned, rr.Fudge, rr.MACSize, rr.MAC, rr.OrigId, rr.Error, rr.OtherLen, rr.OtherData}
+	return &TSIG{rr.Hdr, rr.Algorithm, rr.TimeSigned, rr.Fudge, rr.MACSize, rr.MAC, rr.OrigId, rr.Error, rr.OtherLen, rr.OtherData}
 }
 func (rr *TXT) copy() RR {
 	Txt := make([]string, len(rr.Txt))
 	copy(Txt, rr.Txt)
-	return &TXT{*rr.Hdr.copyHeader(), Txt}
+	return &TXT{rr.Hdr, Txt}
 }
 func (rr *UID) copy() RR {
-	return &UID{*rr.Hdr.copyHeader(), rr.Uid}
+	return &UID{rr.Hdr, rr.Uid}
 }
 func (rr *UINFO) copy() RR {
-	return &UINFO{*rr.Hdr.copyHeader(), rr.Uinfo}
+	return &UINFO{rr.Hdr, rr.Uinfo}
 }
 func (rr *URI) copy() RR {
-	return &URI{*rr.Hdr.copyHeader(), rr.Priority, rr.Weight, rr.Target}
+	return &URI{rr.Hdr, rr.Priority, rr.Weight, rr.Target}
 }
 func (rr *X25) copy() RR {
-	return &X25{*rr.Hdr.copyHeader(), rr.PSDNAddress}
+	return &X25{rr.Hdr, rr.PSDNAddress}
 }


### PR DESCRIPTION
copyHeader() is redundant, we allocate a header and then copy the
non-pointer elements into it; we don't need to do this, because if we
just asssign rr.Hdr to something else we get the same result.

Remove copyHeader() and the generation and use of it in ztypes.go.