### PR TITLE
Fix unpackString bug: 127 DEL is unprintable

### DIFF
--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -275,7 +275,7 @@ func unpackString(msg []byte, off int) (string, int, error) {
 		case b == '"' || b == '\\':
 			s.WriteByte('\\')
 			s.WriteByte(b)
-		case b < 32 || b > 127: // unprintable
+		case b < ' ' || b > '~': // unprintable
 			var buf [3]byte
 			bufs := strconv.AppendInt(buf[:0], int64(b), 10)
 			s.WriteByte('\\')

--- a/msg_helpers_test.go
+++ b/msg_helpers_test.go
@@ -108,7 +108,7 @@ func TestPackDataNsec(t *testing.T) {
 }
 
 func TestUnpackString(t *testing.T) {
-	msg := []byte("\x00abcdef\x0f\\\"ghi\x04mmm")
+	msg := []byte("\x00abcdef\x0f\\\"ghi\x04mmm\x7f")
 	msg[0] = byte(len(msg) - 1)
 
 	got, _, err := unpackString(msg, 0)
@@ -116,7 +116,7 @@ func TestUnpackString(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want := `abcdef\015\\\"ghi\004mmm`; want != got {
+	if want := `abcdef\015\\\"ghi\004mmm\127`; want != got {
 		t.Errorf("expected %q, got %q", want, got)
 	}
 }


### PR DESCRIPTION
This case previously differed from `UnpackDomainName` in msg.go and both `sprintTxtOctet` and `appendTXTStringByte` in types.go and was incorrect.

32 is ASCII space and 126 is ASCII tilde, with 127 being DEL. This was obviously meant to be `>=` but this is consistent with the format of types.go.