### PR TITLE
Add support for truncating a message to fit a given buffer size

### DIFF
--- a/length_test.go
+++ b/length_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
-	"reflect"
 	"strings"
 	"testing"
 )
@@ -278,19 +277,12 @@ func TestCompareCompressionMapsForANY(t *testing.T) {
 	for labelSize := 0; labelSize < 63; labelSize++ {
 		msg.SetQuestion(fmt.Sprintf("a%s.service.acme.", strings.Repeat("x", labelSize)), TypeANY)
 
-		compressionFake := make(map[string]int)
-		lenFake := compressedLenWithCompressionMap(msg, compressionFake)
-
-		compressionReal := make(map[string]int)
-		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal)
+		buf, err := msg.packBufferWithCompressionMap(nil, make(map[string]int))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if lenFake != len(buf) {
-			t.Fatalf("padding= %d ; Predicted len := %d != real:= %d", labelSize, lenFake, len(buf))
-		}
-		if !reflect.DeepEqual(compressionFake, compressionReal) {
-			t.Fatalf("padding= %d ; Fake Compression Map != Real Compression Map\n*** Real:= %v\n\n***Fake:= %v", labelSize, compressionReal, compressionFake)
+		if want, got := len(buf), msg.Len(); want != got {
+			t.Fatalf("padding= %d ; Predicted len := %d != real:= %d", labelSize, got, want)
 		}
 	}
 }
@@ -311,19 +303,12 @@ func TestCompareCompressionMapsForSRV(t *testing.T) {
 	for labelSize := 0; labelSize < 63; labelSize++ {
 		msg.SetQuestion(fmt.Sprintf("a%s.service.acme.", strings.Repeat("x", labelSize)), TypeAAAA)
 
-		compressionFake := make(map[string]int)
-		lenFake := compressedLenWithCompressionMap(msg, compressionFake)
-
-		compressionReal := make(map[string]int)
-		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal)
+		buf, err := msg.packBufferWithCompressionMap(nil, make(map[string]int))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if lenFake != len(buf) {
-			t.Fatalf("padding= %d ; Predicted len := %d != real:= %d", labelSize, lenFake, len(buf))
-		}
-		if !reflect.DeepEqual(compressionFake, compressionReal) {
-			t.Fatalf("padding= %d ; Fake Compression Map != Real Compression Map\n*** Real:= %v\n\n***Fake:= %v", labelSize, compressionReal, compressionFake)
+		if want, got := len(buf), msg.Len(); want != got {
+			t.Fatalf("padding= %d ; Predicted len := %d != real:= %d", labelSize, got, want)
 		}
 	}
 }

--- a/truncate_test.go
+++ b/truncate_test.go
@@ -1,0 +1,106 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTruncate(t *testing.T) {
+	type opts struct {
+		edns0    uint16
+		compress bool
+	}
+	type expectation struct {
+		truncated         bool
+		answer, extra, ns int
+	}
+	newMsg := func(o opts) *Msg {
+		m := new(Msg)
+		m.Compress = o.compress
+		m.SetQuestion("truncation.example.org.", TypeANY)
+		for i := 1; i < 31; i++ {
+			m.Answer = append(m.Answer, testRR(fmt.Sprintf("truncation.example.org. 3600 IN SRV 0 0 80 10-10-0-%d.example.org.", i)))
+			m.Extra = append(m.Extra, testRR(fmt.Sprintf("10-10-0-%d.example.org. 3600 IN A 10.10.0.%d", i, i)))
+		}
+		for i := 0; i < 5; i++ {
+			m.Ns = append(m.Ns, testRR(fmt.Sprintf("example.org. 86400 IN NS ns%d.example.org.", i)))
+			m.Extra = append(m.Extra, testRR(fmt.Sprintf("ns%d.example.org. 3600 IN A 10.1.0.%d", i, i)))
+		}
+		if o.edns0 > 0 {
+			r := &OPT{
+				Hdr: RR_Header{
+					Name:   ".",
+					Rrtype: TypeOPT,
+				},
+			}
+			r.SetVersion(0)
+			r.SetUDPSize(o.edns0)
+			m.Extra = append(m.Extra, r)
+		}
+		return m
+	}
+
+	tests := []struct {
+		name string
+		opts opts
+		size int
+		expt expectation
+	}{
+		{
+			name: "truncated",
+			size: 512,
+			expt: expectation{truncated: true, answer: 7},
+		},
+		{
+			name: "truncated with edns0",
+			opts: opts{edns0: 1024},
+			size: 1024,
+			expt: expectation{truncated: true, answer: 15, extra: 1},
+		},
+		{
+			name: "answers fit",
+			opts: opts{edns0: 2048},
+			size: 2048,
+			expt: expectation{truncated: false, answer: 30, extra: 1},
+		},
+		{
+			name: "answers and authority fit",
+			opts: opts{edns0: 2560},
+			size: 2560,
+			expt: expectation{truncated: false, answer: 30, extra: 11, ns: 5},
+		},
+		{
+			name: "everything fits",
+			opts: opts{edns0: 2048, compress: true},
+			size: 2048,
+			expt: expectation{truncated: false, answer: 30, extra: 36, ns: 5},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := newMsg(test.opts)
+
+			m.Truncate(test.size)
+
+			if want, got := test.size, m.Len(); want < got {
+				t.Errorf("want message to fit %d bytes buffer, but size is %d", want, got)
+			}
+			if want, got := test.expt.truncated, m.Truncated; want != got {
+				t.Errorf("want message to be truncated=%t, but got truncated=%t", want, got)
+			}
+			if want, got := test.expt.answer, len(m.Answer); want != got {
+				t.Errorf("want message to have %d answers, but got %d", want, got)
+			}
+			if want, got := test.expt.extra, len(m.Extra); want != got {
+				t.Errorf("want message to have %d additional records, but got %d", want, got)
+			}
+			if want, got := test.expt.ns, len(m.Ns); want != got {
+				t.Errorf("want message to have %d authority records, but got %d", want, got)
+			}
+			if test.opts.edns0 > 0 && m.IsEdns0() == nil {
+				t.Errorf("want message to include OPT header")
+			}
+		})
+	}
+}


### PR DESCRIPTION
If DNS messages are too large for a given (UDP) buffer size, the
truncated bit should be set to request clients to retry the request via
a different transport (TCP).

This change introduces a Truncate() function which can be used to handle
the modification of the message. As some basic clients (incorrectly)
don't handle the truncation bit, it aims to return as many records as
possible while still being performant (e.g. not traversing resource
record lists multiple times to find the maximum number of fitting
records).

It ensures to always keep TSIG and OPT records in the response according
to the spec (e.g. RFC 6891 section 7).

@miekg 