### PR TITLE
Bail early from UnpackDomainName when name is too long

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -371,7 +371,7 @@ Loop:
 			if off+c > lenmsg {
 				return "", lenmsg, ErrBuf
 			}
-			budget -= c + 1 // +1 for the trailing period
+			budget -= c + 1 // +1 for the label separator
 			if budget <= 0 {
 				return "", lenmsg, ErrLongDomain
 			}

--- a/msg.go
+++ b/msg.go
@@ -423,11 +423,11 @@ Loop:
 	if ptr == 0 {
 		off1 = off
 	}
-	if len(s) == 0 {
-		s = []byte(".")
-	}
 	if budget <= 0 || budget > maxDomainNameWireOctets { // handle overflow
 		return "", lenmsg, ErrLongDomain
+	}
+	if len(s) == 0 {
+		return ".", off1, nil
 	}
 	return string(s), off1, nil
 }

--- a/msg.go
+++ b/msg.go
@@ -426,9 +426,6 @@ Loop:
 	if ptr == 0 {
 		off1 = off
 	}
-	if budget <= 0 {
-		return "", lenmsg, ErrLongDomain
-	}
 	if len(s) == 0 {
 		return ".", off1, nil
 	}

--- a/msg.go
+++ b/msg.go
@@ -372,6 +372,9 @@ Loop:
 				return "", lenmsg, ErrBuf
 			}
 			budget -= c + 1 // +1 for the trailing period
+			if budget <= 0 {
+				return "", lenmsg, ErrLongDomain
+			}
 			for j := off; j < off+c; j++ {
 				switch b := msg[j]; b {
 				case '.', '(', ')', ';', ' ', '@':
@@ -423,7 +426,7 @@ Loop:
 	if ptr == 0 {
 		off1 = off
 	}
-	if budget <= 0 || budget > maxDomainNameWireOctets { // handle overflow
+	if budget <= 0 {
 		return "", lenmsg, ErrLongDomain
 	}
 	if len(s) == 0 {

--- a/msg.go
+++ b/msg.go
@@ -347,7 +347,11 @@ End:
 // In theory, the pointers are only allowed to jump backward.
 // We let them jump anywhere and stop jumping after a while.
 
-// UnpackDomainName unpacks a domain name into a string.
+// UnpackDomainName unpacks a domain name into a string. It returns
+// the name, the new offset into msg and any error that occurred.
+//
+// When an error is encountered, the unpacked name will be discarded
+// and len(msg) will be returned as the offset.
 func UnpackDomainName(msg []byte, off int) (string, int, error) {
 	s := make([]byte, 0, 64)
 	off1 := 0

--- a/msg.go
+++ b/msg.go
@@ -427,8 +427,7 @@ Loop:
 		s = []byte(".")
 	}
 	if budget <= 0 || budget > maxDomainNameWireOctets { // handle overflow
-		// error if the name is too long, but don't throw it away
-		return string(s), lenmsg, ErrLongDomain
+		return "", lenmsg, ErrLongDomain
 	}
 	return string(s), off1, nil
 }

--- a/msg_test.go
+++ b/msg_test.go
@@ -148,7 +148,6 @@ func TestUnpackDomainName(t *testing.T) {
 			"\x03foo" + "\x05\x03com\x00" + "\x07example" + "\xC0\x05",
 			"foo.\\003com\\000.example.com.",
 			""},
-
 		{"too long domain",
 			string(54) + "x" + strings.Replace(longDomain, ".", string(49), -1) + "\x00",
 			"",
@@ -193,10 +192,11 @@ func TestUnpackDomainName(t *testing.T) {
 			""},
 		{"truncated name", "\x07example\x03", "", "dns: buffer size too small"},
 		{"non-absolute name", "\x07example\x03com", "", "dns: buffer size too small"},
-		{"compression pointer cycle",
+		{"compression pointer cycle (too many)", "\xC0\x00", "", "dns: too many compression pointers"},
+		{"compression pointer cycle (too long)",
 			"\x03foo" + "\x03bar" + "\x07example" + "\xC0\x04",
 			"",
-			"dns: too many compression pointers"},
+			ErrLongDomain.Error()},
 		{"reserved compression pointer 0b10", "\x07example\x80", "", "dns: bad rdata"},
 		{"reserved compression pointer 0b01", "\x07example\x40", "", "dns: bad rdata"},
 	}

--- a/msg_test.go
+++ b/msg_test.go
@@ -151,7 +151,7 @@ func TestUnpackDomainName(t *testing.T) {
 
 		{"too long domain",
 			string(54) + "x" + strings.Replace(longDomain, ".", string(49), -1) + "\x00",
-			"x" + longDomain + ".",
+			"",
 			ErrLongDomain.Error()},
 		{"too long by pointer",
 			// a matryoshka doll name to get over 255 octets after expansion via internal pointers


### PR DESCRIPTION
This PR drastically reduces the amount of garbage created in `UnpackDomainName` for certain malicious names.

The wire formatted name
```go
"\x3Faaabbbcccdddeeefffggghhhiiijjjkkklllmmmnnnooopppqqqrrrssstttuuu\xC0\x00"
```
would previously generate 1936B of garbage before #835, and 36112B of garbage since #835, before returning the `"too many compression pointers"` error, while after this PR it will generate just 384B of garbage before returning the error.

Related #835
Fixes #836 
