### PR TITLE
Fix Serve benchmark failures

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -349,7 +349,7 @@ func BenchmarkServe(b *testing.B) {
 	runtime.GOMAXPROCS(a)
 }
 
-func benchmarkServe6(b *testing.B) {
+func BenchmarkServe6(b *testing.B) {
 	b.StopTimer()
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")

--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -356,6 +357,9 @@ func BenchmarkServe6(b *testing.B) {
 	a := runtime.GOMAXPROCS(4)
 	s, addrstr, err := RunLocalUDPServer("[::1]:0")
 	if err != nil {
+		if strings.Contains(err.Error(), "bind: cannot assign requested address") {
+			b.Skip("missing IPv6 support")
+		}
 		b.Fatalf("unable to run test server: %v", err)
 	}
 	defer s.Shutdown()

--- a/server_test.go
+++ b/server_test.go
@@ -337,11 +337,14 @@ func BenchmarkServe(b *testing.B) {
 
 	c := new(Client)
 	m := new(Msg)
-	m.SetQuestion("miek.nl", TypeSOA)
+	m.SetQuestion("miek.nl.", TypeSOA)
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		c.Exchange(m, addrstr)
+		_, _, err := c.Exchange(m, addrstr)
+		if err != nil {
+			b.Fatalf("Exchange failed: %v", err)
+		}
 	}
 	runtime.GOMAXPROCS(a)
 }
@@ -359,11 +362,14 @@ func benchmarkServe6(b *testing.B) {
 
 	c := new(Client)
 	m := new(Msg)
-	m.SetQuestion("miek.nl", TypeSOA)
+	m.SetQuestion("miek.nl.", TypeSOA)
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		c.Exchange(m, addrstr)
+		_, _, err := c.Exchange(m, addrstr)
+		if err != nil {
+			b.Fatalf("Exchange failed: %v", err)
+		}
 	}
 	runtime.GOMAXPROCS(a)
 }
@@ -390,10 +396,13 @@ func BenchmarkServeCompress(b *testing.B) {
 
 	c := new(Client)
 	m := new(Msg)
-	m.SetQuestion("miek.nl", TypeSOA)
+	m.SetQuestion("miek.nl.", TypeSOA)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		c.Exchange(m, addrstr)
+		_, _, err := c.Exchange(m, addrstr)
+		if err != nil {
+			b.Fatalf("Exchange failed: %v", err)
+		}
 	}
 	runtime.GOMAXPROCS(a)
 }


### PR DESCRIPTION
At present, these benchmarks don't actually work or measure anything. `SetQuestion` must have a fully qualified domain name (trailing dot) to be valid. Because the question wasn't valid, the request never reached the server and was rejected by the client.

With the error check added, the benchmarks started failing with:
```
--- FAIL: BenchmarkServe
    server_test.go:346: Exchange failed: dns: domain must be fully qualified
```