### PR TITLE
Rework and optimise ServeMux

### DIFF
--- a/serve_mux.go
+++ b/serve_mux.go
@@ -5,12 +5,14 @@ import (
 	"sync"
 )
 
-// ServeMux is an DNS request multiplexer. It matches the
-// zone name of each incoming request against a list of
-// registered patterns add calls the handler for the pattern
-// that most closely matches the zone name. ServeMux is DNSSEC aware, meaning
-// that queries for the DS record are redirected to the parent zone (if that
-// is also registered), otherwise the child gets the query.
+// ServeMux is an DNS request multiplexer. It matches the zone name of
+// each incoming request against a list of registered patterns add calls
+// the handler for the pattern that most closely matches the zone name.
+//
+// ServeMux is DNSSEC aware, meaning that queries for the DS record are
+// redirected to the parent zone (if that is also registered), otherwise
+// the child gets the query.
+//
 // ServeMux is also safe for concurrent access from multiple goroutines.
 //
 // The zero ServeMux is empty and ready for use.

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -86,17 +86,16 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 // If no handler is found, or there is no question, a standard SERVFAIL
 // message is returned
 func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
-	if len(req.Question) < 1 { // allow more than one question
+	var h Handler
+	if len(req.Question) >= 1 { // allow more than one question
+		h = mux.match(req.Question[0].Name, req.Question[0].Qtype)
+	}
+
+	if h != nil {
+		h.ServeDNS(w, req)
+	} else {
 		HandleFailed(w, req)
-		return
 	}
-
-	h := mux.match(req.Question[0].Name, req.Question[0].Qtype)
-	if h == nil {
-		h = HandlerFunc(HandleFailed)
-	}
-
-	h.ServeDNS(w, req)
 }
 
 // Handle registers the handler with the given pattern

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -37,7 +37,31 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 	}
 
 	var handler Handler
-	q = strings.ToLower(q)
+
+	// TODO(tmthrgd): Once https://go-review.googlesource.com/c/go/+/137575
+	// lands in a go release, replace the following with strings.ToLower.
+	var sb strings.Builder
+	for i := 0; i < len(q); i++ {
+		c := q[i]
+		if !(c >= 'A' && c <= 'Z') {
+			continue
+		}
+
+		sb.Grow(len(q))
+		sb.WriteString(q[:i])
+
+		for ; i < len(q); i++ {
+			c := q[i]
+			if c >= 'A' && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+
+			sb.WriteByte(c)
+		}
+
+		q = sb.String()
+		break
+	}
 
 	for off, end := 0, false; !end; off, end = NextLabel(q, off) {
 		if h, ok := mux.z[q[off:]]; ok {

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -32,19 +32,13 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 	defer mux.m.RUnlock()
 	var handler Handler
 	q = strings.ToLower(q)
-	off := 0
-	end := false
-	for {
+	for off, end := 0, false; !end; off, end = NextLabel(q, off) {
 		if h, ok := mux.z[q[off:]]; ok {
 			if t != TypeDS {
 				return h
 			}
 			// Continue for DS to see if we have a parent too, if so delegeate to the parent
 			handler = h
-		}
-		off, end = NextLabel(q, off)
-		if end {
-			break
 		}
 	}
 	// Wildcard match, if we have found nothing try the root zone as a last resort.

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -42,7 +42,7 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 			if t != TypeDS {
 				return h
 			}
-			// Continue for DS to see if we have a parent too, if so delegeate to the parent
+			// Continue for DS to see if we have a parent too, if so delegate to the parent
 			handler = h
 		}
 	}

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -30,8 +30,13 @@ var DefaultServeMux = NewServeMux()
 func (mux *ServeMux) match(q string, t uint16) Handler {
 	mux.m.RLock()
 	defer mux.m.RUnlock()
+	if mux.z == nil {
+		return nil
+	}
+
 	var handler Handler
 	q = strings.ToLower(q)
+
 	for off, end := 0, false; !end; off, end = NextLabel(q, off) {
 		if h, ok := mux.z[q[off:]]; ok {
 			if t != TypeDS {
@@ -41,10 +46,12 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 			handler = h
 		}
 	}
+
 	// Wildcard match, if we have found nothing try the root zone as a last resort.
 	if h, ok := mux.z["."]; ok {
 		return h
 	}
+
 	return handler
 }
 

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -76,13 +76,15 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 	mux.m.Unlock()
 }
 
-// ServeDNS dispatches the request to the handler whose
-// pattern most closely matches the request message. If DefaultServeMux
-// is used the correct thing for DS queries is done: a possible parent
-// is sought.
-// If no handler is found a standard SERVFAIL message is returned
-// If the request message does not have exactly one question in the
-// question section a SERVFAIL is returned, unlesss Unsafe is true.
+// ServeDNS dispatches the request to the handler whose pattern most
+// closely matches the request message.
+//
+// ServeDNS is DNSSEC aware, meaning that queries for the DS record
+// are redirected to the parent zone (if that is also registered),
+// otherwise the child gets the query.
+//
+// If no handler is found, or there is no question, a standard SERVFAIL
+// message is returned
 func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
 	if len(req.Question) < 1 { // allow more than one question
 		HandleFailed(w, req)

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -9,6 +9,8 @@ import "sync"
 // that queries for the DS record are redirected to the parent zone (if that
 // is also registered), otherwise the child gets the query.
 // ServeMux is also safe for concurrent access from multiple goroutines.
+//
+// The zero ServeMux is empty and ready for use.
 type ServeMux struct {
 	z map[string]Handler
 	m sync.RWMutex
@@ -16,7 +18,7 @@ type ServeMux struct {
 
 // NewServeMux allocates and returns a new ServeMux.
 func NewServeMux() *ServeMux {
-	return &ServeMux{z: make(map[string]Handler)}
+	return new(ServeMux)
 }
 
 // DefaultServeMux is the default ServeMux used by Serve.
@@ -62,6 +64,9 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 		panic("dns: invalid pattern " + pattern)
 	}
 	mux.m.Lock()
+	if mux.z == nil {
+		mux.z = make(map[string]Handler)
+	}
 	mux.z[Fqdn(pattern)] = handler
 	mux.m.Unlock()
 }

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -1,6 +1,9 @@
 package dns
 
-import "sync"
+import (
+	"strings"
+	"sync"
+)
 
 // ServeMux is an DNS request multiplexer. It matches the
 // zone name of each incoming request against a list of
@@ -28,18 +31,11 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 	mux.m.RLock()
 	defer mux.m.RUnlock()
 	var handler Handler
-	b := make([]byte, len(q)) // worst case, one label of length q
+	q = strings.ToLower(q)
 	off := 0
 	end := false
 	for {
-		l := len(q[off:])
-		for i := 0; i < l; i++ {
-			b[i] = q[off+i]
-			if b[i] >= 'A' && b[i] <= 'Z' {
-				b[i] |= 'a' - 'A'
-			}
-		}
-		if h, ok := mux.z[string(b[:l])]; ok { // causes garbage, might want to change the map key
+		if h, ok := mux.z[q[off:]]; ok {
 			if t != TypeDS {
 				return h
 			}

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -75,7 +75,7 @@ func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Ms
 	mux.Handle(pattern, HandlerFunc(handler))
 }
 
-// HandleRemove deregistrars the handler specific for pattern from the ServeMux.
+// HandleRemove deregisters the handler specific for pattern from the ServeMux.
 func (mux *ServeMux) HandleRemove(pattern string) {
 	if pattern == "" {
 		panic("dns: invalid pattern " + pattern)

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -11,12 +11,12 @@ import "sync"
 // ServeMux is also safe for concurrent access from multiple goroutines.
 type ServeMux struct {
 	z map[string]Handler
-	m *sync.RWMutex
+	m sync.RWMutex
 }
 
 // NewServeMux allocates and returns a new ServeMux.
 func NewServeMux() *ServeMux {
-	return &ServeMux{z: make(map[string]Handler), m: new(sync.RWMutex)}
+	return &ServeMux{z: make(map[string]Handler)}
 }
 
 // DefaultServeMux is the default ServeMux used by Serve.

--- a/serve_mux_test.go
+++ b/serve_mux_test.go
@@ -52,3 +52,21 @@ func TestRootServer(t *testing.T) {
 		t.Error("root match failed")
 	}
 }
+
+func BenchmarkMuxMatch(b *testing.B) {
+	mux := NewServeMux()
+	mux.Handle("_udp.example.com.", HandlerFunc(HelloServer))
+
+	bench := func(q string) func(*testing.B) {
+		return func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				handler := mux.match(q, TypeSRV)
+				if handler == nil {
+					b.Fatal("couldn't find match")
+				}
+			}
+		}
+	}
+	b.Run("lowercase", bench("_dns._udp.example.com."))
+	b.Run("uppercase", bench("_DNS._UDP.EXAMPLE.COM."))
+}


### PR DESCRIPTION
This is several changes to `ServeMux` in one PR:
- The zero `ServeMux` is now usable, `NewServeMux` doesn't need to be called.
- A series of documentation changes.
- Changes to make `ServeMux.ServeDNS` more readable.
- Performance improvements, and simplification, in `ServeMux.match`. Note this is complicated somewhat by ^1.

```
name                   old time/op    new time/op    delta
MuxMatch/lowercase-12     108ns ± 3%      68ns ± 2%   -36.94%  (p=0.000 n=10+10)
MuxMatch/uppercase-12     111ns ± 3%     120ns ± 1%    +7.34%  (p=0.000 n=9+10)

name                   old alloc/op   new alloc/op   delta
MuxMatch/lowercase-12     32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
MuxMatch/uppercase-12     32.0B ± 0%     32.0B ± 0%      ~     (all equal)

name                   old allocs/op  new allocs/op  delta
MuxMatch/lowercase-12      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
MuxMatch/uppercase-12      1.00 ± 0%      1.00 ± 0%      ~     (all equal)
```

^1: `strings.ToLower` contains one extra allocation in the uppercase case that will be fixed by [CL 137575](https://go-review.googlesource.com/c/go/+/137575). Until that lands, I've reimplemented an ASCII-only `ToLower` that avoids the allocation. This complicates the diff and only improves the case where `q` (the domain name) has uppercase characters. @miekg If this is uncommon, I'd be very happy to revert that part of this PR, but it will temporarily worsen the uppercase performance.