### PR TITLE
Use strings.EqualFold rather than strings.ToLower

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -401,7 +401,7 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 	if rr.Algorithm != k.Algorithm {
 		return ErrKey
 	}
-	if strings.ToLower(rr.SignerName) != strings.ToLower(k.Hdr.Name) {
+	if !strings.EqualFold(rr.SignerName, k.Hdr.Name) {
 		return ErrKey
 	}
 	if k.Protocol != 3 {

--- a/sig0.go
+++ b/sig0.go
@@ -167,7 +167,7 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 	}
 	// If key has come from the DNS name compression might
 	// have mangled the case of the name
-	if strings.ToLower(signername) != strings.ToLower(k.Header().Name) {
+	if !strings.EqualFold(signername, k.Header().Name) {
 		return &Error{err: "signer name doesn't match key name"}
 	}
 	sigend := offset


### PR DESCRIPTION
`strings.ToLower` may allocate and will do more work than `strings.EqualFold`.