### PR TITLE
Fix TestServerStartStopRace calling t.Fatal on wrong goroutine

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -685,19 +685,21 @@ func TestShutdownUDP(t *testing.T) {
 }
 
 func TestServerStartStopRace(t *testing.T) {
+	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
-		var err error
-		s := &Server{}
-		s, _, _, err = RunLocalUDPServerWithFinChan(":0")
+		wg.Add(1)
+		s, _, _, err := RunLocalUDPServerWithFinChan(":0")
 		if err != nil {
 			t.Fatalf("could not start server: %s", err)
 		}
 		go func() {
+			defer wg.Done()
 			if err := s.Shutdown(); err != nil {
-				t.Fatalf("could not stop server: %s", err)
+				t.Errorf("could not stop server: %s", err)
 			}
 		}()
 	}
+	wg.Wait()
 }
 
 type ExampleFrameLengthWriter struct {


### PR DESCRIPTION
If `Shutdown` returns an error, then `TestServerStartStopRace` will panic because `t.Fatal` is called in a different goroutine. This pull request fixes this, preventing a panic in this case.
```
--- FAIL: TestServerStartStopRace (0.00s)
    server_test.go:856: could not stop server: close udp [::]:52229: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:42807: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:40527: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:46957: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:44677: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:46759: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:51701: use of closed network connection
    server_test.go:856: could not stop server: close udp [::]:52144: use of closed network connection
panic: Fail in goroutine after TestServerStartStopRace has completed

goroutine 2455 [running]:
testing.(*common).Fail(0xc00019e300)
        /home/tom/sdk/go1.11/src/testing/testing.go:546 +0x135
testing.(*common).FailNow(0xc00019e300)
        /home/tom/sdk/go1.11/src/testing/testing.go:568 +0x2b
testing.(*common).Fatalf(0xc00019e300, 0x940473, 0x19, 0xc00072b7b0, 0x1, 0x1)
        /home/tom/sdk/go1.11/src/testing/testing.go:634 +0x83
github.com/tmthrgd/dns.TestServerStartStopRace.func1(0xc00019f700, 0xc00019e300)
        /home/tom/go/src/github.com/tmthrgd/dns/server_test.go:856 +0x97
created by github.com/tmthrgd/dns.TestServerStartStopRace
        /home/tom/go/src/github.com/tmthrgd/dns/server_test.go:854 +0x51
exit status 2
```