### PR TITLE
Test coverage for all packages and merge Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: go
 sudo: false
+
 go:
   - 1.10.x
   - 1.11.x
   - tip
-
-env:
-  - TESTS="-race -v -bench=. -coverprofile=coverage.txt -covermode=atomic"
-  - TESTS="-race -v ./..."
 
 before_install:
   # don't use the miekg/dns when testing forks
@@ -15,7 +12,7 @@ before_install:
   - ln -s $TRAVIS_BUILD_DIR $GOPATH/src/github.com/miekg/ || true
 
 script:
-  - go test $TESTS
+  - go test -race -v -bench=. -coverprofile=coverage.txt -covermode=atomic ./...
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This halves the number of Travis builds that will run, while adding coverage testing to the `dnsutil` package.