### PR TITLE
Reduce lock-contention in ServeMux

### DIFF
--- a/serve_mux.go
+++ b/serve_mux.go
@@ -86,6 +86,10 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 	if pattern == "" {
 		panic("dns: invalid pattern " + pattern)
 	}
+	if handler == nil {
+		panic("dns: nil Handler for pattern " + pattern)
+	}
+
 	mux.m.Lock()
 	if mux.z == nil {
 		mux.z = make(map[string]Handler)


### PR DESCRIPTION
This replaces the `sync.RWMutex` + `map` combo with an `atomic.Value` + `map` that is copied on modification. `sync.RWMutex` causes substantial lock-contention on massively-threaded systems (see golang/go#17973).

It is optimised for the common case of setup with multiple calls to `Handle` before finally serving DNS requests uninterrupted, making no copies in that case. It will incur notable overhead when invoking `Handle` or `HandleRemove` after the `ServeMux` has started serving DNS requests as the entire map must be copied on each call. Despite this, the old map will only be live for a short time before being effectively garbage collected.

---

This is the difference between master and #809:
<details>
<summary>$ benchstat {old,mid}.bench</summary>
<pre>
$ benchstat {old,mid}.bench
name                                      old time/op    new time/op    delta
MuxMatch/lowercase-12                       67.1ns ± 1%    70.9ns ± 1%    +5.70%  (p=0.000 n=9+9)
MuxMatch/uppercase-12                        116ns ± 1%     117ns ± 1%    +0.82%  (p=0.034 n=9+10)
MuxMatchConcurrent-12                       47.2ns ± 1%    12.4ns ± 1%   -73.65%  (p=0.000 n=10+10)
MuxHandleFunc/fresh-12                      35.5ns ± 1%    98.4ns ± 5%  +177.04%  (p=0.000 n=9+10)
MuxHandleFunc/claimed-12                    35.5ns ± 1%    96.7ns ± 6%  +172.62%  (p=0.000 n=9+10)
MuxHandleFunc/concurrent+fresh-12           78.6ns ± 0%   161.3ns ± 0%  +105.19%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12         78.7ns ± 0%   161.7ns ± 0%  +105.40%  (p=0.000 n=8+10)
MuxHandleRemove/fresh-12                    26.4ns ± 0%     6.5ns ± 1%   -75.22%  (p=0.000 n=10+10)
MuxHandleRemove/claimed-12                  26.4ns ± 1%     6.3ns ± 1%   -76.28%  (p=0.000 n=10+9)
MuxHandleRemove/concurrent+fresh-12         64.7ns ± 1%     1.1ns ± 1%   -98.34%  (p=0.000 n=10+9)
MuxHandleRemove/concurrent+claimed-12       64.9ns ± 1%     1.1ns ± 0%   -98.35%  (p=0.000 n=10+8)
MuxHandleAddRemove/fresh-12                 76.6ns ± 1%   194.8ns ± 3%  +154.35%  (p=0.000 n=9+9)
MuxHandleAddRemove/claimed-12               77.0ns ± 1%   194.1ns ± 3%  +152.18%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12       167ns ± 0%     318ns ± 0%   +90.82%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12     166ns ± 1%     318ns ± 0%   +91.07%  (p=0.000 n=10+8)
Serve-12                                    53.7µs ± 4%    54.8µs ± 5%      ~     (p=0.258 n=9+9)
Serve6-12                                   55.7µs ± 7%    56.7µs ± 7%      ~     (p=0.218 n=10+10)
ServeConcurrent-12                          7.77µs ± 1%    7.82µs ± 1%    +0.57%  (p=0.029 n=10+10)
ServeCompress-12                            60.3µs ± 2%    60.1µs ± 6%      ~     (p=0.447 n=9+10)
&nbsp;
name                                      old alloc/op   new alloc/op   delta
MuxMatch/lowercase-12                        0.00B          0.00B           ~     (all equal)
MuxMatch/uppercase-12                        32.0B ± 0%     32.0B ± 0%      ~     (all equal)
MuxMatchConcurrent-12                        0.00B          0.00B           ~     (all equal)
MuxHandleFunc/fresh-12                       0.00B         32.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/claimed-12                     0.00B         32.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+fresh-12            0.00B         32.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12          0.00B         32.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleRemove/fresh-12                     0.00B          0.00B           ~     (all equal)
MuxHandleRemove/claimed-12                   0.00B          0.00B           ~     (all equal)
MuxHandleRemove/concurrent+fresh-12          0.00B          0.00B           ~     (all equal)
MuxHandleRemove/concurrent+claimed-12        0.00B          0.00B           ~     (all equal)
MuxHandleAddRemove/fresh-12                  0.00B         56.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/claimed-12                0.00B         56.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12       0.00B         53.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12     0.00B         53.00B ± 0%     +Inf%  (p=0.000 n=10+10)
Serve-12                                    3.36kB ± 0%    3.36kB ± 0%      ~     (p=0.137 n=8+10)
Serve6-12                                   3.20kB ± 0%    3.20kB ± 0%      ~     (all equal)
ServeConcurrent-12                          3.38kB ± 0%    3.38kB ± 0%      ~     (all equal)
ServeCompress-12                            3.62kB ± 0%    3.62kB ± 0%      ~     (all equal)
&nbsp;
name                                      old allocs/op  new allocs/op  delta
MuxMatch/lowercase-12                         0.00           0.00           ~     (all equal)
MuxMatch/uppercase-12                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
MuxMatchConcurrent-12                         0.00           0.00           ~     (all equal)
MuxHandleFunc/fresh-12                        0.00           2.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/claimed-12                      0.00           2.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+fresh-12             0.00           2.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12           0.00           2.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleRemove/fresh-12                      0.00           0.00           ~     (all equal)
MuxHandleRemove/claimed-12                    0.00           0.00           ~     (all equal)
MuxHandleRemove/concurrent+fresh-12           0.00           0.00           ~     (all equal)
MuxHandleRemove/concurrent+claimed-12         0.00           0.00           ~     (all equal)
MuxHandleAddRemove/fresh-12                   0.00           4.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/claimed-12                 0.00           4.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12        0.00           3.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12      0.00           3.00 ± 0%     +Inf%  (p=0.000 n=10+10)
Serve-12                                      54.0 ± 0%      54.0 ± 0%      ~     (all equal)
Serve6-12                                     51.0 ± 0%      51.0 ± 0%      ~     (all equal)
ServeConcurrent-12                            54.0 ± 0%      54.0 ± 0%      ~     (all equal)
ServeCompress-12                              56.0 ± 0%      56.0 ± 0%      ~     (all equal)
</pre>
</details><br>

This is the difference between master and this PR:
<details>
<summary>$ benchstat {old,new}.bench</summary>
<pre>
$ benchstat {old,new}.bench
name                                      old time/op    new time/op    delta
MuxMatch/lowercase-12                       67.1ns ± 1%    30.4ns ± 1%   -54.75%  (p=0.000 n=9+10)
MuxMatch/uppercase-12                        116ns ± 1%      88ns ± 6%   -24.33%  (p=0.000 n=9+10)
MuxMatchConcurrent-12                       47.2ns ± 1%     4.8ns ± 0%   -89.77%  (p=0.000 n=10+9)
MuxHandleFunc/fresh-12                      35.5ns ± 1%    35.1ns ± 1%    -1.10%  (p=0.000 n=9+9)
MuxHandleFunc/claimed-12                    35.5ns ± 1%   333.3ns ± 7%  +839.56%  (p=0.000 n=9+9)
MuxHandleFunc/concurrent+fresh-12           78.6ns ± 0%    75.8ns ± 1%    -3.56%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12         78.7ns ± 0%   331.8ns ± 5%  +321.47%  (p=0.000 n=8+10)
MuxHandleRemove/fresh-12                    26.4ns ± 0%    18.6ns ± 1%   -29.39%  (p=0.000 n=10+10)
MuxHandleRemove/claimed-12                  26.4ns ± 1%    18.7ns ± 1%   -29.33%  (p=0.000 n=10+10)
MuxHandleRemove/concurrent+fresh-12         64.7ns ± 1%    55.3ns ± 1%   -14.63%  (p=0.000 n=10+10)
MuxHandleRemove/concurrent+claimed-12       64.9ns ± 1%    55.1ns ± 0%   -15.02%  (p=0.000 n=10+9)
MuxHandleAddRemove/fresh-12                 76.6ns ± 1%    81.1ns ± 1%    +5.92%  (p=0.000 n=9+9)
MuxHandleAddRemove/claimed-12               77.0ns ± 1%   566.9ns ± 7%  +636.52%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12       167ns ± 0%     166ns ± 0%      ~     (p=0.656 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12     166ns ± 1%     563ns ± 4%  +238.02%  (p=0.000 n=10+10)
Serve-12                                    53.7µs ± 4%    54.5µs ± 2%      ~     (p=0.094 n=9+9)
Serve6-12                                   55.7µs ± 7%    54.8µs ± 3%      ~     (p=0.393 n=10+10)
ServeConcurrent-12                          7.77µs ± 1%    7.77µs ± 1%      ~     (p=0.896 n=10+10)
ServeCompress-12                            60.3µs ± 2%    57.1µs ± 4%    -5.26%  (p=0.000 n=9+10)
&nbsp;
name                                      old alloc/op   new alloc/op   delta
MuxMatch/lowercase-12                        0.00B          0.00B           ~     (all equal)
MuxMatch/uppercase-12                        32.0B ± 0%     32.0B ± 0%      ~     (all equal)
MuxMatchConcurrent-12                        0.00B          0.00B           ~     (all equal)
MuxHandleFunc/fresh-12                       0.00B          0.00B           ~     (all equal)
MuxHandleFunc/claimed-12                     0.00B        336.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+fresh-12            0.00B          0.00B           ~     (all equal)
MuxHandleFunc/concurrent+claimed-12          0.00B        336.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleRemove/fresh-12                     0.00B          0.00B           ~     (all equal)
MuxHandleRemove/claimed-12                   0.00B          0.00B           ~     (all equal)
MuxHandleRemove/concurrent+fresh-12          0.00B          0.00B           ~     (all equal)
MuxHandleRemove/concurrent+claimed-12        0.00B          0.00B           ~     (all equal)
MuxHandleAddRemove/fresh-12                  0.00B          0.00B           ~     (all equal)
MuxHandleAddRemove/claimed-12                0.00B        672.00B ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12       0.00B          0.00B           ~     (all equal)
MuxHandleAddRemove/concurrent+claimed-12     0.00B        670.00B ± 0%     +Inf%  (p=0.000 n=10+10)
Serve-12                                    3.36kB ± 0%    3.36kB ± 0%      ~     (all equal)
Serve6-12                                   3.20kB ± 0%    3.20kB ± 0%      ~     (all equal)
ServeConcurrent-12                          3.38kB ± 0%    3.38kB ± 0%    +0.02%  (p=0.015 n=9+10)
ServeCompress-12                            3.62kB ± 0%    3.62kB ± 0%      ~     (all equal)
&nbsp;
name                                      old allocs/op  new allocs/op  delta
MuxMatch/lowercase-12                         0.00           0.00           ~     (all equal)
MuxMatch/uppercase-12                         1.00 ± 0%      1.00 ± 0%      ~     (all equal)
MuxMatchConcurrent-12                         0.00           0.00           ~     (all equal)
MuxHandleFunc/fresh-12                        0.00           0.00           ~     (all equal)
MuxHandleFunc/claimed-12                      0.00           2.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+fresh-12             0.00           0.00           ~     (all equal)
MuxHandleFunc/concurrent+claimed-12           0.00           2.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleRemove/fresh-12                      0.00           0.00           ~     (all equal)
MuxHandleRemove/claimed-12                    0.00           0.00           ~     (all equal)
MuxHandleRemove/concurrent+fresh-12           0.00           0.00           ~     (all equal)
MuxHandleRemove/concurrent+claimed-12         0.00           0.00           ~     (all equal)
MuxHandleAddRemove/fresh-12                   0.00           0.00           ~     (all equal)
MuxHandleAddRemove/claimed-12                 0.00           4.00 ± 0%     +Inf%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12        0.00           0.00           ~     (all equal)
MuxHandleAddRemove/concurrent+claimed-12      0.00           3.00 ± 0%     +Inf%  (p=0.000 n=10+10)
Serve-12                                      54.0 ± 0%      54.0 ± 0%      ~     (all equal)
Serve6-12                                     51.0 ± 0%      51.0 ± 0%      ~     (all equal)
ServeConcurrent-12                            54.0 ± 0%      54.0 ± 0%      ~     (all equal)
ServeCompress-12                              56.0 ± 0%      56.0 ± 0%      ~     (all equal)
</pre>
</details><br>

This is the difference between #809 and this PR:
<details>
<summary>$ benchstat {mid,new}.bench</summary>
<pre>
$ benchstat {mid,new}.bench
name                                      old time/op    new time/op    delta
MuxMatch/lowercase-12                       70.9ns ± 1%    30.4ns ± 1%    -57.19%  (p=0.000 n=9+10)
MuxMatch/uppercase-12                        117ns ± 1%      88ns ± 6%    -24.95%  (p=0.000 n=10+10)
MuxMatchConcurrent-12                       12.4ns ± 1%     4.8ns ± 0%    -61.18%  (p=0.000 n=10+9)
MuxHandleFunc/fresh-12                      98.4ns ± 5%    35.1ns ± 1%    -64.30%  (p=0.000 n=10+9)
MuxHandleFunc/claimed-12                    96.7ns ± 6%   333.3ns ± 7%   +244.64%  (p=0.000 n=10+9)
MuxHandleFunc/concurrent+fresh-12            161ns ± 0%      76ns ± 1%    -53.00%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12          162ns ± 0%     332ns ± 5%   +105.19%  (p=0.000 n=10+10)
MuxHandleRemove/fresh-12                    6.54ns ± 1%   18.64ns ± 1%   +184.88%  (p=0.000 n=10+10)
MuxHandleRemove/claimed-12                  6.27ns ± 1%   18.67ns ± 1%   +197.87%  (p=0.000 n=9+10)
MuxHandleRemove/concurrent+fresh-12         1.08ns ± 1%   55.28ns ± 1%  +5029.07%  (p=0.000 n=9+10)
MuxHandleRemove/concurrent+claimed-12       1.07ns ± 0%   55.14ns ± 0%  +5053.69%  (p=0.000 n=8+9)
MuxHandleAddRemove/fresh-12                  195ns ± 3%      81ns ± 1%    -58.36%  (p=0.000 n=9+9)
MuxHandleAddRemove/claimed-12                194ns ± 3%     567ns ± 7%   +192.07%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12       318ns ± 0%     166ns ± 0%    -47.66%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12     318ns ± 0%     563ns ± 4%    +76.91%  (p=0.000 n=8+10)
Serve-12                                    54.8µs ± 5%    54.5µs ± 2%       ~     (p=0.863 n=9+9)
Serve6-12                                   56.7µs ± 7%    54.8µs ± 3%     -3.40%  (p=0.019 n=10+10)
ServeConcurrent-12                          7.82µs ± 1%    7.77µs ± 1%       ~     (p=0.052 n=10+10)
ServeCompress-12                            60.1µs ± 6%    57.1µs ± 4%     -4.92%  (p=0.009 n=10+10)
&nbsp;
name                                      old alloc/op   new alloc/op   delta
MuxMatch/lowercase-12                        0.00B          0.00B            ~     (all equal)
MuxMatch/uppercase-12                        32.0B ± 0%     32.0B ± 0%       ~     (all equal)
MuxMatchConcurrent-12                        0.00B          0.00B            ~     (all equal)
MuxHandleFunc/fresh-12                       32.0B ± 0%      0.0B        -100.00%  (p=0.000 n=10+10)
MuxHandleFunc/claimed-12                     32.0B ± 0%    336.0B ± 0%   +950.00%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+fresh-12            32.0B ± 0%      0.0B        -100.00%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12          32.0B ± 0%    336.0B ± 0%   +950.00%  (p=0.000 n=10+10)
MuxHandleRemove/fresh-12                     0.00B          0.00B            ~     (all equal)
MuxHandleRemove/claimed-12                   0.00B          0.00B            ~     (all equal)
MuxHandleRemove/concurrent+fresh-12          0.00B          0.00B            ~     (all equal)
MuxHandleRemove/concurrent+claimed-12        0.00B          0.00B            ~     (all equal)
MuxHandleAddRemove/fresh-12                  56.0B ± 0%      0.0B        -100.00%  (p=0.000 n=10+10)
MuxHandleAddRemove/claimed-12                56.0B ± 0%    672.0B ± 0%  +1100.00%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+fresh-12       53.0B ± 0%      0.0B        -100.00%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12     53.0B ± 0%    670.0B ± 0%  +1164.15%  (p=0.000 n=10+10)
Serve-12                                    3.36kB ± 0%    3.36kB ± 0%       ~     (p=0.294 n=10+8)
Serve6-12                                   3.20kB ± 0%    3.20kB ± 0%       ~     (all equal)
ServeConcurrent-12                          3.38kB ± 0%    3.38kB ± 0%     +0.02%  (p=0.015 n=9+10)
ServeCompress-12                            3.62kB ± 0%    3.62kB ± 0%       ~     (all equal)
&nbsp;
name                                      old allocs/op  new allocs/op  delta
MuxMatch/lowercase-12                         0.00           0.00            ~     (all equal)
MuxMatch/uppercase-12                         1.00 ± 0%      1.00 ± 0%       ~     (all equal)
MuxMatchConcurrent-12                         0.00           0.00            ~     (all equal)
MuxHandleFunc/fresh-12                        2.00 ± 0%      0.00        -100.00%  (p=0.000 n=10+10)
MuxHandleFunc/claimed-12                      2.00 ± 0%      2.00 ± 0%       ~     (all equal)
MuxHandleFunc/concurrent+fresh-12             2.00 ± 0%      0.00        -100.00%  (p=0.000 n=10+10)
MuxHandleFunc/concurrent+claimed-12           2.00 ± 0%      2.00 ± 0%       ~     (all equal)
MuxHandleRemove/fresh-12                      0.00           0.00            ~     (all equal)
MuxHandleRemove/claimed-12                    0.00           0.00            ~     (all equal)
MuxHandleRemove/concurrent+fresh-12           0.00           0.00            ~     (all equal)
MuxHandleRemove/concurrent+claimed-12         0.00           0.00            ~     (all equal)
MuxHandleAddRemove/fresh-12                   4.00 ± 0%      0.00        -100.00%  (p=0.000 n=10+10)
MuxHandleAddRemove/claimed-12                 4.00 ± 0%      4.00 ± 0%       ~     (all equal)
MuxHandleAddRemove/concurrent+fresh-12        3.00 ± 0%      0.00        -100.00%  (p=0.000 n=10+10)
MuxHandleAddRemove/concurrent+claimed-12      3.00 ± 0%      3.00 ± 0%       ~     (all equal)
Serve-12                                      54.0 ± 0%      54.0 ± 0%       ~     (all equal)
Serve6-12                                     51.0 ± 0%      51.0 ± 0%       ~     (all equal)
ServeConcurrent-12                            54.0 ± 0%      54.0 ± 0%       ~     (all equal)
ServeCompress-12                              56.0 ± 0%      56.0 ± 0%       ~     (all equal)
</pre>
</details>

---

This is an alternative to #809.

/cc @Aestek