### PR TITLE
do not modify dns.Rcode when packing to wire format

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -698,7 +698,6 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 	var (
 		dh          Header
 		compression map[string]int
-		rcode       int
 	)
 
 	if dns.Compress {
@@ -708,7 +707,6 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 	if dns.Rcode < 0 || dns.Rcode > 0xFFF {
 		return nil, ErrRcode
 	}
-	rcode = dns.Rcode & 0xF
 	if dns.Rcode > 0xF {
 		// Regular RCODE field is 4 bits
 		opt := dns.IsEdns0()
@@ -720,7 +718,7 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 
 	// Convert convenient Msg into wire-like Header.
 	dh.Id = dns.Id
-	dh.Bits = uint16(dns.Opcode)<<11 | uint16(rcode)
+	dh.Bits = uint16(dns.Opcode)<<11 | uint16(dns.Rcode&0xF)
 	if dns.Response {
 		dh.Bits |= _QR
 	}

--- a/msg.go
+++ b/msg.go
@@ -698,6 +698,7 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 	var (
 		dh          Header
 		compression map[string]int
+		rcode       int
 	)
 
 	if dns.Compress {
@@ -707,6 +708,7 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 	if dns.Rcode < 0 || dns.Rcode > 0xFFF {
 		return nil, ErrRcode
 	}
+	rcode = dns.Rcode & 0xF
 	if dns.Rcode > 0xF {
 		// Regular RCODE field is 4 bits
 		opt := dns.IsEdns0()
@@ -714,12 +716,11 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 			return nil, ErrExtendedRcode
 		}
 		opt.SetExtendedRcode(uint8(dns.Rcode >> 4))
-		dns.Rcode &= 0xF
 	}
 
 	// Convert convenient Msg into wire-like Header.
 	dh.Id = dns.Id
-	dh.Bits = uint16(dns.Opcode)<<11 | uint16(dns.Rcode)
+	dh.Bits = uint16(dns.Opcode)<<11 | uint16(rcode)
 	if dns.Response {
 		dh.Bits |= _QR
 	}

--- a/msg_test.go
+++ b/msg_test.go
@@ -26,6 +26,31 @@ var (
 	})
 )
 
+func TestPackNoSideEffect(t *testing.T) {
+	m := new(Msg)
+	m.SetQuestion(Fqdn("example.com."), TypeNS)
+
+	a := new(Msg)
+	o := &OPT{
+		Hdr: RR_Header{
+			Name:   ".",
+			Rrtype: TypeOPT,
+		},
+	}
+	o.SetUDPSize(DefaultMsgSize)
+
+	a.Extra = append(a.Extra, o)
+	a.SetRcode(m, RcodeBadVers)
+
+	if a.Rcode != RcodeBadVers {
+		t.Errorf("before pack: Rcode is expected to be BADVERS")
+	}
+	a.Pack()
+	if a.Rcode != RcodeBadVers {
+		t.Errorf("after pack: Rcode is expected to be BADVERS")
+	}
+}
+
 func TestUnpackDomainName(t *testing.T) {
 	var cases = []struct {
 		label          string

--- a/msg_test.go
+++ b/msg_test.go
@@ -42,9 +42,6 @@ func TestPackNoSideEffect(t *testing.T) {
 	a.Extra = append(a.Extra, o)
 	a.SetRcode(m, RcodeBadVers)
 
-	if a.Rcode != RcodeBadVers {
-		t.Errorf("before pack: Rcode is expected to be BADVERS")
-	}
 	a.Pack()
 	if a.Rcode != RcodeBadVers {
 		t.Errorf("after pack: Rcode is expected to be BADVERS")


### PR DESCRIPTION
When the message has an EDNS0 option in the additional section and
dns.Msg.Rcode is set to an extended rcode, dns.Msg.PackBuffer() modifies
dns.Msg.Rcode.
If you were to `Pack` the message and log it after, the Rcode would show
NOERROR.

Running the test before the change would error with:

```
=== RUN   TestPackNoSideEffect
--- FAIL: TestPackNoSideEffect (0.00s)
	msg_test.go:51: after pack: Rcode is expected to be BADVERS
```

after fixing dns.Msg.PackBuffer(), all tests are still passing.

Fixes #674