### PR TITLE
Explicitly panic after (*response).Close

### DIFF
--- a/server.go
+++ b/server.go
@@ -754,7 +754,7 @@ func (w *response) Write(m []byte) (int, error) {
 		n, err := io.Copy(w.tcp, bytes.NewReader(m))
 		return int(n), err
 	default:
-		panic("Write called after Close")
+		panic("dns: Write called after Close")
 	}
 }
 
@@ -766,7 +766,7 @@ func (w *response) LocalAddr() net.Addr {
 	case w.tcp != nil:
 		return w.tcp.LocalAddr()
 	default:
-		panic("LocalAddr called after Close")
+		panic("dns: LocalAddr called after Close")
 	}
 }
 
@@ -778,7 +778,7 @@ func (w *response) RemoteAddr() net.Addr {
 	case w.tcp != nil:
 		return w.tcp.RemoteAddr()
 	default:
-		panic("RemoteAddr called after Close")
+		panic("dns: RemoteAddr called after Close")
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -753,24 +753,33 @@ func (w *response) Write(m []byte) (int, error) {
 
 		n, err := io.Copy(w.tcp, bytes.NewReader(m))
 		return int(n), err
+	default:
+		panic("Write called after Close")
 	}
-	panic("not reached")
 }
 
 // LocalAddr implements the ResponseWriter.LocalAddr method.
 func (w *response) LocalAddr() net.Addr {
-	if w.tcp != nil {
+	switch {
+	case w.udp != nil:
+		return w.udp.LocalAddr()
+	case w.tcp != nil:
 		return w.tcp.LocalAddr()
+	default:
+		panic("LocalAddr called after Close")
 	}
-	return w.udp.LocalAddr()
 }
 
 // RemoteAddr implements the ResponseWriter.RemoteAddr method.
 func (w *response) RemoteAddr() net.Addr {
-	if w.tcp != nil {
+	switch {
+	case w.udpSession != nil:
+		return w.udpSession.RemoteAddr()
+	case w.tcp != nil:
 		return w.tcp.RemoteAddr()
+	default:
+		panic("RemoteAddr called after Close")
 	}
-	return w.udpSession.RemoteAddr()
 }
 
 // TsigStatus implements the ResponseWriter.TsigStatus method.

--- a/server_test.go
+++ b/server_test.go
@@ -993,8 +993,11 @@ func TestServerRoundtripTsig(t *testing.T) {
 func TestResponseAfterClose(t *testing.T) {
 	testPanic := func(name string, fn func()) {
 		defer func() {
-			if recover() == nil {
+			expect := fmt.Sprintf("dns: %s called after Close", name)
+			if err := recover(); err == nil {
 				t.Errorf("expected panic from %s after Close", name)
+			} else if err != expect {
+				t.Errorf("expected explicit panic from %s after Close, expected %q, got %q", name, expect, err)
 			}
 		}()
 		fn()

--- a/server_test.go
+++ b/server_test.go
@@ -990,6 +990,32 @@ func TestServerRoundtripTsig(t *testing.T) {
 	}
 }
 
+func TestResponseAfterClose(t *testing.T) {
+	testPanic := func(name string, fn func()) {
+		defer func() {
+			if recover() == nil {
+				t.Errorf("expected panic from %s after Close", name)
+			}
+		}()
+		fn()
+	}
+
+	rw := &response{
+		tcp:        nil, // Close sets tcp to nil
+		udp:        nil,
+		udpSession: nil,
+	}
+	testPanic("Write", func() {
+		rw.Write(make([]byte, 2))
+	})
+	testPanic("LocalAddr", func() {
+		rw.LocalAddr()
+	})
+	testPanic("RemoteAddr", func() {
+		rw.RemoteAddr()
+	})
+}
+
 type ExampleFrameLengthWriter struct {
 	Writer
 }


### PR DESCRIPTION
Calling any of `Write`, `LocalAddr` or `RemoteAddr` after calling `Close` on a TCP connection will cause a panic like the following:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x93e4db]

goroutine 129363104 [running]:
github.com/miekg/dns.(*SessionUDP).RemoteAddr(...)
/build/go/src/github.com/miekg/dns/udp.go:34
github.com/miekg/dns.(*response).RemoteAddr(0xc0025ebdd0, 0xc0001d6a80, 0xc000952d72)
/build/go/src/github.com/miekg/dns/server.go:773 +0x5b
```

This pull request adds explicit panics in each of these functions. An alternative is to make `LocalAddr` and `RemoteAddr` to return valid results after `Close`, but this is more explicit at least until such a decision is made.

Updates #766

/cc @semihalev