### PR TITLE
Fix race on loop variable in TestConcurrentExchanges

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -539,8 +539,9 @@ func TestConcurrentExchanges(t *testing.T) {
 		block := make(chan struct{})
 		waiting := make(chan struct{})
 
+		mm := m // redeclare m so as not to trip the race detector
 		handler := func(w ResponseWriter, req *Msg) {
-			r := m.Copy()
+			r := mm.Copy()
 			r.SetReply(req)
 
 			waiting <- struct{}{}


### PR DESCRIPTION
The for loop was writing the variable in one goroutine that was being read in another. This didn't actually race under normal conditions, because it was sequential, but still manage to trip the race detector in one case.

```
==================
WARNING: DATA RACE
Write at 0x00c00009e0f8 by goroutine 40:
  github.com/miekg/dns.TestConcurrentExchanges()
      /home/travis/gopath/src/github.com/miekg/dns/client_test.go:538 +0x41c
  testing.tRunner()
      /home/travis/.gimme/versions/go1.11.linux.amd64/src/testing/testing.go:827 +0x162
Previous read at 0x00c00009e0f8 by goroutine 44:
  github.com/miekg/dns.TestConcurrentExchanges.func1()
      /home/travis/gopath/src/github.com/miekg/dns/client_test.go:543 +0x5c
  github.com/miekg/dns.HandlerFunc.ServeDNS()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:52 +0x69
  github.com/miekg/dns.(*ServeMux).ServeDNS()
      /home/travis/gopath/src/github.com/miekg/dns/serve_mux.go:128 +0xf5
  github.com/miekg/dns.(*Server).serveDNS()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:665 +0x2e4
  github.com/miekg/dns.(*Server).serve()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:570 +0x733
  github.com/miekg/dns.(*Server).worker()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:268 +0x3c4
Goroutine 40 (running) created at:
  testing.(*T).Run()
      /home/travis/.gimme/versions/go1.11.linux.amd64/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /home/travis/.gimme/versions/go1.11.linux.amd64/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /home/travis/.gimme/versions/go1.11.linux.amd64/src/testing/testing.go:827 +0x162
  testing.runTests()
      /home/travis/.gimme/versions/go1.11.linux.amd64/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /home/travis/.gimme/versions/go1.11.linux.amd64/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:594 +0x332
Goroutine 44 (running) created at:
  github.com/miekg/dns.(*Server).spawnWorker()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:283 +0xfb
  github.com/miekg/dns.(*Server).serveUDP()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:549 +0x74d
  github.com/miekg/dns.(*Server).ActivateAndServe()
      /home/travis/gopath/src/github.com/miekg/dns/server.go:395 +0x4e8
  github.com/miekg/dns.RunLocalUDPServerWithFinChan.func1()
      /home/travis/gopath/src/github.com/miekg/dns/server_test.go:83 +0x38
==================
```

Fixes #772