### PR TITLE
Add new ZoneParser API

### DIFF
--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -336,6 +336,11 @@ func (kl *klexer) Next() (lex, bool) {
 		}
 	}
 
+	if kl.readErr != nil && kl.readErr != io.EOF {
+		// Don't return any tokens after a read error occurs.
+		return lex{value: zEOF}, false
+	}
+
 	if str.Len() > 0 {
 		// Send remainder
 		l.value = zValue

--- a/generate.go
+++ b/generate.go
@@ -30,7 +30,7 @@ func (zp *ZoneParser) generate(l lex) string {
 		}
 
 		s, err := strconv.Atoi(l.token[i+1:])
-		if err != nil || s < 0 {
+		if err != nil || s <= 0 {
 			return "bad step in $GENERATE range"
 		}
 

--- a/generate.go
+++ b/generate.go
@@ -18,8 +18,6 @@ import (
 // * rhs (rdata)
 // But we are lazy here, only the range is parsed *all* occurrences
 // of $ after that are interpreted.
-// Any error are returned as a string value, the empty string signals
-// "no error".
 func (zp *ZoneParser) generate(l lex) (RR, bool) {
 	token := l.token
 	step := 1

--- a/generate.go
+++ b/generate.go
@@ -64,15 +64,15 @@ BuildRR:
 	}
 
 	r := &generateReader{
-		file: zp.file,
-		lex:  &origL,
-
 		s: s,
 
 		cur:   start,
 		start: start,
 		end:   end,
 		step:  step,
+
+		file: zp.file,
+		lex:  &origL,
 	}
 	zp.sub = NewZoneParser(r, zp.origin, zp.file)
 	zp.sub.SetDefaultTTL(defaultTtl)
@@ -80,9 +80,6 @@ BuildRR:
 }
 
 type generateReader struct {
-	file string
-	lex  *lex
-
 	s  string
 	si int
 
@@ -96,6 +93,9 @@ type generateReader struct {
 	escape bool
 
 	eof bool
+
+	file string
+	lex  *lex
 }
 
 func (r *generateReader) parseError(msg string) *ParseError {

--- a/generate.go
+++ b/generate.go
@@ -60,11 +60,12 @@ func (zp *ZoneParser) generate(l lex) string {
 
 	// Create a complete new string, which we then parse again.
 	var s string
-BuildRR:
-	l, _ = zp.c.Next()
-	if l.value != zNewline && l.value != zEOF {
+	for l, ok := zp.c.Next(); ok; l, ok = zp.c.Next() {
+		if l.value == zNewline {
+			break
+		}
+
 		s += l.token
-		goto BuildRR
 	}
 
 	r := &generateReader{

--- a/generate.go
+++ b/generate.go
@@ -75,7 +75,6 @@ BuildRR:
 		step:  step,
 	}
 	zp.sub = NewZoneParser(r, zp.origin, zp.file)
-	zp.sub.includeDepth = zp.includeDepth
 	zp.sub.SetDefaultTTL(defaultTtl)
 	return ""
 }

--- a/generate.go
+++ b/generate.go
@@ -60,6 +60,9 @@ func (zp *ZoneParser) generate(l lex) (RR, bool) {
 	// Create a complete new string, which we then parse again.
 	var s string
 	for l, ok := zp.c.Next(); ok; l, ok = zp.c.Next() {
+		if l.err {
+			return zp.setParseError("bad data in $GENERATE directive", l)
+		}
 		if l.value == zNewline {
 			break
 		}

--- a/generate.go
+++ b/generate.go
@@ -80,6 +80,7 @@ func (zp *ZoneParser) generate(l lex) string {
 		lex:  &origL,
 	}
 	zp.sub = NewZoneParser(r, zp.origin, zp.file)
+	zp.sub.includeDepth, zp.sub.includeAllowed = zp.includeDepth, zp.includeAllowed
 	zp.sub.SetDefaultTTL(defaultTtl)
 	return ""
 }

--- a/generate.go
+++ b/generate.go
@@ -211,19 +211,23 @@ func modToPrintf(s string) (string, int, string) {
 	if xs[2] != "o" && xs[2] != "d" && xs[2] != "x" && xs[2] != "X" {
 		return "", 0, "bad base in $GENERATE"
 	}
+
 	offset, err := strconv.Atoi(xs[0])
 	if err != nil {
 		return "", 0, "bad offset in $GENERATE"
 	}
+
 	width, err := strconv.Atoi(xs[1])
 	if err != nil || width > 255 {
-		return "", offset, "bad width in $GENERATE"
+		return "", 0, "bad width in $GENERATE"
 	}
+
 	switch {
 	case width < 0:
-		return "", offset, "bad width in $GENERATE"
+		return "", 0, "bad width in $GENERATE"
 	case width == 0:
 		return "%" + xs[1] + xs[2], offset, ""
+	default:
+		return "%0" + xs[1] + xs[2], offset, ""
 	}
-	return "%0" + xs[1] + xs[2], offset, ""
 }

--- a/generate.go
+++ b/generate.go
@@ -99,6 +99,7 @@ type generateReader struct {
 }
 
 func (r *generateReader) parseError(msg string) *ParseError {
+	r.eof = true // Make errors sticky.
 	return &ParseError{r.file, msg, *r.lex}
 }
 

--- a/generate.go
+++ b/generate.go
@@ -22,29 +22,32 @@ import (
 // "no error".
 func (zp *ZoneParser) generate(l lex) string {
 	origL := l
+
 	step := 1
-	if i := strings.IndexAny(l.token, "/"); i != -1 {
+	if i := strings.IndexByte(l.token, '/'); i >= 0 {
 		if i+1 == len(l.token) {
 			return "bad step in $GENERATE range"
 		}
-		if s, err := strconv.Atoi(l.token[i+1:]); err == nil {
-			if s < 0 {
-				return "bad step in $GENERATE range"
-			}
-			step = s
-		} else {
+
+		s, err := strconv.Atoi(l.token[i+1:])
+		if err != nil || s < 0 {
 			return "bad step in $GENERATE range"
 		}
+
+		step = s
 		l.token = l.token[:i]
 	}
+
 	sx := strings.SplitN(l.token, "-", 2)
 	if len(sx) != 2 {
 		return "bad start-stop in $GENERATE range"
 	}
+
 	start, err := strconv.Atoi(sx[0])
 	if err != nil {
 		return "bad start in $GENERATE range"
 	}
+
 	end, err := strconv.Atoi(sx[1])
 	if err != nil {
 		return "bad stop in $GENERATE range"
@@ -54,8 +57,9 @@ func (zp *ZoneParser) generate(l lex) string {
 	}
 
 	zp.c.Next() // _BLANK
+
 	// Create a complete new string, which we then parse again.
-	s := ""
+	var s string
 BuildRR:
 	l, _ = zp.c.Next()
 	if l.value != zNewline && l.value != zEOF {

--- a/generate_test.go
+++ b/generate_test.go
@@ -112,7 +112,6 @@ func TestGenerateSurfacesErrors(t *testing.T) {
 	const zone = `@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 0-1 dhcp-${0,4,dd} A 10.0.0.$
 `
-
 	zp := NewZoneParser(strings.NewReader(zone), ".", "test")
 
 	for _, ok := zp.Next(); ok; _, ok = zp.Next() {

--- a/generate_test.go
+++ b/generate_test.go
@@ -76,3 +76,20 @@ func TestGenerateModToPrintf(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkGenerate(b *testing.B) {
+	const zone = `@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 32-158 dhcp-${-32,4,d} A 10.0.0.$
+`
+
+	for n := 0; n < b.N; n++ {
+		zp := NewZoneParser(strings.NewReader(zone), ".", "")
+
+		for _, ok := zp.Next(); ok; _, ok = zp.Next() {
+		}
+
+		if err := zp.Err(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -93,6 +93,22 @@ $GENERATE 0-1 $$INCLUDE ` + tmpfile.Name() + `
 	}
 }
 
+func TestGenerateSurfacesErrors(t *testing.T) {
+	const zone = `@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1 dhcp-${0,4,dd} A 10.0.0.$
+`
+
+	zp := NewZoneParser(strings.NewReader(zone), ".", "test")
+
+	for _, ok := zp.Next(); ok; _, ok = zp.Next() {
+	}
+
+	const expected = `test: dns: bad base in $GENERATE: "0-1" at line: 2:14`
+	if err := zp.Err(); err == nil || err.Error() != expected {
+		t.Errorf("expected specific error, wanted %q, got %v", expected, err)
+	}
+}
+
 func TestGenerateModToPrintf(t *testing.T) {
 	tests := []struct {
 		mod        string

--- a/generate_test.go
+++ b/generate_test.go
@@ -33,6 +33,9 @@ func TestGenerateRangeGuard(t *testing.T) {
 $GENERATE 0-1 dhcp-${0,4,d} A 10.0.0.$
 `, false},
 		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1 dhcp-${0,0,x} A 10.0.0.$
+`, false},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 128-129 dhcp-${-128,4,d} A 10.0.0.$
 `, false},
 		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
@@ -157,18 +160,18 @@ func TestGenerateModToPrintf(t *testing.T) {
 		wantOffset int
 		wantErr    bool
 	}{
-		{"0,0,d", "%0d", 0, false},
-		{"0,0", "%0d", 0, false},
-		{"0", "%0d", 0, false},
+		{"0,0,d", "%d", 0, false},
+		{"0,0", "%d", 0, false},
+		{"0", "%d", 0, false},
 		{"3,2,d", "%02d", 3, false},
 		{"3,2", "%02d", 3, false},
-		{"3", "%0d", 3, false},
-		{"0,0,o", "%0o", 0, false},
-		{"0,0,x", "%0x", 0, false},
-		{"0,0,X", "%0X", 0, false},
+		{"3", "%d", 3, false},
+		{"0,0,o", "%o", 0, false},
+		{"0,0,x", "%x", 0, false},
+		{"0,0,X", "%X", 0, false},
 		{"0,0,z", "", 0, true},
 		{"0,0,0,d", "", 0, true},
-		{"-100,0,d", "%0d", -100, false},
+		{"-100,0,d", "%d", -100, false},
 	}
 	for _, test := range tests {
 		gotFmt, gotOffset, errMsg := modToPrintf(test.mod)

--- a/generate_test.go
+++ b/generate_test.go
@@ -135,6 +135,21 @@ $GENERATE 0-1 dhcp-${0,4,dd} A 10.0.0.$
 	}
 }
 
+func TestGenerateSurfacesLexerErrors(t *testing.T) {
+	const zone = `@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1 dhcp-${0,4,d} A 10.0.0.$ )
+`
+	zp := NewZoneParser(strings.NewReader(zone), ".", "test")
+
+	for _, ok := zp.Next(); ok; _, ok = zp.Next() {
+	}
+
+	const expected = `test: dns: bad data in $GENERATE directive: "extra closing brace" at line: 2:40`
+	if err := zp.Err(); err == nil || err.Error() != expected {
+		t.Errorf("expected specific error, wanted %q, got %v", expected, err)
+	}
+}
+
 func TestGenerateModToPrintf(t *testing.T) {
 	tests := []struct {
 		mod        string

--- a/generate_test.go
+++ b/generate_test.go
@@ -129,7 +129,7 @@ $GENERATE 0-1 dhcp-${0,4,dd} A 10.0.0.$
 	for _, ok := zp.Next(); ok; _, ok = zp.Next() {
 	}
 
-	const expected = `test: dns: bad base in $GENERATE: "0-1" at line: 2:14`
+	const expected = `test: dns: bad base in $GENERATE: "${0,4,dd}" at line: 2:20`
 	if err := zp.Err(); err == nil || err.Error() != expected {
 		t.Errorf("expected specific error, wanted %q, got %v", expected, err)
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -101,7 +101,7 @@ $GENERATE 0-1 $$INCLUDE ` + tmpfile.Name() + `
 
 	const expected = "too deeply nested $INCLUDE"
 	if err := zp.Err(); err == nil || !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error to include %q, got %q", expected, err.Error())
+		t.Errorf("expected error to include %q, got %v", expected, err)
 	}
 }
 
@@ -116,7 +116,7 @@ $GENERATE 0-1 $$INCLUDE test.conf
 
 	const expected = "$INCLUDE directive not allowed"
 	if err := zp.Err(); err == nil || !strings.Contains(err.Error(), expected) {
-		t.Errorf("expected error to include %q, got %q", expected, err.Error())
+		t.Errorf("expected error to include %q, got %v", expected, err)
 	}
 }
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -63,12 +63,12 @@ func TestGenerateModToPrintf(t *testing.T) {
 		{"-100,0,d", "%0d", -100, false},
 	}
 	for _, test := range tests {
-		gotFmt, gotOffset, err := modToPrintf(test.mod)
+		gotFmt, gotOffset, errMsg := modToPrintf(test.mod)
 		switch {
-		case err != nil && !test.wantErr:
-			t.Errorf("modToPrintf(%q) - expected nil-error, but got %v", test.mod, err)
-		case err == nil && test.wantErr:
-			t.Errorf("modToPrintf(%q) - expected error, but got nil-error", test.mod)
+		case errMsg != "" && !test.wantErr:
+			t.Errorf("modToPrintf(%q) - expected empty-error, but got %v", test.mod, errMsg)
+		case errMsg == "" && test.wantErr:
+			t.Errorf("modToPrintf(%q) - expected error, but got empty-error", test.mod)
 		case gotFmt != test.wantFmt:
 			t.Errorf("modToPrintf(%q) - expected format %q, but got %q", test.mod, test.wantFmt, gotFmt)
 		case gotOffset != test.wantOffset:

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,28 +1,28 @@
 package dns
 
 import (
-	"testing"
 	"strings"
+	"testing"
 )
 
 func TestGenerateRangeGuard(t *testing.T) {
 	var tests = [...]struct {
 		zone string
 		fail bool
-	}{{
-		`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+	}{
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 0-1 dhcp-${0,4,d} A 10.0.0.$
-`, false},{
-		`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+`, false},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 128-129 dhcp-${-128,4,d} A 10.0.0.$
-`, false},{
-		`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+`, false},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 128-129 dhcp-${-129,4,d} A 10.0.0.$
-`, true},{
-		`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+`, true},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 0-2 dhcp-${2147483647,4,d} A 10.0.0.$
-`, true},{
-		`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+`, true},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 0-1 dhcp-${2147483646,4,d} A 10.0.0.$
 `, false},
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -45,6 +45,18 @@ $GENERATE 0-2 dhcp-${2147483647,4,d} A 10.0.0.$
 $GENERATE 0-1 dhcp-${2147483646,4,d} A 10.0.0.$
 `, false},
 		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1/step dhcp-${0,4,d} A 10.0.0.$
+`, true},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1/ dhcp-${0,4,d} A 10.0.0.$
+`, true},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-10/2 dhcp-${0,4,d} A 10.0.0.$
+`, false},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1/0 dhcp-${0,4,d} A 10.0.0.$
+`, true},
+		{`@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 0-1 $$INCLUDE ` + tmpdir + string(filepath.Separator) + `${0,4,d}.conf
 `, false},
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -93,6 +93,21 @@ $GENERATE 0-1 $$INCLUDE ` + tmpfile.Name() + `
 	}
 }
 
+func TestGenerateIncludeDisallowed(t *testing.T) {
+	const zone = `@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
+$GENERATE 0-1 $$INCLUDE test.conf
+`
+	zp := NewZoneParser(strings.NewReader(zone), ".", "")
+
+	for _, ok := zp.Next(); ok; _, ok = zp.Next() {
+	}
+
+	const expected = "$INCLUDE directive not allowed"
+	if err := zp.Err(); err == nil || !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error to include %q, got %q", expected, err.Error())
+	}
+}
+
 func TestGenerateSurfacesErrors(t *testing.T) {
 	const zone = `@ IN SOA ns.test. hostmaster.test. ( 1 8h 2h 7d 1d )
 $GENERATE 0-1 dhcp-${0,4,dd} A 10.0.0.$

--- a/scan.go
+++ b/scan.go
@@ -12,6 +12,10 @@ import (
 
 const maxTok = 2048 // Largest token we can return.
 
+// The maximum depth of $INCLUDE directives supported by the
+// ZoneParser API.
+const maxIncludeDepth = 7
+
 // Tokinize a RFC 1035 zone file. The tokenizer will normalize it:
 // * Add ownernames if they are left blank;
 // * Suppress sequences of spaces;
@@ -456,8 +460,7 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			if !zp.includeAllowed {
 				return zp.setParseError("$INCLUDE directive not allowed", l)
 			}
-
-			if zp.includeDepth >= 7 {
+			if zp.includeDepth >= maxIncludeDepth {
 				return zp.setParseError("too deeply nested $INCLUDE", l)
 			}
 

--- a/scan.go
+++ b/scan.go
@@ -116,7 +116,7 @@ func NewRR(s string) (RR, error) {
 // See NewRR for more documentation.
 func ReadRR(r io.Reader, filename string) (RR, error) {
 	zp := NewZoneParser(r, ".", filename)
-	zp.defttl = &ttlState{defaultTtl, false}
+	zp.SetDefaultTTL(defaultTtl)
 	rr, _ := zp.Next()
 	return rr, zp.Err()
 }
@@ -230,6 +230,10 @@ func (zp *ZoneParser) Err() error {
 
 func (zp *ZoneParser) Comment() string {
 	return zp.com
+}
+
+func (zp *ZoneParser) SetDefaultTTL(ttl uint32) {
+	zp.defttl = &ttlState{ttl, false}
 }
 
 func (zp *ZoneParser) subNext() (RR, bool) {

--- a/scan.go
+++ b/scan.go
@@ -103,8 +103,9 @@ type ttlState struct {
 // NewRR reads the RR contained in the string s. Only the first RR is
 // returned. If s contains no RR, return nil with no error. The class
 // defaults to IN and TTL defaults to 3600. The full zone file syntax
-// like $TTL, $ORIGIN, etc. is supported. All fields of the returned
-// RR are set, except RR.Header().Rdlength which is set to 0.
+// like $TTL, $ORIGIN, etc. is supported, except for $INCLUDE. All
+// fields of the returned RR are set, except RR.Header().Rdlength which
+// is set to 0.
 func NewRR(s string) (RR, error) {
 	if len(s) > 0 && s[len(s)-1] != '\n' { // We need a closing newline
 		return ReadRR(strings.NewReader(s+"\n"), "")
@@ -117,7 +118,6 @@ func NewRR(s string) (RR, error) {
 func ReadRR(r io.Reader, filename string) (RR, error) {
 	zp := NewZoneParser(r, ".", filename)
 	zp.SetDefaultTTL(defaultTtl)
-	zp.SetIncludeAllowed(true)
 	rr, _ := zp.Next()
 	return rr, zp.Err()
 }

--- a/scan.go
+++ b/scan.go
@@ -122,7 +122,8 @@ func NewRR(s string) (RR, error) {
 
 // ReadRR reads the RR contained in r.
 //
-// The string file is only used in error reporting.
+// The string file is used in error reporting and to resolve relative
+// $INCLUDE directives.
 //
 // See NewRR for more documentation.
 func ReadRR(r io.Reader, file string) (RR, error) {

--- a/scan.go
+++ b/scan.go
@@ -240,7 +240,7 @@ type ZoneParser struct {
 
 	com string
 
-	include uint8
+	includeDepth uint8
 
 	includeAllowed bool
 }
@@ -457,7 +457,7 @@ func (zp *ZoneParser) Next() (RR, bool) {
 				return zp.setParseError("$INCLUDE directive not allowed", l)
 			}
 
-			if zp.include >= 7 {
+			if zp.includeDepth >= 7 {
 				return zp.setParseError("too deeply nested $INCLUDE", l)
 			}
 
@@ -479,7 +479,7 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			}
 
 			zp.sub = NewZoneParser(r1, neworigin, includePath)
-			zp.sub.defttl, zp.sub.include, zp.sub.osFile = zp.defttl, zp.include+1, r1
+			zp.sub.defttl, zp.sub.includeDepth, zp.sub.osFile = zp.defttl, zp.includeDepth+1, r1
 			zp.sub.SetIncludeAllowed(true)
 			return zp.subNext()
 		case zExpectDirTTLBl:

--- a/scan.go
+++ b/scan.go
@@ -148,20 +148,15 @@ func ReadRR(r io.Reader, filename string) (RR, error) {
 // RR are returned concatenated along with the RR. Comments on a line by themselves
 // are discarded.
 func ParseZone(r io.Reader, origin, file string) chan *Token {
-	return parseZoneHelper(r, origin, file, nil, 10000)
-}
-
-func parseZoneHelper(r io.Reader, origin, file string, defttl *ttlState, chansize int) chan *Token {
-	t := make(chan *Token, chansize)
-	go parseZone(r, origin, file, defttl, t)
+	t := make(chan *Token, 10000)
+	go parseZone(r, origin, file, t)
 	return t
 }
 
-func parseZone(r io.Reader, origin, file string, defttl *ttlState, t chan *Token) {
+func parseZone(r io.Reader, origin, file string, t chan *Token) {
 	defer close(t)
 
 	zp := NewZoneParser(r, origin, file)
-	zp.defttl = defttl
 
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
 		t <- &Token{RR: rr, Comment: zp.Comment()}

--- a/scan.go
+++ b/scan.go
@@ -546,11 +546,7 @@ func (zp *ZoneParser) Next() (RR, bool) {
 				return zp.setParseError("expecting $GENERATE value, not this...", l)
 			}
 
-			if errMsg := zp.generate(l); errMsg != "" {
-				return zp.setParseError(errMsg, l)
-			}
-
-			return zp.subNext()
+			return zp.generate(l)
 		case zExpectOwnerBl:
 			if l.value != zBlank {
 				return zp.setParseError("no blank after owner", l)

--- a/scan.go
+++ b/scan.go
@@ -233,14 +233,14 @@ type ZoneParser struct {
 
 	h RR_Header
 
-	include int
-
 	sub *ZoneParser
 	gen []RR
 
 	osFile *os.File
 
 	com string
+
+	include uint8
 
 	includeAllowed bool
 }

--- a/scan.go
+++ b/scan.go
@@ -1091,6 +1091,11 @@ func (zl *zlexer) Next() (lex, bool) {
 		}
 	}
 
+	if zl.readErr != nil && zl.readErr != io.EOF {
+		// Don't return any tokens after a read error occurs.
+		return lex{value: zEOF}, false
+	}
+
 	var retL lex
 	if stri > 0 {
 		// Send remainder of str

--- a/scan.go
+++ b/scan.go
@@ -238,6 +238,9 @@ type ZoneParser struct {
 
 	h RR_Header
 
+	// sub is used to parse $INCLUDE files and $GENERATE directives.
+	// Next, by calling subNext, forwards the resulting RRs from this
+	// sub parser to the calling code.
 	sub    *ZoneParser
 	osFile *os.File
 

--- a/scan.go
+++ b/scan.go
@@ -231,8 +231,7 @@ type ZoneParser struct {
 
 	defttl *ttlState
 
-	h        RR_Header
-	prevName string
+	h RR_Header
 
 	include int
 
@@ -385,7 +384,6 @@ func (zp *ZoneParser) Next() (RR, bool) {
 				}
 
 				h.Name = name
-				zp.prevName = h.Name
 
 				st = zExpectOwnerBl
 			case zDirTTL:
@@ -397,12 +395,10 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			case zDirGenerate:
 				st = zExpectDirGenerateBl
 			case zRrtpe:
-				h.Name = zp.prevName
 				h.Rrtype = l.torc
 
 				st = zExpectRdata
 			case zClass:
-				h.Name = zp.prevName
 				h.Class = l.torc
 
 				st = zExpectAnyNoClassBl

--- a/scan.go
+++ b/scan.go
@@ -319,20 +319,23 @@ func (zp *ZoneParser) Comment() string {
 }
 
 func (zp *ZoneParser) subNext() (RR, bool) {
-	rr, ok := zp.sub.Next()
-	zp.com = zp.sub.com
-
-	if !ok && zp.sub.Err() == nil {
-		// zp.sub has ended
-		if zp.sub.osFile != nil {
-			zp.sub.osFile.Close()
-		}
-
-		zp.sub = nil
-		return zp.Next()
+	if rr, ok := zp.sub.Next(); ok {
+		zp.com = zp.sub.com
+		return rr, true
 	}
 
-	return rr, ok
+	if zp.sub.osFile != nil {
+		zp.sub.osFile.Close()
+		zp.sub.osFile = nil
+	}
+
+	if zp.sub.Err() != nil {
+		// We have errors to surface.
+		return nil, false
+	}
+
+	zp.sub = nil
+	return zp.Next()
 }
 
 // Next advances the parser to the next RR in the zonefile and

--- a/scan.go
+++ b/scan.go
@@ -469,11 +469,12 @@ func (zp *ZoneParser) Next() (RR, bool) {
 
 			r1, e1 := os.Open(includePath)
 			if e1 != nil {
-				msg := fmt.Sprintf("failed to open `%s'", l.token)
+				var as string
 				if !filepath.IsAbs(l.token) {
-					msg += fmt.Sprintf(" as `%s'", includePath)
+					as = fmt.Sprintf(" as `%s'", includePath)
 				}
 
+				msg := fmt.Sprintf("failed to open `%s'%s: %v", l.token, as, e1)
 				return zp.setParseError(msg, l)
 			}
 

--- a/scan.go
+++ b/scan.go
@@ -112,19 +112,13 @@ func NewRR(s string) (RR, error) {
 	return ReadRR(strings.NewReader(s), "")
 }
 
-// ReadRR reads the RR contained in q.
+// ReadRR reads the RR contained in r.
 // See NewRR for more documentation.
-func ReadRR(q io.Reader, filename string) (RR, error) {
-	defttl := &ttlState{defaultTtl, false}
-	r := <-parseZoneHelper(q, ".", filename, defttl, 1)
-	if r == nil {
-		return nil, nil
-	}
-
-	if r.Error != nil {
-		return nil, r.Error
-	}
-	return r.RR, nil
+func ReadRR(r io.Reader, filename string) (RR, error) {
+	zp := NewZoneParser(r, ".", filename)
+	zp.defttl = &ttlState{defaultTtl, false}
+	rr, _ := zp.Next()
+	return rr, zp.Err()
 }
 
 // ParseZone reads a RFC 1035 style zonefile from r. It returns *Tokens on the

--- a/scan.go
+++ b/scan.go
@@ -109,8 +109,7 @@ type ttlState struct {
 // error.
 //
 // The class defaults to IN and TTL defaults to 3600. The full zone
-// file syntax like $TTL, $ORIGIN, etc. is supported, except for
-// $INCLUDE.
+// file syntax like $TTL, $ORIGIN, etc. is supported.
 //
 // All fields of the returned RR are set, except RR.Header().Rdlength
 // which is set to 0.
@@ -129,6 +128,7 @@ func NewRR(s string) (RR, error) {
 func ReadRR(r io.Reader, file string) (RR, error) {
 	zp := NewZoneParser(r, ".", file)
 	zp.SetDefaultTTL(defaultTtl)
+	zp.SetIncludeAllowed(true)
 	rr, _ := zp.Next()
 	return rr, zp.Err()
 }

--- a/scan.go
+++ b/scan.go
@@ -272,6 +272,24 @@ func NewZoneParser(r io.Reader, origin, file string) *ZoneParser {
 	}
 }
 
+// SetDefaultTTL sets the parsers default TTL to ttl.
+func (zp *ZoneParser) SetDefaultTTL(ttl uint32) {
+	zp.defttl = &ttlState{ttl, false}
+}
+
+// SetIncludeAllowed controls whether $INCLUDE directives are
+// allowed. $INCLUDE directives are not supported by default.
+//
+// The $INCLUDE directive will open and read from a user controlled
+// file on the system. Even if the file is not a valid zonefile, the
+// contents of the file may be revealed in error messages, such as:
+//
+//	/etc/passwd: dns: not a TTL: "root:x:0:0:root:/root:/bin/bash" at line: 1:31
+//	/etc/shadow: dns: not a TTL: "root:$6$<redacted>::0:99999:7:::" at line: 1:125
+func (zp *ZoneParser) SetIncludeAllowed(v bool) {
+	zp.includeAllowed = v
+}
+
 // Err returns the first non-EOF error that was encountered by the
 // ZoneParser.
 func (zp *ZoneParser) Err() error {
@@ -297,24 +315,6 @@ func (zp *ZoneParser) setParseError(err string, l lex) (RR, bool) {
 // the RR.
 func (zp *ZoneParser) Comment() string {
 	return zp.com
-}
-
-// SetDefaultTTL sets the parsers default TTL to ttl.
-func (zp *ZoneParser) SetDefaultTTL(ttl uint32) {
-	zp.defttl = &ttlState{ttl, false}
-}
-
-// SetIncludeAllowed controls whether $INCLUDE directives are
-// allowed. $INCLUDE directives are not supported by default.
-//
-// The $INCLUDE directive will open and read from a user controlled
-// file on the system. Even if the file is not a valid zonefile, the
-// contents of the file may be revealed in error messages, such as:
-//
-//	/etc/passwd: dns: not a TTL: "root:x:0:0:root:/root:/bin/bash" at line: 1:31
-//	/etc/shadow: dns: not a TTL: "root:$6$<redacted>::0:99999:7:::" at line: 1:125
-func (zp *ZoneParser) SetIncludeAllowed(v bool) {
-	zp.includeAllowed = v
 }
 
 func (zp *ZoneParser) subNext() (RR, bool) {

--- a/scan.go
+++ b/scan.go
@@ -164,6 +164,8 @@ func ReadRR(r io.Reader, file string) (RR, error) {
 // To prevent memory leaks it is important to always fully drain the
 // returned channel. If an error occurs, it will always be the last
 // Token sent on the channel.
+//
+// Deprecated: New users should prefer the ZoneParser API.
 func ParseZone(r io.Reader, origin, file string) chan *Token {
 	t := make(chan *Token, 10000)
 	go parseZone(r, origin, file, t)

--- a/scan.go
+++ b/scan.go
@@ -148,6 +148,10 @@ func ReadRR(r io.Reader, filename string) (RR, error) {
 // The text "; this is comment" is returned in Token.Comment. Comments inside the
 // RR are returned concatenated along with the RR. Comments on a line by themselves
 // are discarded.
+//
+// To prevent memory leaks it is important to always fully drain the returned
+// channel. If an error occurs, it will always be the last Token sent on the
+// channel.
 func ParseZone(r io.Reader, origin, file string) chan *Token {
 	t := make(chan *Token, 10000)
 	go parseZone(r, origin, file, t)

--- a/scan_test.go
+++ b/scan_test.go
@@ -112,9 +112,7 @@ func TestZoneParserIncludeDisallowed(t *testing.T) {
 
 	zp := NewZoneParser(strings.NewReader("$INCLUDE "+tmpfile.Name()), "example.org.", "")
 
-	rr, ok := zp.Next()
-	if rr != nil || ok {
-		t.Errorf("expected nil RR, got %v", rr)
+	for _, ok := zp.Next(); ok; _, ok = zp.Next() {
 	}
 
 	const expect = "$INCLUDE directive not allowed"

--- a/scan_test.go
+++ b/scan_test.go
@@ -88,8 +88,10 @@ func TestParseZoneInclude(t *testing.T) {
 			t.Fatalf("expected first token to contain an error but it didn't")
 		}
 		if !strings.Contains(x.Error.Error(), "failed to open") ||
-			!strings.Contains(x.Error.Error(), tmpfile.Name()) {
-			t.Fatalf(`expected error to contain: "failed to open" and %q but got: %s`, tmpfile.Name(), x.Error)
+			!strings.Contains(x.Error.Error(), tmpfile.Name()) ||
+			!strings.Contains(x.Error.Error(), "no such file or directory") {
+			t.Fatalf(`expected error to contain: "failed to open", %q and "no such file or directory" but got: %s`,
+				tmpfile.Name(), x.Error)
 		}
 	}
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -94,6 +94,30 @@ func TestParseZoneInclude(t *testing.T) {
 	}
 }
 
+func TestNewRRNoInclude(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "dns")
+	if err != nil {
+		t.Fatalf("could not create tmpfile for test: %s", err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.WriteString("foo\tIN\tA\t127.0.0.1"); err != nil {
+		t.Fatalf("unable to write content to tmpfile %q: %s", tmpfile.Name(), err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("could not close tmpfile %q: %s", tmpfile.Name(), err)
+	}
+
+	rr, err := NewRR("$ORIGIN example.org.\n$INCLUDE " + tmpfile.Name())
+	if expect := "$INCLUDE directive not allowed"; err == nil ||
+		!strings.Contains(err.Error(), expect) {
+		t.Errorf("expected error to contain %q, got %v", expect, err)
+	}
+	if rr != nil {
+		t.Errorf("expected nil RR, got %v", rr)
+	}
+}
+
 func TestParseTA(t *testing.T) {
 	rr, err := NewRR(` Ta 0 0 0`)
 	if err != nil {


### PR DESCRIPTION
This is a pretty large pull request, but again it's ultimately rather simple. The `parseZone` goroutine is eliminated and replaced with a new `ZoneParser` type with a simple chan-like API. This eliminates the goroutines and the 10,000 element buffered `parseZone` chan, which will substantially reduce memory usage.

Errors such as #786 should be impossible with the new API.

`ParseZone` maintains the same semantics as previous, including using a buffered chan of 10,000 elements. It is now a wrapper around the `ZoneParser` API.

The API (minus the `SetX` methods) was discussed in https://github.com/miekg/dns/issues/786#issuecomment-429630595.

~**Note:** This pull request contains an API change. `NewRR` and `ReadRR` no longer support the `$INCLUDE` directive. See the `SetIncludeAllowed` comment for why.~

Note: This pull request fixes a DOS vulnerability and infinite loop in processing of $GENERATE directives, see 213fc6e4e22915a8c2712ebe5a983c103fde442b.

This is the comparison between tip (17c1bc6792fdf1918200e9a675cdf2e3c9d585cd) and the pull request:
```
name                  old time/op    new time/op    delta
NewRR-12                6.57µs ± 2%    2.42µs ± 2%  -63.19%  (p=0.000 n=24+24)
ReadRR-12               6.99µs ± 1%    2.77µs ± 5%  -60.36%  (p=0.000 n=25+24)
ParseZone-12            33.9µs ±11%    40.3µs ± 9%  +18.93%  (p=0.000 n=25+23)
Generate-12              720µs ± 3%     154µs ± 3%  -78.59%  (p=0.000 n=25+25)
ParseZoneGenerate-12     720µs ± 3%     365µs ±29%  -49.29%  (p=0.000 n=25+25)

name                  old alloc/op   new alloc/op   delta
NewRR-12                  808B ± 0%      816B ± 0%   +0.99%  (p=0.000 n=25+25)
ReadRR-12               1.82kB ± 0%    1.82kB ± 0%   +0.44%  (p=0.000 n=25+25)
ParseZone-12            83.9kB ± 0%    84.0kB ± 0%   +0.19%  (p=0.000 n=25+25)
Generate-12              188kB ± 0%      32kB ± 0%  -83.09%  (p=0.000 n=25+25)
ParseZoneGenerate-12     188kB ± 0%     120kB ± 0%  -36.28%  (p=0.000 n=25+25)

name                  old allocs/op  new allocs/op  delta
NewRR-12                  17.0 ± 0%      15.0 ± 0%  -11.76%  (p=0.000 n=25+25)
ReadRR-12                 19.0 ± 0%      17.0 ± 0%  -10.53%  (p=0.000 n=25+25)
ParseZone-12              91.0 ± 0%      92.0 ± 0%   +1.10%  (p=0.000 n=25+25)
Generate-12              3.20k ± 0%     1.55k ± 0%  -51.45%  (p=0.000 n=25+25)
ParseZoneGenerate-12     3.20k ± 0%     1.69k ± 0%  -47.39%  (p=0.000 n=25+25)
```

_`ParseZoneGenerate` is `$GENERATE` used with `ParseZone` at both master and PR HEAD, while `Generate` is `$GENERATE` used with `ParseZone` at master and `ZoneParser` at PR HEAD._

This is the comparison between `ParseZone` (old) and `ZoneParser` (new)—both after this pull request:
```
name           old time/op    new time/op    delta
Parse-12       40.3µs ± 9%    10.6µs ± 1%  -73.80%  (p=0.000 n=23+24)
Generate-12     365µs ±29%     154µs ± 3%  -57.79%  (p=0.000 n=25+25)

name           old alloc/op   new alloc/op   delta
Parse-12       84.0kB ± 0%     1.6kB ± 0%  -98.10%  (p=0.000 n=25+25)
Generate-12     120kB ± 0%      32kB ± 0%  -73.46%  (p=0.000 n=25+25)

name            old allocs/op  new allocs/op  delta
Parse-12         92.0 ± 0%      81.0 ± 0%  -11.96%  (p=0.000 n=25+25)
Generate-12     1.69k ± 0%     1.55k ± 0%   -7.72%  (p=0.000 n=25+25)
```

Fixes #786
Updates coredns/coredns#2194