### PR TITLE
Revert 6f3c0a126ca15bec6b0db0c77e65ed4ad2354ca2

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -102,12 +102,15 @@ func (rr *OPT) SetVersion(v uint8) {
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
 func (rr *OPT) ExtendedRcode() int {
-	return int((rr.Hdr.Ttl & 0xFF000000) >> 24)
+	return int((rr.Hdr.Ttl&0xFF000000)>>24) + 15
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.
 func (rr *OPT) SetExtendedRcode(v uint8) {
-	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | (uint32(v) << 24)
+	if v < RcodeBadVers { // Smaller than 16.. Use the 4 bits you have!
+		return
+	}
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | (uint32(v-15) << 24)
 }
 
 // UDPSize returns the UDP buffer size.


### PR DESCRIPTION
Previous behavior was correct. Checking with coredns:

current:

~~~
; <<>> DiG 9.10.3-P4-Debian <<>> +norec +noad +edns=1 +noednsneg soa miek.nl @localhost -p 1043
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: ?256, id: 35480
;; flags: qr; QUERY: 0, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 0
;; Query time: 0 msec
;; SERVER: ::1#1043(::1)
;; WHEN: Sat May 19 16:42:54 BST 2018
;; MSG SIZE  rcvd: 23
~~~

this pr:

~~~
; <<>> DiG 9.10.3-P4-Debian <<>> +norec +noad +edns=1 +noednsneg soa miek.nl @localhost -p 1043
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: BADVERS, id: 25912
;; flags: qr; QUERY: 0, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 0
;; Query time: 0 msec
;; SERVER: ::1#1043(::1)
;; WHEN: Sat May 19 16:51:28 BST 2018
;; MSG SIZE  rcvd: 23
~~~