### PR TITLE
properly set extended rcode when packing

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -102,15 +102,15 @@ func (rr *OPT) SetVersion(v uint8) {
 
 // ExtendedRcode returns the EDNS extended RCODE field (the upper 8 bits of the TTL).
 func (rr *OPT) ExtendedRcode() int {
-	return int(rr.Hdr.Ttl&0xFF000000>>24) + 15
+	return int(rr.Hdr.Ttl&0xFF000000>>24) << 4
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.
-func (rr *OPT) SetExtendedRcode(v uint8) {
+func (rr *OPT) SetExtendedRcode(v uint16) {
 	if v < RcodeBadVers { // Smaller than 16.. Use the 4 bits you have!
 		return
 	}
-	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v-15)<<24
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v >> 4)<<24
 }
 
 // UDPSize returns the UDP buffer size.

--- a/edns.go
+++ b/edns.go
@@ -106,10 +106,8 @@ func (rr *OPT) ExtendedRcode() int {
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.
+// If the RCODE is not an extended RCODE, will reset the extended RCODE field to 0.
 func (rr *OPT) SetExtendedRcode(v uint16) {
-	if v < RcodeBadVers { // Smaller than 16.. Use the 4 bits you have!
-		return
-	}
 	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v >> 4)<<24
 }
 

--- a/edns.go
+++ b/edns.go
@@ -106,6 +106,7 @@ func (rr *OPT) ExtendedRcode() int {
 }
 
 // SetExtendedRcode sets the EDNS extended RCODE field.
+//
 // If the RCODE is not an extended RCODE, will reset the extended RCODE field to 0.
 func (rr *OPT) SetExtendedRcode(v uint16) {
 	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v>>4)<<24

--- a/edns.go
+++ b/edns.go
@@ -108,7 +108,7 @@ func (rr *OPT) ExtendedRcode() int {
 // SetExtendedRcode sets the EDNS extended RCODE field.
 // If the RCODE is not an extended RCODE, will reset the extended RCODE field to 0.
 func (rr *OPT) SetExtendedRcode(v uint16) {
-	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v >> 4)<<24
+	rr.Hdr.Ttl = rr.Hdr.Ttl&0x00FFFFFF | uint32(v>>4)<<24
 }
 
 // UDPSize returns the UDP buffer size.

--- a/edns_test.go
+++ b/edns_test.go
@@ -62,7 +62,8 @@ func TestOPTTtl(t *testing.T) {
 	}
 
 	e.SetExtendedRcode(42)
-	if e.ExtendedRcode() != 42 {
-		t.Errorf("set 42, expected %d, got %d", 42, e.ExtendedRcode())
+	// ExtendedRcode has the last 4 bits set to 0.
+	if e.ExtendedRcode() != 42 & 0xFFFFFFF0 {
+		t.Errorf("set 42, expected %d, got %d", 42 & 0xFFFFFFF0, e.ExtendedRcode())
 	}
 }

--- a/edns_test.go
+++ b/edns_test.go
@@ -66,4 +66,10 @@ func TestOPTTtl(t *testing.T) {
 	if e.ExtendedRcode() != 42 & 0xFFFFFFF0 {
 		t.Errorf("set 42, expected %d, got %d", 42 & 0xFFFFFFF0, e.ExtendedRcode())
 	}
+
+	// This will reset the 8 upper bits of the extended rcode
+	e.SetExtendedRcode(RcodeNotAuth)
+	if e.ExtendedRcode() != 0 {
+		t.Errorf("Setting a non-extended rcode is expected to set extended rcode to 0, got: %d", e.ExtendedRcode())
+	}
 }

--- a/msg.go
+++ b/msg.go
@@ -839,7 +839,7 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 
 	// Set extended Rcode
 	if opt := dns.IsEdns0(); opt != nil {
-		dns.Rcode = dns.Rcode | opt.ExtendedRcode()
+		dns.Rcode |= opt.ExtendedRcode()
 	}
 
 	if off != len(msg) {

--- a/msg.go
+++ b/msg.go
@@ -690,7 +690,7 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]
 		if opt == nil {
 			return nil, ErrExtendedRcode
 		}
-		opt.SetExtendedRcode(uint8(dns.Rcode >> 4))
+		opt.SetExtendedRcode(uint8(dns.Rcode))
 	}
 
 	// Convert convenient Msg into wire-like Header.

--- a/msg.go
+++ b/msg.go
@@ -685,13 +685,12 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]
 		return nil, ErrRcode
 	}
 
-	opt := dns.IsEdns0()
 	// Set extended rcode unconditionally if we have an opt, this will allow
 	// reseting the extended rcode bits if they need to.
-	if opt != nil {
+	if opt := dns.IsEdns0(); opt != nil {
 		opt.SetExtendedRcode(uint16(dns.Rcode))
-		// If Rcode is an extended one and opt is nil, error out.
 	} else if dns.Rcode > 0xF {
+		// If Rcode is an extended one and opt is nil, error out.
 		return nil, ErrExtendedRcode
 	}
 

--- a/msg.go
+++ b/msg.go
@@ -690,7 +690,7 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]
 		if opt == nil {
 			return nil, ErrExtendedRcode
 		}
-		opt.SetExtendedRcode(uint8(dns.Rcode))
+		opt.SetExtendedRcode(uint16(dns.Rcode))
 	}
 
 	// Convert convenient Msg into wire-like Header.

--- a/msg.go
+++ b/msg.go
@@ -837,6 +837,11 @@ func (dns *Msg) Unpack(msg []byte) (err error) {
 	// The header counts might have been wrong so we need to update it
 	dh.Arcount = uint16(len(dns.Extra))
 
+	// Set extended Rcode
+	if opt := dns.IsEdns0(); opt != nil {
+		dns.Rcode = dns.Rcode | opt.ExtendedRcode()
+	}
+
 	if off != len(msg) {
 		// TODO(miek) make this an error?
 		// use PackOpt to let people tell how detailed the error reporting should be?

--- a/msg.go
+++ b/msg.go
@@ -685,15 +685,14 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]
 		return nil, ErrRcode
 	}
 
-	// Regular RCODE field is 4 bits
 	opt := dns.IsEdns0()
-	// If Rcode is an extended one and opt is nil, error out.
-	if opt == nil && dns.Rcode > 0xF {
-		return nil, ErrExtendedRcode
-	// Else set extended rcode unconditionally if we have an opt, this will allow
+	// Set extended rcode unconditionally if we have an opt, this will allow
 	// reseting the extended rcode bits if they need to.
-	} else if opt != nil {
+	if opt != nil {
 		opt.SetExtendedRcode(uint16(dns.Rcode))
+		// If Rcode is an extended one and opt is nil, error out.
+	} else if dns.Rcode > 0xF {
+		return nil, ErrExtendedRcode
 	}
 
 	// Convert convenient Msg into wire-like Header.

--- a/msg_test.go
+++ b/msg_test.go
@@ -68,7 +68,7 @@ func TestPackExtendedBadCookie(t *testing.T) {
 	}
 	// SetExtendedRcode is only called as part of `Pack()`, hence at this stage,
 	// the OPT RR is not set yet.
-	if edns0.ExtendedRcode() == RcodeBadCookie & 0xFFFFFFF0 {
+	if edns0.ExtendedRcode() == RcodeBadCookie&0xFFFFFFF0 {
 		t.Errorf("ExtendedRcode is expected to not be BADCOOKIE before Pack")
 	}
 
@@ -79,7 +79,7 @@ func TestPackExtendedBadCookie(t *testing.T) {
 		t.Fatal("Expected OPT RR")
 	}
 
-	if edns0.ExtendedRcode() != RcodeBadCookie & 0xFFFFFFF0 {
+	if edns0.ExtendedRcode() != RcodeBadCookie&0xFFFFFFF0 {
 		t.Errorf("ExtendedRcode is expected to be BADCOOKIE after Pack")
 	}
 }
@@ -100,7 +100,6 @@ func TestUnPackExtendedRcode(t *testing.T) {
 	a.Extra = append(a.Extra, o)
 
 	a.SetRcode(m, RcodeBadCookie)
-
 
 	packed, err := a.Pack()
 	if err != nil {

--- a/msg_test.go
+++ b/msg_test.go
@@ -45,7 +45,7 @@ func TestPackNoSideEffect(t *testing.T) {
 	}
 }
 
-func TestPackExtendedBadvers(t *testing.T) {
+func TestPackExtendedBadCookie(t *testing.T) {
 	m := new(Msg)
 	m.SetQuestion(Fqdn("example.com."), TypeNS)
 
@@ -60,15 +60,16 @@ func TestPackExtendedBadvers(t *testing.T) {
 	o.SetUDPSize(DefaultMsgSize)
 	a.Extra = append(a.Extra, o)
 
-	a.SetRcode(m, RcodeBadVers)
+	a.SetRcode(m, RcodeBadCookie)
 
 	edns0 := a.IsEdns0()
 	if edns0 == nil {
 		t.Fatal("")
 	}
-
-	if edns0.ExtendedRcode() == RcodeBadVers {
-		t.Errorf("ExtendedRcode is expected to not be BADVERS before Pack")
+	// SetExtendedRcode is only called as part of `Pack()`, hence at this stage,
+	// the OPT RR is not set yet.
+	if edns0.ExtendedRcode() == RcodeBadCookie & 0xFFFFFFF0 {
+		t.Errorf("ExtendedRcode is expected to not be BADCOOKIE before Pack")
 	}
 
 	a.Pack()
@@ -78,8 +79,8 @@ func TestPackExtendedBadvers(t *testing.T) {
 		t.Fatal("")
 	}
 
-	if edns0.ExtendedRcode() != RcodeBadVers {
-		t.Errorf("ExtendedRcode is expected to be BADVERS after Pack")
+	if edns0.ExtendedRcode() != RcodeBadCookie & 0xFFFFFFF0 {
+		t.Errorf("ExtendedRcode is expected to be BADCOOKIE after Pack")
 	}
 }
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -84,6 +84,39 @@ func TestPackExtendedBadCookie(t *testing.T) {
 	}
 }
 
+func TestUnPackExtendedRcode(t *testing.T) {
+	m := new(Msg)
+	m.SetQuestion(Fqdn("example.com."), TypeNS)
+
+	a := new(Msg)
+	a.SetReply(m)
+	o := &OPT{
+		Hdr: RR_Header{
+			Name:   ".",
+			Rrtype: TypeOPT,
+		},
+	}
+	o.SetUDPSize(DefaultMsgSize)
+	a.Extra = append(a.Extra, o)
+
+	a.SetRcode(m, RcodeBadCookie)
+
+
+	packed, err := a.Pack()
+	if err != nil {
+		t.Fatalf("Could not unpack %v", a)
+	}
+
+	unpacked := new(Msg)
+	if err := unpacked.Unpack(packed); err != nil {
+		t.Fatalf("Failed to unpack message")
+	}
+
+	if unpacked.Rcode != RcodeBadCookie {
+		t.Fatalf("Rcode should be matching RcodeBadCookie (%d), got (%d)", RcodeBadCookie, unpacked.Rcode)
+	}
+}
+
 func TestUnpackDomainName(t *testing.T) {
 	var cases = []struct {
 		label          string

--- a/msg_test.go
+++ b/msg_test.go
@@ -45,6 +45,44 @@ func TestPackNoSideEffect(t *testing.T) {
 	}
 }
 
+func TestPackExtendedBadvers(t *testing.T) {
+	m := new(Msg)
+	m.SetQuestion(Fqdn("example.com."), TypeNS)
+
+	a := new(Msg)
+	a.SetReply(m)
+	o := &OPT{
+		Hdr: RR_Header{
+			Name:   ".",
+			Rrtype: TypeOPT,
+		},
+	}
+	o.SetUDPSize(DefaultMsgSize)
+	a.Extra = append(a.Extra, o)
+
+	a.SetRcode(m, RcodeBadVers)
+
+	edns0 := a.IsEdns0()
+	if edns0 == nil {
+		t.Fatal("")
+	}
+
+	if edns0.ExtendedRcode() == RcodeBadVers {
+		t.Errorf("ExtendedRcode is expected to not be BADVERS before Pack")
+	}
+
+	a.Pack()
+
+	edns0 = a.IsEdns0()
+	if edns0 == nil {
+		t.Fatal("")
+	}
+
+	if edns0.ExtendedRcode() != RcodeBadVers {
+		t.Errorf("ExtendedRcode is expected to be BADVERS after Pack")
+	}
+}
+
 func TestUnpackDomainName(t *testing.T) {
 	var cases = []struct {
 		label          string

--- a/msg_test.go
+++ b/msg_test.go
@@ -64,7 +64,7 @@ func TestPackExtendedBadCookie(t *testing.T) {
 
 	edns0 := a.IsEdns0()
 	if edns0 == nil {
-		t.Fatal("")
+		t.Fatal("Expected OPT RR")
 	}
 	// SetExtendedRcode is only called as part of `Pack()`, hence at this stage,
 	// the OPT RR is not set yet.
@@ -76,7 +76,7 @@ func TestPackExtendedBadCookie(t *testing.T) {
 
 	edns0 = a.IsEdns0()
 	if edns0 == nil {
-		t.Fatal("")
+		t.Fatal("Expected OPT RR")
 	}
 
 	if edns0.ExtendedRcode() != RcodeBadCookie & 0xFFFFFFF0 {


### PR DESCRIPTION
When calling `SetExtendedRcode`, we expect to get the full extended
rcode, not the rcode after we shift 4 bytes right.