### PR TITLE
Don't use padding in base32 helpers

### DIFF
--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -141,20 +141,24 @@ func truncateMsgFromRdlength(msg []byte, off int, rdlength uint16) (truncmsg []b
 	return msg[:lenrd], nil
 }
 
+var base32HexNoPadEncoding = base32.HexEncoding.WithPadding(base32.NoPadding)
+
 func fromBase32(s []byte) (buf []byte, err error) {
 	for i, b := range s {
 		if b >= 'a' && b <= 'z' {
 			s[i] = b - 32
 		}
 	}
-	buflen := base32.HexEncoding.DecodedLen(len(s))
+	buflen := base32HexNoPadEncoding.DecodedLen(len(s))
 	buf = make([]byte, buflen)
-	n, err := base32.HexEncoding.Decode(buf, s)
+	n, err := base32HexNoPadEncoding.Decode(buf, s)
 	buf = buf[:n]
 	return
 }
 
-func toBase32(b []byte) string { return base32.HexEncoding.EncodeToString(b) }
+func toBase32(b []byte) string {
+	return base32HexNoPadEncoding.EncodeToString(b)
+}
 
 func fromBase64(s []byte) (buf []byte, err error) {
 	buflen := base64.StdEncoding.DecodedLen(len(s))


### PR DESCRIPTION
The base32 variant NSEC3 uses doesn't have padding. This hasn't been a
problem in practice because SHA1 is the only current NSEC3 hash algorithm
and its output doesn't require padding.

No-pad support was introduced in Go 1.9 which is the oldest release this
package supports.

---

This is a follow up to the discussion in #426.