### PR TITLE
tests: remove t.Log(f) when nothing is failing

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -606,7 +606,5 @@ func TestDoHExchange(t *testing.T) {
 		t.Errorf("failed to get an valid answer\n%v", r)
 	}
 
-	t.Log(r)
-
 	// TODO: proper tests for this
 }

--- a/dns_test.go
+++ b/dns_test.go
@@ -311,7 +311,7 @@ func TestTKEY(t *testing.T) {
 
 	// Make sure we can parse our string output
 	tkey.Hdr.Class = ClassINET // https://github.com/miekg/dns/issues/577
-	newRR, newError := NewRR(tkey.String())
+	_, newError := NewRR(tkey.String())
 	if newError != nil {
 		t.Fatalf("unable to parse TKEY string: %s", newError)
 	}

--- a/dns_test.go
+++ b/dns_test.go
@@ -296,7 +296,7 @@ func TestTKEY(t *testing.T) {
 	if bytes.Compare(tkeyBytes, msg[0:offset]) != 0 {
 		t.Fatal("mismatched TKEY data after rewriting bytes")
 	}
-	t.Logf("got TKEY of: " + rr.String())
+
 	// Now add some bytes to this and make sure we can encode OtherData properly
 	tkey := rr.(*TKEY)
 	tkey.OtherData = "abcd"
@@ -308,7 +308,6 @@ func TestTKEY(t *testing.T) {
 	if offset != (len(tkeyBytes) + 2) {
 		t.Fatalf("mismatched TKEY RR size %d != %d", offset, len(tkeyBytes)+2)
 	}
-	t.Logf("modified to TKEY of: " + rr.String())
 
 	// Make sure we can parse our string output
 	tkey.Hdr.Class = ClassINET // https://github.com/miekg/dns/issues/577
@@ -316,5 +315,4 @@ func TestTKEY(t *testing.T) {
 	if newError != nil {
 		t.Fatalf("unable to parse TKEY string: %s", newError)
 	}
-	t.Log("got reparsed TKEY of newRR: " + newRR.String())
 }


### PR DESCRIPTION
This clears up the travis output some more and adheres to the Unix
saying: no output is good news