### PR TITLE
Add go1.10.x to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 sudo: false
 go:
   - 1.9.x
+  - 1.10.x
   - tip
 
 env:


### PR DESCRIPTION
tip now points to what will be go1.11 leaving go1.10 untested.