### PR TITLE
Use correct build constraints for listen_*.go files

### DIFF
--- a/listen_go111.go
+++ b/listen_go111.go
@@ -1,4 +1,5 @@
-// +build go1.11,!windows
+// +build go1.11
+// +build aix darwin dragonfly freebsd linux netbsd openbsd
 
 package dns
 

--- a/listen_go_not111.go
+++ b/listen_go_not111.go
@@ -1,4 +1,4 @@
-// +build !go1.11 windows
+// +build !go1.11 !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
 
 package dns
 


### PR DESCRIPTION
`unix.SO_REUSEPORT` isn't defined for solaris (or some other non-windows platforms).

The format for build constraints is confusing IMHO, but I'm pretty certain these are correct [[ref]](https://golang.org/pkg/go/build/#hdr-Build_Constraints).

I've confirmed this now builds for solaris/amd64 (cross-compiled from linux/amd64).

This fixes #747.