### PR TITLE
Hold srv.lock while calling SetReadDeadline

### DIFF
--- a/server.go
+++ b/server.go
@@ -416,13 +416,12 @@ func (srv *Server) Shutdown() error {
 // to terminate.
 func (srv *Server) ShutdownContext(ctx context.Context) error {
 	srv.lock.Lock()
-	started := srv.started
-	srv.started = false
-	srv.lock.Unlock()
-
-	if !started {
+	if !srv.started {
+		srv.lock.Unlock()
 		return &Error{err: "server not started"}
 	}
+
+	srv.started = false
 
 	if srv.PacketConn != nil {
 		srv.PacketConn.SetReadDeadline(aLongTimeAgo) // Unblock reads
@@ -432,10 +431,10 @@ func (srv *Server) ShutdownContext(ctx context.Context) error {
 		srv.Listener.Close()
 	}
 
-	srv.lock.Lock()
 	for rw := range srv.conns {
 		rw.SetReadDeadline(aLongTimeAgo) // Unblock reads
 	}
+
 	srv.lock.Unlock()
 
 	if testShutdownNotify != nil {
@@ -666,13 +665,15 @@ func (srv *Server) serveDNS(w *response) {
 }
 
 func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
-	if srv.isStarted() {
-		// If we race with ShutdownContext, the read deadline may
-		// have been set in the distant past to unblock the read
-		// below. We must not override it, otherwise we may block
-		// ShutdownContext.
+	// If we race with ShutdownContext, the read deadline may
+	// have been set in the distant past to unblock the read
+	// below. We must not override it, otherwise we may block
+	// ShutdownContext.
+	srv.lock.Lock()
+	if srv.started {
 		conn.SetReadDeadline(time.Now().Add(timeout))
 	}
+	srv.lock.Unlock()
 
 	l := make([]byte, 2)
 	n, err := conn.Read(l)
@@ -708,10 +709,12 @@ func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error)
 }
 
 func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error) {
-	if srv.isStarted() {
+	srv.lock.Lock()
+	if srv.started {
 		// See the comment in readTCP above.
 		conn.SetReadDeadline(time.Now().Add(timeout))
 	}
+	srv.lock.Unlock()
 
 	m := srv.udpPool.Get().([]byte)
 	n, s, err := ReadFromSessionUDP(conn, m)

--- a/server.go
+++ b/server.go
@@ -669,11 +669,11 @@ func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error)
 	// have been set in the distant past to unblock the read
 	// below. We must not override it, otherwise we may block
 	// ShutdownContext.
-	srv.lock.Lock()
+	srv.lock.RLock()
 	if srv.started {
 		conn.SetReadDeadline(time.Now().Add(timeout))
 	}
-	srv.lock.Unlock()
+	srv.lock.RUnlock()
 
 	l := make([]byte, 2)
 	n, err := conn.Read(l)
@@ -709,12 +709,12 @@ func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error)
 }
 
 func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error) {
-	srv.lock.Lock()
+	srv.lock.RLock()
 	if srv.started {
 		// See the comment in readTCP above.
 		conn.SetReadDeadline(time.Now().Add(timeout))
 	}
-	srv.lock.Unlock()
+	srv.lock.RUnlock()
 
 	m := srv.udpPool.Get().([]byte)
 	n, s, err := ReadFromSessionUDP(conn, m)


### PR DESCRIPTION
It seems I was very much on the right track with #774, but the race was still there. This *should* finally solve the problem and make graceful shutdown more reliable and not hang like before.

Like I did in #774, I'm going to run the Travis build a few times and see if anything trips.

~This does introduce a lock where there previously wasn't so it could negatively affect performance, that being said, only a read lock is held during the critical path which shouldn't cause any lock congestion.~ (Edit: no it doesn’t, `isShutdown` already held the same lock).

Fixes #756
Closes #761
Closes #763
Closes #771
Updates #774
