### PR TITLE
Reduce UDP server memory usage

### DIFF
--- a/server.go
+++ b/server.go
@@ -377,6 +377,12 @@ func (srv *Server) spawnWorker(w *response) {
 	}
 }
 
+func makeUDPBuffer(size int) func() interface{} {
+	return func() interface{} {
+		return make([]byte, size)
+	}
+}
+
 func (srv *Server) init() {
 	srv.queue = make(chan *response)
 
@@ -384,9 +390,7 @@ func (srv *Server) init() {
 		srv.UDPSize = MinMsgSize
 	}
 
-	srv.udpPool.New = func() interface{} {
-		return make([]byte, srv.UDPSize)
-	}
+	srv.udpPool.New = makeUDPBuffer(srv.UDPSize)
 }
 
 func unlockOnce(l sync.Locker) func() {

--- a/server.go
+++ b/server.go
@@ -630,6 +630,7 @@ func (srv *Server) serve(w *response) {
 func (srv *Server) serveDNS(w *response) {
 	req := new(Msg)
 	err := req.Unpack(w.msg)
+	w.msg = nil
 	if err != nil { // Send a FormatError back
 		x := new(Msg)
 		x.SetRcodeFormatError(req)


### PR DESCRIPTION
This pull request reduces the memory usage of the UDP server by using a `sync.Pool`.

This is the result of the server benchmarks (with #734):
```
name              old time/op    new time/op    delta
Serve-12            48.7µs ± 3%    50.3µs ± 2%   +3.36%  (p=0.000 n=10+9)
Serve6-12           49.4µs ± 2%    50.8µs ± 3%   +2.80%  (p=0.000 n=10+10)
ServeCompress-12    50.9µs ± 2%    52.9µs ± 3%   +3.87%  (p=0.000 n=10+10)

name              old alloc/op   new alloc/op   delta
Serve-12            3.86kB ± 0%    3.39kB ± 0%  -12.36%  (p=0.000 n=10+10)
Serve6-12           3.70kB ± 0%    3.23kB ± 0%  -12.90%  (p=0.000 n=10+10)
ServeCompress-12    4.12kB ± 0%    3.64kB ± 0%  -11.58%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
Serve-12              56.0 ± 0%      56.0 ± 0%     ~     (all equal)
Serve6-12             53.0 ± 0%      53.0 ± 0%     ~     (all equal)
ServeCompress-12      58.0 ± 0%      58.0 ± 0%     ~     (all equal)
```
The reduced memory usage in those benchmarks would be even more pronounced with a larger `UDPSize` value.

A more complete benchmark, using [dnstrace](https://github.com/redsift/dnstrace), is here: https://gist.github.com/tmthrgd/cfcc4b245267cd8d2571eaeeda0f83ad. Those benchmarks are quite interesting: with the minimum UDP message size, there is no meaningful performance change (182972.7 q/s -> 185201.5 q/s). While on the other hand, when using the maximum message size, there is a *huge* performance increase (74972.8 q/s -> 172692.6 q/s).

This partially address #732.

/cc @larytet @haosdent