### PR TITLE
Fix NotImp RCode string

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -151,7 +151,7 @@ var RcodeToString = map[int]string{
 	RcodeFormatError:    "FORMERR",
 	RcodeServerFailure:  "SERVFAIL",
 	RcodeNameError:      "NXDOMAIN",
-	RcodeNotImplemented: "NOTIMPL",
+	RcodeNotImplemented: "NOTIMP",
 	RcodeRefused:        "REFUSED",
 	RcodeYXDomain:       "YXDOMAIN", // See RFC 2136
 	RcodeYXRrset:        "YXRRSET",

--- a/reverse.go
+++ b/reverse.go
@@ -12,6 +12,11 @@ var StringToOpcode = reverseInt(OpcodeToString)
 // StringToRcode is a map of rcodes to strings.
 var StringToRcode = reverseInt(RcodeToString)
 
+func init() {
+	// Preserve previous NOTIMP typo, see github.com/miekg/dns/issues/733.
+	StringToRcode["NOTIMPL"] = RcodeNotImplemented
+}
+
 // Reverse a map
 func reverseInt8(m map[uint8]string) map[string]uint8 {
 	n := make(map[string]uint8, len(m))


### PR DESCRIPTION
[RFC 6895](https://tools.ietf.org/html/rfc6895#page-5) lists RCODE 4 as NotImp.

This PR also continues to support the legacy spelling `NOTIMPL` in `StringToRcode`.

Fixes #733.

/cc @bcorijn