### PR TITLE
Server - Graceful shutdown (ensure all queries are processed before closing)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -117,7 +117,7 @@ func TestClientTLSSyncV4(t *testing.T) {
 		Certificates: []tls.Certificate{cert},
 	}
 
-	s, addrstr, err := RunLocalTLSServer(":0", &config)
+	s, addrstr, err := RunLocalTLSServer(":0", &config, time.Second, time.Hour)
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -611,7 +611,8 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 					m.SetQuestion("example.com.", TypeTXT)
 					atomic.AddInt64(&sendMsg, 1)
 					_, _, err := client.Exchange(m, addr)
-					// ignore errors that are not "read" errors - if we have a read error, it means the shutdown did not act properly
+					// ignore errors that are not "read" errors
+					// if we have a read error, it means the shutdown did not act properly
 					if err != nil {
 						if operr, ok := err.(*net.OpError); ok {
 							if operr.Op != "read" {

--- a/server_test.go
+++ b/server_test.go
@@ -66,10 +66,9 @@ func RunLocalUDPServerWithFinChan(laddr string, rdtimeout time.Duration) (*Serve
 	// tune the timeouts. If shutdown is lower than rdtimeout and there is no queries,
 	// then ActivateAndServe will end on an error because connection will be close before timeout of ReadUDP.
 
-	shtimeout := rdtimeout + 1 * time.Second  // to avoid error return by Server, we need that ShutdownTimeout is > ReadTimeout
+	shtimeout := rdtimeout + (1 * time.Second)  // to avoid error return by Server, we need that ShutdownTimeout is > ReadTimeout
 	if rdtimeout == 0 {
 		rdtimeout = 1 * time.Hour
-		shtimeout = 1 * time.Second
 	}
 
 	server := &Server{PacketConn: pc, ReadTimeout: rdtimeout, WriteTimeout: time.Hour, ShutdownTimeout:shtimeout}

--- a/server_test.go
+++ b/server_test.go
@@ -578,7 +578,7 @@ func TestShutdownTCP(t *testing.T) {
 	}
 }
 
-func checkLostQueriesAtShutdownServer(t *testing.T, srv *Server, addr string, fin chan error, client *Client) {
+func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr string, fin chan error, client *Client) {
 
 	var h = func(w ResponseWriter, req *Msg) {
 		// simulate small delay between 0 to 0.5 sec.
@@ -657,7 +657,7 @@ func checkLostQueriesAtShutdownServer(t *testing.T, srv *Server, addr string, fi
 
 }
 
-func TestLostQueriesAtShutdownTCP(t *testing.T) {
+func TestInProgressQueriesAtShutdownTCP(t *testing.T) {
 
 	s, addr, fin, err := RunLocalTCPServerWithFinChan(":0")
 	if err != nil {
@@ -666,7 +666,7 @@ func TestLostQueriesAtShutdownTCP(t *testing.T) {
 
 	client := &Client{Net: "tcp"}
 
-	checkLostQueriesAtShutdownServer(t, s, addr, fin, client)
+	checkInProgressQueriesAtShutdownServer(t, s, addr, fin, client)
 
 }
 
@@ -690,7 +690,7 @@ func TestShutdownTLS(t *testing.T) {
 	}
 }
 
-func TestLostQueriesAtShutdownTLS(t *testing.T) {
+func TestInProgressQueriesAtShutdownTLS(t *testing.T) {
 
 	cert, err := tls.X509KeyPair(CertPEMBlock, KeyPEMBlock)
 	if err != nil {
@@ -710,7 +710,7 @@ func TestLostQueriesAtShutdownTLS(t *testing.T) {
 		InsecureSkipVerify: true,
 	}}
 
-	checkLostQueriesAtShutdownServer(t, s, addr, nil, client)
+	checkInProgressQueriesAtShutdownServer(t, s, addr, nil, client)
 
 }
 
@@ -794,7 +794,7 @@ func TestShutdownUDP(t *testing.T) {
 	}
 }
 
-func TestLostQueriesAtShutdownUDP(t *testing.T) {
+func TestInProgressQueriesAtShutdownUDP(t *testing.T) {
 
 	s, addr, fin, err := RunLocalUDPServerWithFinChan(":0")
 	if err != nil {
@@ -803,7 +803,7 @@ func TestLostQueriesAtShutdownUDP(t *testing.T) {
 
 	client := &Client{Net: "udp"}
 
-	checkLostQueriesAtShutdownServer(t, s, addr, fin, client)
+	checkInProgressQueriesAtShutdownServer(t, s, addr, fin, client)
 
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -584,7 +584,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 
 	HandleFunc("example.com", func(w ResponseWriter, req *Msg) {
 		// simulate small delay between 0 to 0.5 sec.
-		time.Sleep(time.Duration((rand.Intn(500))+100) * time.Millisecond)
+		time.Sleep(time.Duration((rand.Intn(500))+500) * time.Millisecond)
 		HelloServer(w, req)
 	})
 
@@ -636,11 +636,11 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 	}
 
 	// wait at least 1 sec the mechanism start to send msgs
-	time.Sleep(time.Millisecond * 1000)
+	time.Sleep(time.Millisecond * 100)
 
 	// then stop sending msgs ..
 	close(stop)
-	time.Sleep(time.Millisecond * 200) // expected time to at least do the write part of the msg (TLS would need about 100ms)
+	time.Sleep(time.Millisecond * 500) // expected time to at least do the write part of the msg (TLS would need about 100ms)
 
 	// And now shutdown the server : we expect that all msg sent will be served
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))

--- a/server_test.go
+++ b/server_test.go
@@ -588,6 +588,9 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 		HelloServer(w, req)
 	})
 
+	// tune the timeout of the client, based on expecting delay to reply - from 1 to 2 sec.
+	client.Timeout = time.Duration(4 * time.Second)
+
 	var sendMsg int64
 	var recvMsg int64
 	var wg sync.WaitGroup
@@ -810,19 +813,6 @@ func TestShutdownUDPWithContext(t *testing.T) {
 	err = s.ShutdownContext(ctx)
 	if err != nil {
 		t.Errorf("could not shutdown test UDP server, %v", err)
-	}
-	cancel()
-}
-
-func TestShutdownUDPWithContextError(t *testing.T) {
-	s, _, _, err := RunLocalUDPServerWithFinChan(":0", time.Hour, time.Hour)
-	if err != nil {
-		t.Fatalf("unable to run test server: %v", err)
-	}
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
-	err = s.ShutdownContext(ctx)
-	if err == nil {
-		t.Errorf("shutdown context triggered by deadline did not occur")
 	}
 	cancel()
 }

--- a/server_test.go
+++ b/server_test.go
@@ -600,7 +600,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 	// run a series of queries until we shutdown, for each thread, most likely the last query send will not
 	// be processed before we call the shutdown
 	// but as we force the server to wait all incoming query are processed we expect ALL queries to be replied.
-	for i := 1; i < 50; i++ {
+	for i := 1; i < 10; i++ {
 		wg.Add(1)
 		go func() {
 			for {
@@ -640,7 +640,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 
 	// then stop sending msgs ..
 	close(stop)
-	//time.Sleep(time.Millisecond * 200) // expected time to at least do the write part of the msg (TLS would need about 100ms)
+	time.Sleep(time.Millisecond * 200) // expected time to at least do the write part of the msg (TLS would need about 100ms)
 
 	// And now shutdown the server : we expect that all msg sent will be served
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))

--- a/server_test.go
+++ b/server_test.go
@@ -66,7 +66,7 @@ func RunLocalUDPServerWithFinChan(laddr string, rdtimeout time.Duration) (*Serve
 	// tune the timeouts. If shutdown is lower than rdtimeout and there is no queries,
 	// then ActivateAndServe will end on an error because connection will be close before timeout of ReadUDP.
 
-	shtimeout := rdtimeout
+	shtimeout := rdtimeout + 1 * time.Second  // to avoid error return by Server, we need that ShutdownTimeout is > ReadTimeout
 	if rdtimeout == 0 {
 		rdtimeout = 1 * time.Hour
 		shtimeout = 1 * time.Second

--- a/server_test.go
+++ b/server_test.go
@@ -715,7 +715,7 @@ func TestInProgressQueriesAtShutdownTLS(t *testing.T) {
 		Certificates: []tls.Certificate{cert},
 	}
 
-	s, addr, err := RunLocalTLSServer(":0", &config, time.Second, time.Hour)
+	s, addr, err := RunLocalTLSServer(":0", &config, 3*time.Second, time.Hour)
 	if err != nil {
 		t.Fatalf("unable to run test server: %v", err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -584,7 +584,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 
 	HandleFunc("example.com", func(w ResponseWriter, req *Msg) {
 		// simulate small delay between 0 to 0.5 sec.
-		time.Sleep(time.Duration((rand.Intn(900))+1000) * time.Millisecond)
+		time.Sleep(time.Duration((rand.Intn(500))+100) * time.Millisecond)
 		HelloServer(w, req)
 	})
 
@@ -640,7 +640,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 
 	// then stop sending msgs ..
 	close(stop)
-	time.Sleep(time.Millisecond * 200) // expected time to at least do the write part of the msg (TLS would need about 100ms)
+	//time.Sleep(time.Millisecond * 200) // expected time to at least do the write part of the msg (TLS would need about 100ms)
 
 	// And now shutdown the server : we expect that all msg sent will be served
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*10))

--- a/server_test.go
+++ b/server_test.go
@@ -582,7 +582,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 
 	var h = func(w ResponseWriter, req *Msg) {
 		// simulate small delay between 0 to 0.5 sec.
-		time.Sleep(time.Duration((rand.Intn(500))+ 100)*time.Millisecond)
+		time.Sleep(time.Duration((rand.Intn(900))+ 100)*time.Millisecond)
 		HelloServer(w, req)
 	}
 	HandleFunc("example.com", h)
@@ -626,11 +626,10 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 
 	// then stop everything .. and let see
 	close(stop)
-	time.Sleep(time.Millisecond*50)	// expected time to at least do the write part of the msg
-	// but less than time needed to handle the msg (min is 100 ms)
+	time.Sleep(time.Millisecond*200)	// expected time to at least do the write part of the msg (TLS would need about 100ms)
 
 	// let enough time to shutdown to happen - but do not wait the whole hours defined for readTimeout
-	srv.ShutdownTimeout = time.Second*2
+	srv.ShutdownTimeout = time.Second*5
 	err := srv.Shutdown()
 	if err != nil {
 		t.Errorf("could not shutdown test server, %v", err)


### PR DESCRIPTION
## Summary

Enhance the Shutdown of the server to ensure that all queries received before shutdown is called are completely handled before closing the connections.

related PR : https://github.com/coredns/coredns/pull/1963
related issue : https://github.com/coredns/coredns/issues/1666

### tracking the incoming msg
It requires a SyncGroup to take into account the thread going into READ wait mode, and ack the handle is finished after either an error or the full service of the query.

After shutdown is started none of the listening thread can go start a new READ process. However the current one has to be continued until either a msg is received, either a timeout is reached.

At shutdown, the process wait that all listening thread are terminated before closing the connection

### Timeout
For those who does not want to wait, it is now possible to specify a ShudownTimeout.
Default value is 0 - which means use the biggest of the ReadTimeout of TCP or UDP (incl idleTimeout).


## Tests

I added a test "testLostQueriesAtShutdownServer" that:
- run a server that handle any incoming queries within a random delay of 100 to 600ms
- run a set of 50 concurrent thread. Each one is sending a query to the server until STOP is asked
- wait 1 sec all thread are running
- ask for STOP the msg, 
- wait 50ms that any started sending msg are received bu Server
- ask for Shutdown of the server
- count all sent msg and all received msg by the 50 threads.
- ensure that sent msg == received msg

This test is run for a each of the 3 protocols : UDP, TCP, TLS

