### PR TITLE
Avoid compressing QNAMEs

### DIFF
--- a/length_test.go
+++ b/length_test.go
@@ -369,3 +369,20 @@ func TestMsgCompressLengthLargeRecordsAllValues(t *testing.T) {
 		}
 	}
 }
+
+func TestMsgCompressionMultipleQuestions(t *testing.T) {
+	msg := new(Msg)
+	msg.Compress = true
+	msg.SetQuestion("www.example.org.", TypeA)
+	msg.Question = append(msg.Question, Question{"other.example.org.", TypeA, ClassINET})
+
+	predicted := msg.Len()
+	buf, err := msg.Pack()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if predicted != len(buf) {
+		t.Fatalf("predicted compressed length is wrong: predicted %d, actual %d", predicted, len(buf))
+	}
+}

--- a/msg.go
+++ b/msg.go
@@ -747,7 +747,7 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]
 		return nil, err
 	}
 	for i := 0; i < len(question); i++ {
-		off, err = question[i].pack(msg, off, compression, dns.Compress)
+		off, err = question[i].pack(msg, off, compression)
 		if err != nil {
 			return nil, err
 		}
@@ -1090,8 +1090,8 @@ func (dns *Msg) CopyTo(r1 *Msg) *Msg {
 	return r1
 }
 
-func (q *Question) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
-	off, err := PackDomainName(q.Name, msg, off, compression, compress)
+func (q *Question) pack(msg []byte, off int, compression map[string]int) (int, error) {
+	off, err := PackDomainName(q.Name, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}

--- a/types.go
+++ b/types.go
@@ -213,7 +213,7 @@ var StringToCertType = reverseInt16(CertTypeToString)
 // Question holds a DNS question. There can be multiple questions in the
 // question section of a message. Usually there is just one.
 type Question struct {
-	Name   string `dns:"cdomain-name"` // "cdomain-name" specifies encoding (and may be compressed)
+	Name   string `dns:"domain-name"` // "domain-name" specifies encoding
 	Qtype  uint16
 	Qclass uint16
 }


### PR DESCRIPTION
Although very rare and largely unsupported, whether QNAMEs can be compressed isn't clear to me. I can't find anything clear in the RFCs, but I don't *think* we want to compress QNAMEs (see #821). As compression is optional anyway, this can never be wrong just non-optimal.

Fixes #821.