### PR TITLE
Only test coverage against latest stable go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,16 @@
 language: go
 sudo: false
+
 go:
   - 1.10.x
   - 1.11.x
   - tip
 
-env:
-  - TESTS="-race -v -bench=. -coverprofile=coverage.txt -covermode=atomic"
-  - TESTS="-race -v ./..."
+matrix:
+  include:
+  - name: test coverage profile
+    go: 1.11.x
+    env: COVER="-bench=. -coverprofile=coverage.txt -covermode=atomic"
 
 before_install:
   # don't use the miekg/dns when testing forks
@@ -15,7 +18,7 @@ before_install:
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
 
 script:
-  - go test $TESTS
+  - go test -race -v "$COVER" ./...
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - if [[ -n "${COVER}" ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ go:
   - 1.11.x
   - tip
 
+env: TESTS="-race -v ./..."
+
 matrix:
   include:
-  - name: test coverage profile
+  - name: test coverage profile (go 1.11.x)
     go: 1.11.x
-    env: COVER="-bench=. -coverprofile=coverage.txt -covermode=atomic"
+    env: TESTS="-race -v -bench=. -coverprofile=coverage.txt -covermode=atomic"
 
 before_install:
   # don't use the miekg/dns when testing forks
@@ -18,7 +20,7 @@ before_install:
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
 
 script:
-  - go test -race -v "$COVER" ./...
+  - go test $TESTS
 
 after_success:
-  - if [[ -n "${COVER}" ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ -e coverage.txt ]]; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
**DO NOT MERGE**: This is a work in progress.

The coverage Travis builds are much slower (2x on average) than the non-coverage builds. The coverage results also shouldn't diverge that significantly between go versions.