### PR TITLE
Fix "too many compression points" for valid message

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -33,8 +33,8 @@ const (
 	//
 	// It is possible to construct a valid message that has more compression pointers
 	// than this, and still doesn't loop, by pointing to a previous pointer. This is
-	// not something a well written implementation should ever do, so we ignore that
-	// possibility.
+	// not something a well written implementation should ever do, so we leave them
+	// to trip the maximum compression pointer check.
 	maxCompressionPointers = (maxDomainNameWireOctets+1)/2 - 2
 )
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -257,3 +257,23 @@ func TestPackDomainNameNSECTypeBitmap(t *testing.T) {
 		t.Logf("got:      %v", msg2.Answer[1])
 	}
 }
+
+func TestPackUnpackManyCompressionPointers(t *testing.T) {
+	m := new(Msg)
+	m.Compress = true
+	m.SetQuestion("example.org.", TypeNS)
+
+	for domain := "a."; len(domain) < maxDomainNameWireOctets; domain += "a." {
+		m.Answer = append(m.Answer, &NS{Hdr: RR_Header{Name: domain, Rrtype: TypeNS, Class: ClassINET}, Ns: "example.org."})
+
+		b, err := m.Pack()
+		if err != nil {
+			t.Fatalf("Pack failed for %q and %d records with: %v", domain, len(m.Answer), err)
+		}
+
+		var m2 Msg
+		if err := m2.Unpack(b); err != nil {
+			t.Fatalf("Unpack failed for %q and %d records with: %v", domain, len(m.Answer), err)
+		}
+	}
+}


### PR DESCRIPTION
The comment should explain my rational for sizing the constant. The added test case now passes.

Fixes #834 