### PR TITLE
[tls] Carry TLS state within (possibly) response writer

### DIFF
--- a/server.go
+++ b/server.go
@@ -56,6 +56,12 @@ type ResponseWriter interface {
 	Hijack()
 }
 
+// A TLSResponse interface is used by a DNS Handler to access TLS connection state
+// when available.
+type TLSResponse interface {
+	TLS() *tls.ConnectionState
+}
+
 type response struct {
 	msg            []byte
 	hijacked       bool // connection has been hijacked by handler
@@ -784,6 +790,18 @@ func (w *response) Close() error {
 		e := w.tcp.Close()
 		w.tcp = nil
 		return e
+	}
+	return nil
+}
+
+// TLS implements the TLSResponse.TLS method.
+func (w *response) TLS() *tls.ConnectionState {
+	if w.tcp == nil {
+		return nil
+	}
+	if v, ok := w.tcp.(*tls.Conn); ok {
+		t := v.ConnectionState()
+		return &t
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -56,10 +56,10 @@ type ResponseWriter interface {
 	Hijack()
 }
 
-// A ConnectionState interface is used by a DNS Handler to access TLS connection state
+// A ConnectionStater interface is used by a DNS Handler to access TLS connection state
 // when available.
-type ConnectionState interface {
-	ConnectionState() tls.ConnectionState
+type ConnectionStater interface {
+	ConnectionState() *tls.ConnectionState
 }
 
 type response struct {
@@ -794,10 +794,11 @@ func (w *response) Close() error {
 	return nil
 }
 
-// ConnectionState() implements the ConnectionState.ConnectionState() interface.
-func (w *response) ConnectionState() (t tls.ConnectionState) {
+// ConnectionState() implements the ConnectionStater.ConnectionState() interface.
+func (w *response) ConnectionState() *tls.ConnectionState {
 	if v, ok := w.tcp.(*tls.Conn); ok {
-		return v.ConnectionState()
+		t := v.ConnectionState()
+		return &t
 	}
-	return
+	return nil
 }

--- a/server.go
+++ b/server.go
@@ -59,7 +59,7 @@ type ResponseWriter interface {
 // A ConnectionState interface is used by a DNS Handler to access TLS connection state
 // when available.
 type ConnectionState interface {
-	ConnectionState() *tls.ConnectionState
+	ConnectionState() tls.ConnectionState
 }
 
 type response struct {
@@ -795,10 +795,9 @@ func (w *response) Close() error {
 }
 
 // ConnectionState() implements the ConnectionState.ConnectionState() interface.
-func (w *response) ConnectionState() *tls.ConnectionState {
+func (w *response) ConnectionState() (t tls.ConnectionState) {
 	if v, ok := w.tcp.(*tls.Conn); ok {
-		t := v.ConnectionState()
-		return &t
+		return v.ConnectionState()
 	}
-	return nil
+	return
 }

--- a/server.go
+++ b/server.go
@@ -796,9 +796,6 @@ func (w *response) Close() error {
 
 // TLS implements the TLSResponse.TLS method.
 func (w *response) TLS() *tls.ConnectionState {
-	if w.tcp == nil {
-		return nil
-	}
 	if v, ok := w.tcp.(*tls.Conn); ok {
 		t := v.ConnectionState()
 		return &t

--- a/server.go
+++ b/server.go
@@ -56,10 +56,10 @@ type ResponseWriter interface {
 	Hijack()
 }
 
-// A TLSResponse interface is used by a DNS Handler to access TLS connection state
+// A ConnectionState interface is used by a DNS Handler to access TLS connection state
 // when available.
-type TLSResponse interface {
-	TLS() *tls.ConnectionState
+type ConnectionState interface {
+	ConnectionState() *tls.ConnectionState
 }
 
 type response struct {
@@ -794,8 +794,8 @@ func (w *response) Close() error {
 	return nil
 }
 
-// TLS implements the TLSResponse.TLS method.
-func (w *response) TLS() *tls.ConnectionState {
+// ConnectionState() implements the ConnectionState.ConnectionState() interface.
+func (w *response) ConnectionState() *tls.ConnectionState {
 	if v, ok := w.tcp.(*tls.Conn); ok {
 		t := v.ConnectionState()
 		return &t

--- a/server.go
+++ b/server.go
@@ -796,7 +796,10 @@ func (w *response) Close() error {
 
 // ConnectionState() implements the ConnectionStater.ConnectionState() interface.
 func (w *response) ConnectionState() *tls.ConnectionState {
-	if v, ok := w.tcp.(*tls.Conn); ok {
+	type tlsConnectionStater interface {
+		ConnectionState() tls.ConnectionState
+	}
+	if v, ok := w.tcp.(tlsConnectionStater); ok {
 		t := v.ConnectionState()
 		return &t
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -265,7 +265,6 @@ func TestServingTLS(t *testing.T) {
 // handler which will set a testing error if tls.ConnectionState is available
 // when it is not expected, or the other way around.
 func TestServingTLSConnectionState(t *testing.T) {
-
 	handlerResponse := "Hello example"
 	// tlsHandlerTLS is a HandlerFunc that can be set to expect or not TLS
 	// connection state.
@@ -274,7 +273,7 @@ func TestServingTLSConnectionState(t *testing.T) {
 			m := new(Msg)
 			m.SetReply(req)
 			tlsFound := true
-			if connState := w.(ConnectionState).ConnectionState(); connState.Version == 0 {
+			if connState := w.(ConnectionStater).ConnectionState(); connState == nil {
 				tlsFound = false
 			}
 			if tlsFound != tlsExpected {
@@ -308,10 +307,11 @@ func TestServingTLSConnectionState(t *testing.T) {
 	defer s.Shutdown()
 
 	// TLS DNS query
-	c := new(Client)
-	c.Net = "tcp-tls"
-	c.TLSConfig = &tls.Config{
-		InsecureSkipVerify: true,
+	c := &Client{
+		Net: "tcp-tls",
+		TLSConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
 	}
 
 	_, _, err = c.Exchange(m, addrstr)
@@ -344,8 +344,7 @@ func TestServingTLSConnectionState(t *testing.T) {
 	defer s.Shutdown()
 
 	// TCP DNS query
-	c = new(Client)
-	c.Net = "tcp"
+	c = &Client{Net: "tcp"}
 	_, _, err = c.Exchange(m, addrstr)
 	if err != nil {
 		t.Error("failed to exchange tlsstate.example.net", err)

--- a/server_test.go
+++ b/server_test.go
@@ -58,10 +58,10 @@ func TLSStateServer(w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	txt := TLSOffMsg
-	m.Extra = make([]RR, 1)
 	if tlsState := w.(TLSResponse).TLS(); tlsState != nil {
 		txt = TLSOnMsg
 	}
+	m.Extra = make([]RR, 1)
 	m.Extra[0] = &TXT{Hdr: RR_Header{Name: m.Question[0].Name, Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{txt}}
 	w.WriteMsg(m)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -274,7 +274,7 @@ func TestServingTLSConnectionState(t *testing.T) {
 			m := new(Msg)
 			m.SetReply(req)
 			tlsFound := true
-			if connState := w.(ConnectionState).ConnectionState(); connState == nil {
+			if connState := w.(ConnectionState).ConnectionState(); connState.Version == 0 {
 				tlsFound = false
 			}
 			if tlsFound != tlsExpected {


### PR DESCRIPTION
This allows a server to make decision wether or not the link used to
connect to the DNS server is using TLS.
This can be used by the handler for instance to (but not limited to):
- log that the request was TLS vs TCP
- craft specific responsed knowing that the link is secured
- return custom answers based on client cert (if provided)
...

Fixes #711