### PR TITLE
Use map[string]struct{} for compression map in Len

### DIFF
--- a/compress_generate.go
+++ b/compress_generate.go
@@ -101,7 +101,7 @@ Names:
 
 	// compressionLenHelperType - all types that have domain-name/cdomain-name can be used for compressing names
 
-	fmt.Fprint(b, "func compressionLenHelperType(c map[string]int, r RR, initLen int) int {\n")
+	fmt.Fprint(b, "func compressionLenHelperType(c map[string]struct{}, r RR, initLen int) int {\n")
 	fmt.Fprint(b, "currentLen := initLen\n")
 	fmt.Fprint(b, "switch x := r.(type) {\n")
 	for _, name := range domainTypes {
@@ -145,7 +145,7 @@ Names:
 
 	// compressionLenSearchType - search cdomain-tags types for compressible names.
 
-	fmt.Fprint(b, "func compressionLenSearchType(c map[string]int, r RR) (int, bool, int) {\n")
+	fmt.Fprint(b, "func compressionLenSearchType(c map[string]struct{}, r RR) (int, bool, int) {\n")
 	fmt.Fprint(b, "switch x := r.(type) {\n")
 	for _, name := range cdomainTypes {
 		o := scope.Lookup(name)

--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"fmt"
 	"net"
 	"testing"
 )
@@ -60,6 +61,31 @@ func BenchmarkMsgLengthPack(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = msg.Pack()
+	}
+}
+
+func BenchmarkMsgLengthMassive(b *testing.B) {
+	makeMsg := func(question string, ans, ns, e []RR) *Msg {
+		msg := new(Msg)
+		msg.SetQuestion(Fqdn(question), TypeANY)
+		msg.Answer = append(msg.Answer, ans...)
+		msg.Ns = append(msg.Ns, ns...)
+		msg.Extra = append(msg.Extra, e...)
+		msg.Compress = true
+		return msg
+	}
+	const name1 = "12345678901234567890123456789012345.12345678.123."
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
+	answer := []RR{rrMx, rrMx}
+	for i := 0; i < 128; i++ {
+		rrA := testRR(fmt.Sprintf("example%03d.something%03delse.org. 2311 IN A 127.0.0.1", i/32, i%32))
+		answer = append(answer, rrA)
+	}
+	answer = append(answer, rrMx, rrMx)
+	msg := makeMsg(name1, answer, nil, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg.Len()
 	}
 }
 

--- a/zcompress.go
+++ b/zcompress.go
@@ -2,7 +2,7 @@
 
 package dns
 
-func compressionLenHelperType(c map[string]int, r RR, initLen int) int {
+func compressionLenHelperType(c map[string]struct{}, r RR, initLen int) int {
 	currentLen := initLen
 	switch x := r.(type) {
 	case *AFSDB:
@@ -107,7 +107,7 @@ func compressionLenHelperType(c map[string]int, r RR, initLen int) int {
 	return currentLen - initLen
 }
 
-func compressionLenSearchType(c map[string]int, r RR) (int, bool, int) {
+func compressionLenSearchType(c map[string]struct{}, r RR) (int, bool, int) {
 	switch x := r.(type) {
 	case *CNAME:
 		k1, ok1, sz1 := compressionLenSearch(c, x.Target)


### PR DESCRIPTION
`map[string]int` requires 8 bytes per entry to store the unused position information.

~I couldn't get any clean benchmarks from this, but `map[string]struct{}` definitely uses less memory than `map[string]int`.~

This does unfortunately make the related test cases slightly weaker as they no longer test that the `Len` code is finding compression points in the correct spot.

Updates #709.

Edit: I was able to get some better benchmarks that show a very notable improvement in memory use.

```
$ benchstat {old,new}.bench
name                       old time/op    new time/op    delta
MsgLength-12                  329ns ± 0%     328ns ± 0%   -0.27%  (p=0.040 n=9+9)
MsgLengthNoCompression-12    9.37ns ± 1%    9.34ns ± 2%     ~     (p=0.099 n=10+10)
MsgLengthPack-12             2.26µs ± 9%    2.36µs ±23%     ~     (p=0.780 n=9+10)
MsgLengthMassive-12          63.1µs ± 8%    53.0µs ± 3%  -15.89%  (p=0.000 n=10+10)

name                       old alloc/op   new alloc/op   delta
MsgLength-12                  32.0B ± 0%     32.0B ± 0%     ~     (all equal)
MsgLengthNoCompression-12     0.00B          0.00B          ~     (all equal)
MsgLengthPack-12               896B ± 0%      896B ± 0%     ~     (all equal)
MsgLengthMassive-12          20.2kB ± 0%    14.8kB ± 0%  -26.74%  (p=0.000 n=8+9)

name                       old allocs/op  new allocs/op  delta
MsgLength-12                   1.00 ± 0%      1.00 ± 0%     ~     (all equal)
MsgLengthNoCompression-12      0.00           0.00          ~     (all equal)
MsgLengthPack-12               8.00 ± 0%      8.00 ± 0%     ~     (all equal)
MsgLengthMassive-12             138 ± 0%       138 ± 0%     ~     (all equal)
```