### PR TITLE
Correctly handle $GENERATE modifiers

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -133,10 +133,20 @@ BuildRR:
 
 // Convert a $GENERATE modifier 0,0,d to something Printf can deal with.
 func modToPrintf(s string) (string, int, error) {
-	xs := strings.SplitN(s, ",", 3)
-	if len(xs) != 3 {
+	xs := strings.Split(s, ",")
+
+	// Modifier is { offset [ ,width [ ,base ] ] } - provide default
+	// values for optional width and type, if necessary.
+	switch len(xs) {
+	case 1:
+		xs = append(xs, "0", "d")
+	case 2:
+		xs = append(xs, "d")
+	case 3:
+	default:
 		return "", 0, errors.New("bad modifier in $GENERATE")
 	}
+
 	// xs[0] is offset, xs[1] is width, xs[2] is base
 	if xs[2] != "o" && xs[2] != "d" && xs[2] != "x" && xs[2] != "X" {
 		return "", 0, errors.New("bad base in $GENERATE")

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,39 @@
+package dns
+
+import (
+	"testing"
+)
+
+func TestGenerateModToPrintf(t *testing.T) {
+	tests := []struct {
+		mod        string
+		wantFmt    string
+		wantOffset int
+		wantErr    bool
+	}{
+		{"0,0,d", "%0d", 0, false},
+		{"0,0", "%0d", 0, false},
+		{"0", "%0d", 0, false},
+		{"3,2,d", "%02d", 3, false},
+		{"3,2", "%02d", 3, false},
+		{"3", "%0d", 3, false},
+		{"0,0,o", "%0o", 0, false},
+		{"0,0,x", "%0x", 0, false},
+		{"0,0,X", "%0X", 0, false},
+		{"0,0,z", "", 0, true},
+		{"0,0,0,d", "", 0, true},
+	}
+	for _, test := range tests {
+		gotFmt, gotOffset, err := modToPrintf(test.mod)
+		switch {
+		case err != nil && !test.wantErr:
+			t.Errorf("modToPrintf(%q) - expected nil-error, but got %v", test.mod, err)
+		case err == nil && test.wantErr:
+			t.Errorf("modToPrintf(%q) - expected error, but got nil-error", test.mod)
+		case gotFmt != test.wantFmt:
+			t.Errorf("modToPrintf(%q) - expected format %q, but got %q", test.mod, test.wantFmt, gotFmt)
+		case gotOffset != test.wantOffset:
+			t.Errorf("modToPrintf(%q) - expected offset %d, but got %d", test.mod, test.wantOffset, gotOffset)
+		}
+	}
+}


### PR DESCRIPTION
Correctly handle `$GENERATE` modifiers. The width and type (aka base)
components of a modifier are optional. This means that `${2,0,d}`, `${2,0}` and `${2}` are
valid modifiers, however only the first format was previously permitted. Use default
values for the width and/or type if they are unspecified in the modifier.

While here improve test coverage by adding tests for parsing zones with `$GENERATE` and the `modToPrintf` used by `$GENERATE`.

Fixes issue #702 