### PR TITLE
Simplify (*Client).Dial handling of network type

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,27 +94,17 @@ func (c *Client) Dial(address string) (conn *Conn, err error) {
 		d = net.Dialer(*c.Dialer)
 	}
 
-	network := "udp"
-	useTLS := false
-
-	switch c.Net {
-	case "tcp-tls":
-		network = "tcp"
-		useTLS = true
-	case "tcp4-tls":
-		network = "tcp4"
-		useTLS = true
-	case "tcp6-tls":
-		network = "tcp6"
-		useTLS = true
-	default:
-		if c.Net != "" {
-			network = c.Net
-		}
+	network := c.Net
+	if network == "" {
+		network = "udp"
 	}
+
+	useTLS := strings.HasPrefix(network, "tcp") && strings.HasSuffix(network, "-tls")
 
 	conn = new(Conn)
 	if useTLS {
+		network = strings.TrimSuffix(network, "-tls")
+
 		conn.Conn, err = tls.DialWithDialer(&d, network, address, c.TLSConfig)
 	} else {
 		conn.Conn, err = d.Dial(network, address)
@@ -122,6 +112,7 @@ func (c *Client) Dial(address string) (conn *Conn, err error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return conn, nil
 }
 

--- a/client.go
+++ b/client.go
@@ -91,7 +91,7 @@ func (c *Client) Dial(address string) (conn *Conn, err error) {
 	if c.Dialer == nil {
 		d = net.Dialer{Timeout: c.getTimeoutForRequest(c.dialTimeout())}
 	} else {
-		d = net.Dialer(*c.Dialer)
+		d = *c.Dialer
 	}
 
 	network := c.Net


### PR DESCRIPTION
This isn't a functional change, but it does leave `(*Client).Dial` cleaner and more readable IMHO.