### PR TITLE
Put escaped names into compression map

### DIFF
--- a/length_test.go
+++ b/length_test.go
@@ -387,7 +387,7 @@ func TestMsgCompressLengthEscapingMatch(t *testing.T) {
 	// Although slightly non-optimal, "example.org." and "ex\\097mple.org."
 	// are not considered equal in the compression map, even though \097 is
 	// a valid escaping of a. This test ensures that the Len code and the
-	// Pack don't disagree on this.
+	// Pack code don't disagree on this.
 
 	msg := new(Msg)
 	msg.Compress = true

--- a/length_test.go
+++ b/length_test.go
@@ -382,3 +382,26 @@ func TestMsgCompressLengthLargeRecordsAllValues(t *testing.T) {
 		}
 	}
 }
+
+func TestMsgCompressLengthEscapingMatch(t *testing.T) {
+	// Although slightly non-optimal, "example.org." and "ex\\097mple.org."
+	// are not considered equal in the compression map, even though \097 is
+	// a valid escaping of a. This test ensures that the Len code and the
+	// Pack don't disagree on this.
+
+	msg := new(Msg)
+	msg.Compress = true
+	msg.SetQuestion("www.example.org.", TypeA)
+	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: "ex\\097mple.org.", Rrtype: TypeNS, Class: ClassINET}, Ns: "ns.example.org."})
+
+	predicted := msg.Len()
+	buf, err := msg.Pack()
+	if err != nil {
+		t.Error(err)
+	}
+	// Len doesn't account for escaping when calculating the length *yet* so
+	// we're off by three here. This will be fixed in a follow up change.
+	if predicted != len(buf)+3 {
+		t.Fatalf("predicted compressed length is wrong: predicted %d, actual %d", predicted, len(buf))
+	}
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -214,8 +214,15 @@ func TestUnpackDomainName(t *testing.T) {
 }
 
 func TestPackDomainNameCompressionMap(t *testing.T) {
-	msg := make([]byte, 256)
+	expected := map[string]struct{}{
+		`www.this.is.\131an.example.org.`: struct{}{},
+		`is.\131an.example.org.`:          struct{}{},
+		"\x83an.example.org.":             struct{}{},
+		`example.org.`:                    struct{}{},
+		`org.`:                            struct{}{},
+	}
 
+	msg := make([]byte, 256)
 	for _, compress := range []bool{true, false} {
 		compression := make(map[string]int)
 
@@ -224,16 +231,8 @@ func TestPackDomainNameCompressionMap(t *testing.T) {
 			t.Fatalf("PackDomainName failed: %v", err)
 		}
 
-		for _, dname := range []string{
-			`www.this.is.\131an.example.org.`,
-			`is.\131an.example.org.`,
-			"\x83an.example.org.",
-			`example.org.`,
-			`org.`,
-		} {
-			if _, ok := compression[dname]; !ok {
-				t.Errorf("expected to find %q in compression map", dname)
-			}
+		if !compressionMapsEqual(expected, compression) {
+			t.Errorf("expected compression maps to be equal; expected %v, got %v", expected, compression)
 		}
 	}
 }

--- a/msg_test.go
+++ b/msg_test.go
@@ -215,11 +215,11 @@ func TestUnpackDomainName(t *testing.T) {
 
 func TestPackDomainNameCompressionMap(t *testing.T) {
 	expected := map[string]struct{}{
-		`www.this.is.\131an.example.org.`: struct{}{},
-		`is.\131an.example.org.`:          struct{}{},
-		"\x83an.example.org.":             struct{}{},
-		`example.org.`:                    struct{}{},
-		`org.`:                            struct{}{},
+		`www\.this.is.\131an.example.org.`: struct{}{},
+		`is.\131an.example.org.`:           struct{}{},
+		`\131an.example.org.`:              struct{}{},
+		`example.org.`:                     struct{}{},
+		`org.`:                             struct{}{},
 	}
 
 	msg := make([]byte, 256)


### PR DESCRIPTION
After this PR, the escaped form of the name will be inserted into the compression map rather than the partially unescaped form. This is slightly non-optimal as certain names won't compress even though they're identical, this could be improved in future, but it's not a bug as compression is purely optional.

This only partially addresses #841, the rest of it will be fixed in a follow up PR once #833 has been merged.

Updates #841