### PR TITLE
Fix TCP connection tracking memory leak

### DIFF
--- a/server.go
+++ b/server.go
@@ -779,10 +779,6 @@ func (w *response) Write(m []byte) (int, error) {
 
 // LocalAddr implements the ResponseWriter.LocalAddr method.
 func (w *response) LocalAddr() net.Addr {
-	if w.closed {
-		panic("dns: LocalAddr called after Close")
-	}
-
 	switch {
 	case w.udp != nil:
 		return w.udp.LocalAddr()
@@ -795,10 +791,6 @@ func (w *response) LocalAddr() net.Addr {
 
 // RemoteAddr implements the ResponseWriter.RemoteAddr method.
 func (w *response) RemoteAddr() net.Addr {
-	if w.closed {
-		panic("dns: RemoteAddr called after Close")
-	}
-
 	switch {
 	case w.udpSession != nil:
 		return w.udpSession.RemoteAddr()

--- a/server.go
+++ b/server.go
@@ -730,7 +730,7 @@ func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *S
 // WriteMsg implements the ResponseWriter.WriteMsg method.
 func (w *response) WriteMsg(m *Msg) (err error) {
 	if w.closed {
-		panic("dns: WriteMsg called after Close")
+		return &Error{err: "WriteMsg called after Close"}
 	}
 
 	var data []byte
@@ -755,7 +755,7 @@ func (w *response) WriteMsg(m *Msg) (err error) {
 // Write implements the ResponseWriter.Write method.
 func (w *response) Write(m []byte) (int, error) {
 	if w.closed {
-		panic("dns: Write called after Close")
+		return 0, &Error{err: "Write called after Close"}
 	}
 
 	switch {

--- a/server.go
+++ b/server.go
@@ -729,6 +729,10 @@ func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *S
 
 // WriteMsg implements the ResponseWriter.WriteMsg method.
 func (w *response) WriteMsg(m *Msg) (err error) {
+	if w.closed {
+		panic("dns: WriteMsg called after Close")
+	}
+
 	var data []byte
 	if w.tsigSecret != nil { // if no secrets, dont check for the tsig (which is a longer check)
 		if t := m.IsTsig(); t != nil {

--- a/server.go
+++ b/server.go
@@ -812,7 +812,13 @@ func (w *response) TsigStatus() error { return w.tsigStatus }
 func (w *response) TsigTimersOnly(b bool) { w.tsigTimersOnly = b }
 
 // Hijack implements the ResponseWriter.Hijack method.
-func (w *response) Hijack() { w.hijacked = true }
+func (w *response) Hijack() {
+	if w.closed {
+		panic("dns: Hijack called after Close")
+	}
+
+	w.hijacked = true
+}
 
 // Close implements the ResponseWriter.Close method
 func (w *response) Close() error {

--- a/server.go
+++ b/server.go
@@ -812,13 +812,7 @@ func (w *response) TsigStatus() error { return w.tsigStatus }
 func (w *response) TsigTimersOnly(b bool) { w.tsigTimersOnly = b }
 
 // Hijack implements the ResponseWriter.Hijack method.
-func (w *response) Hijack() {
-	if w.closed {
-		panic("dns: Hijack called after Close")
-	}
-
-	w.hijacked = true
-}
+func (w *response) Hijack() { w.hijacked = true }
 
 // Close implements the ResponseWriter.Close method
 func (w *response) Close() error {

--- a/server.go
+++ b/server.go
@@ -823,7 +823,7 @@ func (w *response) Hijack() {
 // Close implements the ResponseWriter.Close method
 func (w *response) Close() error {
 	if w.closed {
-		return nil
+		return &Error{err: "connection already closed"}
 	}
 	w.closed = true
 

--- a/server_test.go
+++ b/server_test.go
@@ -996,6 +996,15 @@ func TestResponseAfterClose(t *testing.T) {
 	})
 }
 
+func TestResponseDoubleClose(t *testing.T) {
+	rw := &response{
+		closed: true,
+	}
+	if err, expect := rw.Close(), "dns: connection already closed"; err == nil || err.Error() != expect {
+		t.Errorf("Close did not return expected: error %q, got: %v", expect, err)
+	}
+}
+
 type ExampleFrameLengthWriter struct {
 	Writer
 }

--- a/server_test.go
+++ b/server_test.go
@@ -725,7 +725,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 	srv.lock.RLock()
 	defer srv.lock.RUnlock()
 	if len(srv.conns) != 0 {
-		t.Errorf("TCP connection tracking map not empty after Shutdown; map still contains %d connections", len(srv.conns))
+		t.Errorf("TCP connection tracking map not empty after ShutdownContext; map still contains %d connections", len(srv.conns))
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -991,6 +991,9 @@ func TestResponseAfterClose(t *testing.T) {
 	testPanic("WriteMsg", func() {
 		rw.WriteMsg(new(Msg))
 	})
+	testPanic("Hijack", func() {
+		rw.Hijack()
+	})
 }
 
 type ExampleFrameLengthWriter struct {

--- a/server_test.go
+++ b/server_test.go
@@ -719,7 +719,11 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 	}
 
 	if eg.Wait() != nil {
-		t.Fatalf("conn.ReadMsg error: %v", eg.Wait())
+		t.Errorf("conn.ReadMsg error: %v", eg.Wait())
+	}
+
+	if len(srv.conns) != 0 {
+		t.Errorf("TCP connection tracking map not empty after Shutdown; map still contains %d connections", len(srv.conns))
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -988,12 +988,6 @@ func TestResponseAfterClose(t *testing.T) {
 	testPanic("Write", func() {
 		rw.Write(make([]byte, 2))
 	})
-	testPanic("LocalAddr", func() {
-		rw.LocalAddr()
-	})
-	testPanic("RemoteAddr", func() {
-		rw.RemoteAddr()
-	})
 }
 
 type ExampleFrameLengthWriter struct {

--- a/server_test.go
+++ b/server_test.go
@@ -988,6 +988,9 @@ func TestResponseAfterClose(t *testing.T) {
 	testPanic("Write", func() {
 		rw.Write(make([]byte, 2))
 	})
+	testPanic("WriteMsg", func() {
+		rw.WriteMsg(new(Msg))
+	})
 }
 
 type ExampleFrameLengthWriter struct {

--- a/server_test.go
+++ b/server_test.go
@@ -722,6 +722,8 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 		t.Errorf("conn.ReadMsg error: %v", eg.Wait())
 	}
 
+	srv.lock.RLock()
+	defer srv.lock.RUnlock()
 	if len(srv.conns) != 0 {
 		t.Errorf("TCP connection tracking map not empty after Shutdown; map still contains %d connections", len(srv.conns))
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -993,9 +993,6 @@ func TestResponseAfterClose(t *testing.T) {
 	testPanic("WriteMsg", func() {
 		rw.WriteMsg(new(Msg))
 	})
-	testPanic("Hijack", func() {
-		rw.Hijack()
-	})
 }
 
 func TestResponseDoubleClose(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -983,9 +983,7 @@ func TestResponseAfterClose(t *testing.T) {
 	}
 
 	rw := &response{
-		tcp:        nil, // Close sets tcp to nil
-		udp:        nil,
-		udpSession: nil,
+		closed: true,
 	}
 	testPanic("Write", func() {
 		rw.Write(make([]byte, 2))


### PR DESCRIPTION
This refactors how `response.Close` works. This fixes both the memory leak observed in #807 and a similar memory leak that would occur if `Close` was called manually by the handler. The `checkInProgressQueriesAtShutdownServer` test now checks the tracking map is empty after `ShutdownContext` returns.

Along for the ride are some changes to which `response` methods ~panic-after-`Close`~ (edit: fail-after-`Close`), this fixes #766 and allows `LocalAddr` and `RemoteAddr` to work after `Close`.

`Close` also now returns an error if called multiple times.

Fixes #807
Fixes #766
Updates #769