### PR TITLE
Use strings.Builder in unpackString

### DIFF
--- a/msg_helpers_test.go
+++ b/msg_helpers_test.go
@@ -106,3 +106,33 @@ func TestPackDataNsec(t *testing.T) {
 		})
 	}
 }
+
+func TestUnpackString(t *testing.T) {
+	msg := []byte("\x00abcdef\x0f\\\"ghi\x04mmm")
+	msg[0] = byte(len(msg) - 1)
+
+	got, _, err := unpackString(msg, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if want := `abcdef\015\\\"ghi\004mmm`; want != got {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func BenchmarkUnpackString(b *testing.B) {
+	msg := []byte("\x00abcdef\x0f\\\"ghi\x04mmm")
+	msg[0] = byte(len(msg) - 1)
+
+	for n := 0; n < b.N; n++ {
+		got, _, err := unpackString(msg, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if want := `abcdef\015\\\"ghi\004mmm`; want != got {
+			b.Errorf("expected %q, got %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
This improves the performance of `unpackString` and reduces the memory allocations.

```
name             old time/op    new time/op    delta
UnpackString-12     186ns ±29%     122ns ±11%  -34.58%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
UnpackString-12     80.0B ± 0%     48.0B ± 0%  -40.00%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
UnpackString-12      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```