### PR TITLE
Handle empty NSEC3 salt in scanner

### DIFF
--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -131,3 +131,11 @@ func TestNsec3(t *testing.T) {
 		}
 	}
 }
+
+func TestNsec3EmptySalt(t *testing.T) {
+	rr, _ := NewRR("CK0POJMG874LJREF7EFN8430QVIT8BSM.com. 86400 IN NSEC3 1 1 0 - CK0Q1GIN43N1ARRC9OSM6QPQR81H5M9A  NS SOA RRSIG DNSKEY NSEC3PARAM")
+
+	if !rr.(*NSEC3).Match("com.") {
+		t.Fatalf("expected record to match com. label")
+	}
+}

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1255,8 +1255,10 @@ func setNSEC3(h RR_Header, c chan lex, o, f string) (RR, *ParseError, string) {
 	if len(l.token) == 0 || l.err {
 		return nil, &ParseError{f, "bad NSEC3 Salt", l}, ""
 	}
-	rr.SaltLength = uint8(len(l.token)) / 2
-	rr.Salt = l.token
+	if l.token != "-" {
+		rr.SaltLength = uint8(len(l.token)) / 2
+		rr.Salt = l.token
+	}
 
 	<-c
 	l = <-c
@@ -1321,8 +1323,10 @@ func setNSEC3PARAM(h RR_Header, c chan lex, o, f string) (RR, *ParseError, strin
 	rr.Iterations = uint16(i)
 	<-c
 	l = <-c
-	rr.SaltLength = uint8(len(l.token))
-	rr.Salt = l.token
+	if l.token != "-" {
+		rr.SaltLength = uint8(len(l.token))
+		rr.Salt = l.token
+	}
 	return rr, nil, ""
 }
 


### PR DESCRIPTION
This fixes #676 and should be non-invasive.

/cc @shadrick