### PR TITLE
Remove redundant parenthesis

### DIFF
--- a/client.go
+++ b/client.go
@@ -89,7 +89,7 @@ func (c *Client) Dial(address string) (conn *Conn, err error) {
 	// create a new dialer with the appropriate timeout
 	var d net.Dialer
 	if c.Dialer == nil {
-		d = net.Dialer{Timeout:c.getTimeoutForRequest(c.dialTimeout())}
+		d = net.Dialer{Timeout: c.getTimeoutForRequest(c.dialTimeout())}
 	} else {
 		d = net.Dialer(*c.Dialer)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -489,8 +489,8 @@ func TestTimeout(t *testing.T) {
 	done := make(chan struct{}, 2)
 
 	timeout := time.Millisecond
-	allowable := timeout + (10 * time.Millisecond)
-	abortAfter := timeout + (100 * time.Millisecond)
+	allowable := timeout + 10*time.Millisecond
+	abortAfter := timeout + 100*time.Millisecond
 
 	start := time.Now()
 

--- a/dns_test.go
+++ b/dns_test.go
@@ -305,7 +305,7 @@ func TestTKEY(t *testing.T) {
 	if packErr != nil {
 		t.Fatal("unable to pack TKEY RR after modification", packErr)
 	}
-	if offset != (len(tkeyBytes) + 2) {
+	if offset != len(tkeyBytes)+2 {
 		t.Fatalf("mismatched TKEY RR size %d != %d", offset, len(tkeyBytes)+2)
 	}
 

--- a/dnssec.go
+++ b/dnssec.go
@@ -512,8 +512,8 @@ func (rr *RRSIG) ValidityPeriod(t time.Time) bool {
 	}
 	modi := (int64(rr.Inception) - utc) / year68
 	mode := (int64(rr.Expiration) - utc) / year68
-	ti := int64(rr.Inception) + (modi * year68)
-	te := int64(rr.Expiration) + (mode * year68)
+	ti := int64(rr.Inception) + modi*year68
+	te := int64(rr.Expiration) + mode*year68
 	return ti <= utc && utc <= te
 }
 

--- a/dnssec.go
+++ b/dnssec.go
@@ -173,7 +173,7 @@ func (k *DNSKEY) KeyTag() uint16 {
 				keytag += int(v) << 8
 			}
 		}
-		keytag += (keytag >> 16) & 0xFFFF
+		keytag += keytag >> 16 & 0xFFFF
 		keytag &= 0xFFFF
 	}
 	return uint16(keytag)

--- a/edns.go
+++ b/edns.go
@@ -97,7 +97,7 @@ func (rr *OPT) Version() uint8 {
 
 // SetVersion sets the version of EDNS. This is usually zero.
 func (rr *OPT) SetVersion(v uint8) {
-	rr.Hdr.Ttl = rr.Hdr.Ttl&0xFF00FFFF | (uint32(v) << 16)
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0xFF00FFFF | uint32(v)<<16
 }
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
@@ -110,7 +110,7 @@ func (rr *OPT) SetExtendedRcode(v uint8) {
 	if v < RcodeBadVers { // Smaller than 16.. Use the 4 bits you have!
 		return
 	}
-	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | (uint32(v-15) << 24)
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v-15)<<24
 }
 
 // UDPSize returns the UDP buffer size.

--- a/edns.go
+++ b/edns.go
@@ -92,7 +92,7 @@ func (rr *OPT) len() int {
 
 // Version returns the EDNS version used. Only zero is defined.
 func (rr *OPT) Version() uint8 {
-	return uint8((rr.Hdr.Ttl & 0x00FF0000) >> 16)
+	return uint8(rr.Hdr.Ttl & 0x00FF0000 >> 16)
 }
 
 // SetVersion sets the version of EDNS. This is usually zero.
@@ -102,7 +102,7 @@ func (rr *OPT) SetVersion(v uint8) {
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
 func (rr *OPT) ExtendedRcode() int {
-	return int((rr.Hdr.Ttl&0xFF000000)>>24) + 15
+	return int(rr.Hdr.Ttl&0xFF000000>>24) + 15
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.

--- a/labels.go
+++ b/labels.go
@@ -178,10 +178,10 @@ func equal(a, b string) bool {
 		ai := a[i]
 		bi := b[i]
 		if ai >= 'A' && ai <= 'Z' {
-			ai |= ('a' - 'A')
+			ai |= 'a' - 'A'
 		}
 		if bi >= 'A' && bi <= 'Z' {
-			bi |= ('a' - 'A')
+			bi |= 'a' - 'A'
 		}
 		if ai != bi {
 			return false

--- a/msg.go
+++ b/msg.go
@@ -808,15 +808,15 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	}
 
 	dns.Id = dh.Id
-	dns.Response = (dh.Bits & _QR) != 0
+	dns.Response = dh.Bits&_QR != 0
 	dns.Opcode = int(dh.Bits>>11) & 0xF
-	dns.Authoritative = (dh.Bits & _AA) != 0
-	dns.Truncated = (dh.Bits & _TC) != 0
-	dns.RecursionDesired = (dh.Bits & _RD) != 0
-	dns.RecursionAvailable = (dh.Bits & _RA) != 0
-	dns.Zero = (dh.Bits & _Z) != 0
-	dns.AuthenticatedData = (dh.Bits & _AD) != 0
-	dns.CheckingDisabled = (dh.Bits & _CD) != 0
+	dns.Authoritative = dh.Bits&_AA != 0
+	dns.Truncated = dh.Bits&_TC != 0
+	dns.RecursionDesired = dh.Bits&_RD != 0
+	dns.RecursionAvailable = dh.Bits&_RA != 0
+	dns.Zero = dh.Bits&_Z != 0
+	dns.AuthenticatedData = dh.Bits&_AD != 0
+	dns.CheckingDisabled = dh.Bits&_CD != 0
 	dns.Rcode = int(dh.Bits & 0xF)
 
 	// If we are at the end of the message we should return *just* the

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -223,8 +223,8 @@ func unpackUint48(msg []byte, off int) (i uint64, off1 int, err error) {
 		return 0, len(msg), &Error{err: "overflow unpacking uint64 as uint48"}
 	}
 	// Used in TSIG where the last 48 bits are occupied, so for now, assume a uint48 (6 bytes)
-	i = (uint64(uint64(msg[off])<<40 | uint64(msg[off+1])<<32 | uint64(msg[off+2])<<24 | uint64(msg[off+3])<<16 |
-		uint64(msg[off+4])<<8 | uint64(msg[off+5])))
+	i = uint64(uint64(msg[off])<<40 | uint64(msg[off+1])<<32 | uint64(msg[off+2])<<24 | uint64(msg[off+3])<<16 |
+		uint64(msg[off+4])<<8 | uint64(msg[off+5]))
 	off += 6
 	return i, off, nil
 }
@@ -363,7 +363,7 @@ func packStringHex(s string, msg []byte, off int) (int, error) {
 	if err != nil {
 		return len(msg), err
 	}
-	if off+(len(h)) > len(msg) {
+	if off+len(h) > len(msg) {
 		return len(msg), &Error{err: "overflow packing hex"}
 	}
 	copy(msg[off:off+len(h)], h)
@@ -603,7 +603,7 @@ func packDataNsec(bitmap []uint16, msg []byte, off int) (int, error) {
 		// Setting the octets length
 		msg[off+1] = byte(length)
 		// Setting the bit value for the type in the right octet
-		msg[off+1+int(length)] |= byte(1 << (7 - (t % 8)))
+		msg[off+1+int(length)] |= byte(1 << (7 - t%8))
 		lastwindow, lastlength = window, length
 	}
 	off += int(lastlength) + 2

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -893,19 +893,19 @@ Altitude:
 				if !ok {
 					return nil, &ParseError{f, "bad LOC Size", l}, ""
 				}
-				rr.Size = (e & 0x0f) | (m << 4 & 0xf0)
+				rr.Size = e&0x0f | (m<<4)&0xf0
 			case 1: // HorizPre
 				e, m, ok := stringToCm(l.token)
 				if !ok {
 					return nil, &ParseError{f, "bad LOC HorizPre", l}, ""
 				}
-				rr.HorizPre = (e & 0x0f) | (m << 4 & 0xf0)
+				rr.HorizPre = e&0x0f | (m<<4)&0xf0
 			case 2: // VertPre
 				e, m, ok := stringToCm(l.token)
 				if !ok {
 					return nil, &ParseError{f, "bad LOC VertPre", l}, ""
 				}
-				rr.VertPre = (e & 0x0f) | (m << 4 & 0xf0)
+				rr.VertPre = e&0x0f | (m<<4)&0xf0
 			}
 			count++
 		case zBlank:

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -893,19 +893,19 @@ Altitude:
 				if !ok {
 					return nil, &ParseError{f, "bad LOC Size", l}, ""
 				}
-				rr.Size = e&0x0f | (m<<4)&0xf0
+				rr.Size = e&0x0f | m<<4&0xf0
 			case 1: // HorizPre
 				e, m, ok := stringToCm(l.token)
 				if !ok {
 					return nil, &ParseError{f, "bad LOC HorizPre", l}, ""
 				}
-				rr.HorizPre = e&0x0f | (m<<4)&0xf0
+				rr.HorizPre = e&0x0f | m<<4&0xf0
 			case 2: // VertPre
 				e, m, ok := stringToCm(l.token)
 				if !ok {
 					return nil, &ParseError{f, "bad LOC VertPre", l}, ""
 				}
-				rr.VertPre = e&0x0f | (m<<4)&0xf0
+				rr.VertPre = e&0x0f | m<<4&0xf0
 			}
 			count++
 		case zBlank:

--- a/server.go
+++ b/server.go
@@ -151,7 +151,7 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 		for i := 0; i < l; i++ {
 			b[i] = q[off+i]
 			if b[i] >= 'A' && b[i] <= 'Z' {
-				b[i] |= ('a' - 'A')
+				b[i] |= 'a' - 'A'
 			}
 		}
 		if h, ok := mux.z[string(b[:l])]; ok { // causes garbage, might want to change the map key

--- a/types.go
+++ b/types.go
@@ -752,9 +752,9 @@ func (rr *LOC) String() string {
 		s += fmt.Sprintf("%.0fm ", alt)
 	}
 
-	s += cmToM((rr.Size&0xf0)>>4, rr.Size&0x0f) + "m "
-	s += cmToM((rr.HorizPre&0xf0)>>4, rr.HorizPre&0x0f) + "m "
-	s += cmToM((rr.VertPre&0xf0)>>4, rr.VertPre&0x0f) + "m"
+	s += cmToM(rr.Size&0xf0>>4, rr.Size&0x0f) + "m "
+	s += cmToM(rr.HorizPre&0xf0>>4, rr.HorizPre&0x0f) + "m "
+	s += cmToM(rr.VertPre&0xf0>>4, rr.VertPre&0x0f) + "m"
 
 	return s
 }

--- a/types.go
+++ b/types.go
@@ -728,7 +728,7 @@ func (rr *LOC) String() string {
 	lat = lat % LOC_DEGREES
 	m := lat / LOC_HOURS
 	lat = lat % LOC_HOURS
-	s += fmt.Sprintf("%02d %02d %0.3f %s ", h, m, (float64(lat) / 1000), ns)
+	s += fmt.Sprintf("%02d %02d %0.3f %s ", h, m, float64(lat)/1000, ns)
 
 	lon := rr.Longitude
 	ew := "E"
@@ -742,7 +742,7 @@ func (rr *LOC) String() string {
 	lon = lon % LOC_DEGREES
 	m = lon / LOC_HOURS
 	lon = lon % LOC_HOURS
-	s += fmt.Sprintf("%02d %02d %0.3f %s ", h, m, (float64(lon) / 1000), ew)
+	s += fmt.Sprintf("%02d %02d %0.3f %s ", h, m, float64(lon)/1000, ew)
 
 	var alt = float64(rr.Altitude) / 100
 	alt -= LOC_ALTITUDEBASE
@@ -1306,11 +1306,11 @@ func (rr *CSYNC) len() int {
 // string representation used when printing the record.
 // It takes serial arithmetic (RFC 1982) into account.
 func TimeToString(t uint32) string {
-	mod := ((int64(t) - time.Now().Unix()) / year68) - 1
+	mod := (int64(t)-time.Now().Unix())/year68 - 1
 	if mod < 0 {
 		mod = 0
 	}
-	ti := time.Unix(int64(t)-(mod*year68), 0).UTC()
+	ti := time.Unix(int64(t)-mod*year68, 0).UTC()
 	return ti.Format("20060102150405")
 }
 
@@ -1322,11 +1322,11 @@ func StringToTime(s string) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	mod := (t.Unix() / year68) - 1
+	mod := t.Unix()/year68 - 1
 	if mod < 0 {
 		mod = 0
 	}
-	return uint32(t.Unix() - (mod * year68)), nil
+	return uint32(t.Unix() - mod*year68), nil
 }
 
 // saltToString converts a NSECX salt to uppercase and returns "-" when it is empty.


### PR DESCRIPTION
These were caught with:
```bash
gofmt -r '(a) -> a' -w *.go
```

---

I decided to exclude the following change because, although it is correct, it doesn't look as clear to me. I can include it if you disagree.
```diff
diff --git a/msg_helpers_test.go b/msg_helpers_test.go
index adceb882c5..dccc539248 100644
--- a/msg_helpers_test.go
+++ b/msg_helpers_test.go
@@ -92,7 +92,7 @@ func TestPackDataNsec(t *testing.T) {
        for _, tt := range tests {
                t.Run(tt.name, func(t *testing.T) {
                        got, err := packDataNsec(tt.args.bitmap, tt.args.msg, tt.args.off)
-                       if (err != nil) != tt.wantErr {
+                       if err != nil != tt.wantErr {
                                t.Errorf("packDataNsec() error = %v, wantErr %v", err, tt.wantErr)
                                return
                        }
```