### PR TITLE
Avoid creating compression map for question only Msg

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -63,6 +63,16 @@ func BenchmarkMsgLengthPack(b *testing.B) {
 	}
 }
 
+func BenchmarkMsgLengthOnlyQuestion(b *testing.B) {
+	msg := new(Msg)
+	msg.SetQuestion(Fqdn("12345678901234567890123456789012345.12345678.123."), TypeANY)
+	msg.Compress = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg.Len()
+	}
+}
+
 func BenchmarkPackDomainName(b *testing.B) {
 	name1 := "12345678901234567890123456789012345.12345678.123."
 	buf := make([]byte, len(name1)+1)
@@ -194,6 +204,18 @@ func BenchmarkPackMsg(b *testing.B) {
 	name1 := "12345678901234567890123456789012345.12345678.123."
 	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
 	msg := makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)
+	buf := make([]byte, 512)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.PackBuffer(buf)
+	}
+}
+
+func BenchmarkPackMsgOnlyQuestion(b *testing.B) {
+	msg := new(Msg)
+	msg.SetQuestion(Fqdn("12345678901234567890123456789012345.12345678.123."), TypeANY)
+	msg.Compress = true
 	buf := make([]byte, 512)
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/length_test.go
+++ b/length_test.go
@@ -282,7 +282,7 @@ func TestCompareCompressionMapsForANY(t *testing.T) {
 		lenFake := compressedLenWithCompressionMap(msg, compressionFake)
 
 		compressionReal := make(map[string]int)
-		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal)
+		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -315,7 +315,7 @@ func TestCompareCompressionMapsForSRV(t *testing.T) {
 		lenFake := compressedLenWithCompressionMap(msg, compressionFake)
 
 		compressionReal := make(map[string]int)
-		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal)
+		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/msg.go
+++ b/msg.go
@@ -909,8 +909,9 @@ func (dns *Msg) Len() int { return compressedLen(dns, dns.Compress) }
 
 // isCompressible returns whether the msg may be compressible.
 func (dns *Msg) isCompressible() bool {
-	// If we only have questions, there is nothing we can ever compress.
-	return len(dns.Answer) > 0 || len(dns.Ns) > 0 || len(dns.Extra) > 0
+	// If we only have one question, there is nothing we can ever compress.
+	return len(dns.Question) > 1 || len(dns.Answer) > 0 ||
+		len(dns.Ns) > 0 || len(dns.Extra) > 0
 }
 
 func compressedLenWithCompressionMap(dns *Msg, compression map[string]int) int {

--- a/msg.go
+++ b/msg.go
@@ -672,11 +672,12 @@ func (dns *Msg) PackBuffer(buf []byte) (msg []byte, err error) {
 	if dns.Compress {
 		compression = make(map[string]int) // Compression pointer mappings.
 	}
-	return dns.packBufferWithCompressionMap(buf, compression)
+
+	return dns.packBufferWithCompressionMap(buf, compression, dns.Compress)
 }
 
 // packBufferWithCompressionMap packs a Msg, using the given buffer buf.
-func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]int) (msg []byte, err error) {
+func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]int, compress bool) (msg []byte, err error) {
 	// We use a similar function in tsig.go's stripTsig.
 
 	var dh Header
@@ -742,30 +743,30 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression map[string]
 
 	// Pack it in: header and then the pieces.
 	off := 0
-	off, err = dh.pack(msg, off, compression, dns.Compress)
+	off, err = dh.pack(msg, off, compression, compress)
 	if err != nil {
 		return nil, err
 	}
 	for i := 0; i < len(question); i++ {
-		off, err = question[i].pack(msg, off, compression, dns.Compress)
+		off, err = question[i].pack(msg, off, compression, compress)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for i := 0; i < len(answer); i++ {
-		off, err = PackRR(answer[i], msg, off, compression, dns.Compress)
+		off, err = PackRR(answer[i], msg, off, compression, compress)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for i := 0; i < len(ns); i++ {
-		off, err = PackRR(ns[i], msg, off, compression, dns.Compress)
+		off, err = PackRR(ns[i], msg, off, compression, compress)
 		if err != nil {
 			return nil, err
 		}
 	}
 	for i := 0; i < len(extra); i++ {
-		off, err = PackRR(extra[i], msg, off, compression, dns.Compress)
+		off, err = PackRR(extra[i], msg, off, compression, compress)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This avoids creating the compression map, and associated garbage, when the `Msg` only has one question.

~This needs to wait on both #821 & #822, and will probably need to be rebased~.

```
$ benchstat {old,new}.bench
name                       old time/op    new time/op    delta
MsgLength-12                  335ns ± 3%     324ns ± 0%    -3.53%  (p=0.000 n=10+9)
MsgLengthNoCompression-12    9.46ns ± 0%    9.46ns ± 1%      ~     (p=0.623 n=9+9)
MsgLengthPack-12             1.91µs ±31%    2.14µs ±16%      ~     (p=0.219 n=10+9)
MsgLengthOnlyQuestion-12      165ns ± 2%       5ns ± 3%   -96.74%  (p=0.000 n=10+10)
PackMsg-12                   1.59µs ±20%    1.56µs ± 6%      ~     (p=0.905 n=10+9)
PackMsgOnlyQuestion-12        757ns ±33%     232ns ± 4%   -69.28%  (p=0.000 n=10+10)

name                       old alloc/op   new alloc/op   delta
MsgLength-12                  32.0B ± 0%     32.0B ± 0%      ~     (all equal)
MsgLengthNoCompression-12     0.00B          0.00B           ~     (all equal)
MsgLengthPack-12               896B ± 0%      896B ± 0%      ~     (all equal)
MsgLengthOnlyQuestion-12      32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
PackMsg-12                     576B ± 0%      576B ± 0%      ~     (all equal)
PackMsgOnlyQuestion-12         320B ± 0%       64B ± 0%   -80.00%  (p=0.000 n=10+10)

name                       old allocs/op  new allocs/op  delta
MsgLength-12                   1.00 ± 0%      1.00 ± 0%      ~     (all equal)
MsgLengthNoCompression-12      0.00           0.00           ~     (all equal)
MsgLengthPack-12               8.00 ± 0%      8.00 ± 0%      ~     (all equal)
MsgLengthOnlyQuestion-12       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
PackMsg-12                     7.00 ± 0%      7.00 ± 0%      ~     (all equal)
PackMsgOnlyQuestion-12         3.00 ± 0%      1.00 ± 0%   -66.67%  (p=0.000 n=10+10)
```

Related #821 & #822.
Updates #709.