### PR TITLE
Use FQDN for question in TestCompressLength

### DIFF
--- a/length_test.go
+++ b/length_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestCompressLength(t *testing.T) {
 	m := new(Msg)
-	m.SetQuestion("miek.nl", TypeMX)
+	m.SetQuestion("miek.nl.", TypeMX)
 	ul := m.Len()
 	m.Compress = true
 	if ul != m.Len() {


### PR DESCRIPTION
This was a bug.