### PR TITLE
nsec3 cover problems

### DIFF
--- a/nsecx.go
+++ b/nsecx.go
@@ -63,6 +63,8 @@ func (rr *NSEC3) Cover(name string) bool {
 	}
 
 	nextHash := rr.NextDomain
+
+	// if empty interval found, try cover wildcard hashes so nameHash shouldn't match with ownerHash
 	if ownerHash == nextHash && nameHash != ownerHash { // empty interval
 		return true
 	}

--- a/nsecx.go
+++ b/nsecx.go
@@ -64,6 +64,9 @@ func (rr *NSEC3) Cover(name string) bool {
 
 	nextHash := rr.NextDomain
 	if ownerHash == nextHash { // empty interval
+		if nameHash < nextHash {
+			return true
+		}
 		return false
 	}
 	if ownerHash > nextHash { // end of zone

--- a/nsecx.go
+++ b/nsecx.go
@@ -64,10 +64,7 @@ func (rr *NSEC3) Cover(name string) bool {
 
 	nextHash := rr.NextDomain
 	if ownerHash == nextHash { // empty interval
-		if nameHash < nextHash {
-			return true
-		}
-		return false
+		return true
 	}
 	if ownerHash > nextHash { // end of zone
 		if nameHash > ownerHash { // covered since there is nothing after ownerHash

--- a/nsecx.go
+++ b/nsecx.go
@@ -63,7 +63,7 @@ func (rr *NSEC3) Cover(name string) bool {
 	}
 
 	nextHash := rr.NextDomain
-	if ownerHash == nextHash { // empty interval
+	if ownerHash == nextHash && nameHash != ownerHash { // empty interval
 		return true
 	}
 	if ownerHash > nextHash { // end of zone

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -112,6 +112,18 @@ func TestNsec3(t *testing.T) {
 			name:   "asd.com.",
 			covers: false,
 		},
+		{ // empty interval close to next
+			rr: &NSEC3{
+				Hdr:        RR_Header{Name: "2n1tb3vairuobl6rkdvii42n9tfmialp.com."},
+				Hash:       1,
+				Flags:      1,
+				Iterations: 5,
+				Salt:       "F10E9F7EA83FC8F3",
+				NextDomain: "2N1TB3VAIRUOBL6RKDVII42N9TFMIALP",
+			},
+			name:   "asdc.com.",
+			covers: true,
+		},
 		{ // name hash is before owner hash, not covered
 			rr: &NSEC3{
 				Hdr:        RR_Header{Name: "3V62ULR0NRE83V0RJA2VJGTLIF9V6RAB.com."},

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -110,6 +110,18 @@ func TestNsec3(t *testing.T) {
 				NextDomain: "2N1TB3VAIRUOBL6RKDVII42N9TFMIALP",
 			},
 			name:   "asd.com.",
+			covers: false,
+		},
+		{ // empty interval wildcard
+			rr: &NSEC3{
+				Hdr:        RR_Header{Name: "2n1tb3vairuobl6rkdvii42n9tfmialp.com."},
+				Hash:       1,
+				Flags:      1,
+				Iterations: 5,
+				Salt:       "F10E9F7EA83FC8F3",
+				NextDomain: "2N1TB3VAIRUOBL6RKDVII42N9TFMIALP",
+			},
+			name:   "*.asd.com.",
 			covers: true,
 		},
 		{ // name hash is before owner hash, not covered

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -110,18 +110,6 @@ func TestNsec3(t *testing.T) {
 				NextDomain: "2N1TB3VAIRUOBL6RKDVII42N9TFMIALP",
 			},
 			name:   "asd.com.",
-			covers: false,
-		},
-		{ // empty interval close to next
-			rr: &NSEC3{
-				Hdr:        RR_Header{Name: "2n1tb3vairuobl6rkdvii42n9tfmialp.com."},
-				Hash:       1,
-				Flags:      1,
-				Iterations: 5,
-				Salt:       "F10E9F7EA83FC8F3",
-				NextDomain: "2N1TB3VAIRUOBL6RKDVII42N9TFMIALP",
-			},
-			name:   "asdc.com.",
 			covers: true,
 		},
 		{ // name hash is before owner hash, not covered


### PR DESCRIPTION
I got a NX record (219.50.238.170.virbl.dnsbl.bit.nl) but looks like not covering in `(*NSEC3).Cover()` 

I checked on http://dnsviz.net/d/219.50.238.170.virbl.dnsbl.bit.nl/dnssec/ wildcard hash covered and valid. 

RFC 5155 section 8.4 (https://tools.ietf.org/html/rfc5155#section-8.4) described this.

Can you check it?