### PR TITLE
Use RFC 8032 functions added to x/crypto/ed25519

### DIFF
--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -1,7 +1,6 @@
 package dns
 
 import (
-	"bytes"
 	"crypto"
 	"crypto/dsa"
 	"crypto/ecdsa"
@@ -181,22 +180,10 @@ func readPrivateKeyED25519(m map[string]string) (ed25519.PrivateKey, error) {
 			if err != nil {
 				return nil, err
 			}
-			if len(p1) != 32 {
+			if len(p1) != ed25519.SeedSize {
 				return nil, ErrPrivKey
 			}
-			// RFC 8080 and Golang's x/crypto/ed25519 differ as to how the
-			// private keys are represented. RFC 8080 specifies that private
-			// keys be stored solely as the seed value (p1 above) while the
-			// ed25519 package represents them as the seed value concatenated
-			// to the public key, which is derived from the seed value.
-			//
-			// ed25519.GenerateKey reads exactly 32 bytes from the passed in
-			// io.Reader and uses them as the seed. It also derives the
-			// public key and produces a compatible private key.
-			_, p, err = ed25519.GenerateKey(bytes.NewReader(p1))
-			if err != nil {
-				return nil, err
-			}
+			p = ed25519.NewKeyFromSeed(p1)
 		case "created", "publish", "activate":
 			/* not used in Go (yet) */
 		}

--- a/dnssec_privkey.go
+++ b/dnssec_privkey.go
@@ -82,7 +82,7 @@ func (r *DNSKEY) PrivateKeyString(p crypto.PrivateKey) string {
 			"Public_value(y): " + pub + "\n"
 
 	case ed25519.PrivateKey:
-		private := toBase64(p[:32])
+		private := toBase64(p.Seed())
 		return format +
 			"Algorithm: " + algorithm + "\n" +
 			"PrivateKey: " + private + "\n"


### PR DESCRIPTION
This was added in golang/crypto@5ba7f63082 and can replace the workaround from #458 / #591.