### PR TITLE
Read SO_REUSEPORT on socket before setting

### DIFF
--- a/listen_go111.go
+++ b/listen_go111.go
@@ -5,6 +5,7 @@ package dns
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"syscall"
 
@@ -16,6 +17,11 @@ const supportsReusePort = true
 func reuseportControl(network, address string, c syscall.RawConn) error {
 	var opErr error
 	err := c.Control(func(fd uintptr) {
+		_, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT)
+		if err != nil {
+			opErr = fmt.Errorf("could not get SO_REUSEPORT: %s", err.Error())
+			return
+		}
 		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 	})
 	if err != nil {


### PR DESCRIPTION
See if we're able to read the value from the
socket. If that fails, skip setting the value on
the port.

Note: I don't have any machines with an old enough kernel lying around to test that it fails correctly, but perhaps someone out there could jump in and give it a try.

Given this comment: https://github.com/miekg/dns/issues/802#issuecomment-433618478
I'm not sure where you want this to live, or if it's on the user to know they can use SO_REUSEPORT or not.