### PR TITLE
Require URLs for DOH addresses

### DIFF
--- a/client.go
+++ b/client.go
@@ -216,14 +216,11 @@ func (c *Client) exchangeDOH(ctx context.Context, m *Msg, a string) (r *Msg, rtt
 		return nil, 0, err
 	}
 
-	// TODO(tmthrgd): Allow the path to be customised?
-	u := &url.URL{
-		Scheme: "https",
-		Host:   a,
-		Path:   "/.well-known/dns-query",
-	}
-	if u.Port() == "443" {
-		u.Host = u.Hostname()
+	u, err := url.Parse(a)
+	if err != nil {
+		return nil, 0, err
+	} else if u.Scheme != "https" {
+		return nil, 0, fmt.Errorf(`dns: unexpected url scheme %q; expected "https"`, u.Scheme)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(p))

--- a/client.go
+++ b/client.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 )
@@ -216,14 +215,7 @@ func (c *Client) exchangeDOH(ctx context.Context, m *Msg, a string) (r *Msg, rtt
 		return nil, 0, err
 	}
 
-	u, err := url.Parse(a)
-	if err != nil {
-		return nil, 0, err
-	} else if u.Scheme != "https" {
-		return nil, 0, fmt.Errorf(`dns: unexpected url scheme %q; expected "https"`, u.Scheme)
-	}
-
-	req, err := http.NewRequest(http.MethodPost, u.String(), bytes.NewReader(p))
+	req, err := http.NewRequest(http.MethodPost, a, bytes.NewReader(p))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/client.go
+++ b/client.go
@@ -231,8 +231,6 @@ func (c *Client) exchangeDOH(ctx context.Context, m *Msg, a string) (r *Msg, rtt
 	req.Header.Set("Content-Type", dohMimeType)
 	req.Header.Set("Accept", dohMimeType)
 
-	t := time.Now()
-
 	hc := http.DefaultClient
 	if c.HTTPClient != nil {
 		hc = c.HTTPClient
@@ -241,6 +239,8 @@ func (c *Client) exchangeDOH(ctx context.Context, m *Msg, a string) (r *Msg, rtt
 	if ctx != context.Background() && ctx != context.TODO() {
 		req = req.WithContext(ctx)
 	}
+
+	t := time.Now()
 
 	resp, err := hc.Do(req)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -590,7 +590,7 @@ func TestConcurrentExchanges(t *testing.T) {
 }
 
 func TestDoHExchange(t *testing.T) {
-	const addrstr = "dns.cloudflare.com:443"
+	const addrstr = "https://dns.cloudflare.com/dns-query"
 
 	m := new(Msg)
 	m.SetQuestion("miek.nl.", TypeSOA)


### PR DESCRIPTION
DoH support now requires the full URL to be passed to `Exchange` rather than just the hostname.

This is to accommodate the (unfortunate) removal of the `.well-known/dns-query` path in draft-ietf-doh-dns-over-https-03, see https://www.ietf.org/rfcdiff?url1=draft-ietf-doh-dns-over-https-02&url2=draft-ietf-doh-dns-over-https-03&difftype=--html.

DNS-over-HTTPS support now works as:
```go
(&Client{Net: "https"}).Exchange(new(Msg), "https://dns.cloudflare.com/dns-query")
```