### PR TITLE
NSEC type bitmap packing bug

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -302,6 +302,12 @@ func packDomainName(s string, msg []byte, off int, compression map[string]int, c
 	}
 	// If we did compression and we find something add the pointer here
 	if pointer != -1 {
+		// Clear the msg buffer after the pointer location, otherwise
+		// packDataNsec writes the wrong data to msg.
+		tainted := msg[nameoffset:off]
+		for i := range tainted {
+			tainted[i] = 0
+		}
 		// We have two bytes (14 bits) to put the pointer in
 		// if msg == nil, we will never do compression
 		binary.BigEndian.PutUint16(msg[nameoffset:], uint16(pointer^0xC000))


### PR DESCRIPTION
This clears the tainted part of the message before writing the compression pointer.

This includes a test case ported from the original issue.

Fixes #741

/cc @cesarkuroiwa