### PR TITLE
Reduce memory consumption in HashName

### DIFF
--- a/nsecx.go
+++ b/nsecx.go
@@ -2,13 +2,14 @@ package dns
 
 import (
 	"crypto/sha1"
+	"encoding/hex"
 	"hash"
 	"strings"
 )
 
 // HashName hashes a string (label) according to RFC 5155. It returns the hashed string in uppercase.
 func HashName(label string, ha uint8, iter uint16, salt string) string {
-	wireSalt := make([]byte, DefaultMsgSize)
+	wireSalt := make([]byte, hex.DecodedLen(len(salt)))
 	n, err := packStringHex(salt, wireSalt, 0)
 	if err != nil {
 		return ""

--- a/nsecx.go
+++ b/nsecx.go
@@ -6,16 +6,10 @@ import (
 	"strings"
 )
 
-type saltWireFmt struct {
-	Salt string `dns:"size-hex"`
-}
-
 // HashName hashes a string (label) according to RFC 5155. It returns the hashed string in uppercase.
 func HashName(label string, ha uint8, iter uint16, salt string) string {
-	saltwire := new(saltWireFmt)
-	saltwire.Salt = salt
 	wire := make([]byte, DefaultMsgSize)
-	n, err := packSaltWire(saltwire, wire)
+	n, err := packStringHex(salt, wire, 0)
 	if err != nil {
 		return ""
 	}
@@ -97,12 +91,4 @@ func (rr *NSEC3) Match(name string) bool {
 		return true
 	}
 	return false
-}
-
-func packSaltWire(sw *saltWireFmt, msg []byte) (int, error) {
-	off, err := packStringHex(sw.Salt, msg, 0)
-	if err != nil {
-		return off, err
-	}
-	return off, nil
 }

--- a/nsecx.go
+++ b/nsecx.go
@@ -8,12 +8,12 @@ import (
 
 // HashName hashes a string (label) according to RFC 5155. It returns the hashed string in uppercase.
 func HashName(label string, ha uint8, iter uint16, salt string) string {
-	wire := make([]byte, DefaultMsgSize)
-	n, err := packStringHex(salt, wire, 0)
+	wireSalt := make([]byte, DefaultMsgSize)
+	n, err := packStringHex(salt, wireSalt, 0)
 	if err != nil {
 		return ""
 	}
-	wire = wire[:n]
+	wireSalt = wireSalt[:n]
 	name := make([]byte, 255)
 	off, err := PackDomainName(strings.ToLower(label), name, 0, nil, false)
 	if err != nil {
@@ -30,13 +30,13 @@ func HashName(label string, ha uint8, iter uint16, salt string) string {
 
 	// k = 0
 	s.Write(name)
-	s.Write(wire)
+	s.Write(wireSalt)
 	nsec3 := s.Sum(nil)
 	// k > 0
 	for k := uint16(0); k < iter; k++ {
 		s.Reset()
 		s.Write(nsec3)
-		s.Write(wire)
+		s.Write(wireSalt)
 		nsec3 = s.Sum(nsec3[:0])
 	}
 	return toBase32(nsec3)

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -1,6 +1,9 @@
 package dns
 
-import "testing"
+import (
+	"strconv"
+	"testing"
+)
 
 func TestPackNsec3(t *testing.T) {
 	nsec3 := HashName("dnsex.nl.", SHA1, 0, "DEAD")
@@ -149,5 +152,19 @@ func TestNsec3EmptySalt(t *testing.T) {
 
 	if !rr.(*NSEC3).Match("com.") {
 		t.Fatalf("expected record to match com. label")
+	}
+}
+
+func BenchmarkHashName(b *testing.B) {
+	for _, iter := range []uint16{
+		150, 2500, 5000, 10000, ^uint16(0),
+	} {
+		b.Run(strconv.Itoa(int(iter)), func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				if HashName("some.example.org.", SHA1, iter, "deadbeef") == "" {
+					b.Fatalf("HashName failed")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
This reduces the memory consumption of `HashName` and makes it slightly cleaner.

```
name               old time/op    new time/op    delta
HashName/150-12      21.2µs ± 2%    20.4µs ± 1%   -3.72%  (p=0.000 n=9+10)
HashName/2500-12      333µs ± 1%     332µs ± 1%     ~     (p=0.165 n=10+10)
HashName/5000-12      663µs ± 1%     668µs ± 2%     ~     (p=0.123 n=10+10)
HashName/10000-12    1.32ms ± 1%    1.33ms ± 1%     ~     (p=0.190 n=9+9)
HashName/65535-12    8.63ms ± 1%    8.61ms ± 1%     ~     (p=0.243 n=10+9)

name               old alloc/op   new alloc/op   delta
HashName/150-12      4.57kB ± 0%    0.48kB ± 0%  -89.49%  (p=0.000 n=10+10)
HashName/2500-12     4.57kB ± 0%    0.48kB ± 0%  -89.49%  (p=0.000 n=10+10)
HashName/5000-12     4.57kB ± 0%    0.48kB ± 0%  -89.49%  (p=0.000 n=10+10)
HashName/10000-12    4.57kB ± 0%    0.48kB ± 0%  -89.49%  (p=0.000 n=10+10)
HashName/65535-12    4.57kB ± 0%    0.48kB ± 0%  -89.49%  (p=0.000 n=10+10)

name               old allocs/op  new allocs/op  delta
HashName/150-12        7.00 ± 0%      7.00 ± 0%     ~     (all equal)
HashName/2500-12       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
HashName/5000-12       7.00 ± 0%      7.00 ± 0%     ~     (all equal)
HashName/10000-12      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
HashName/65535-12      7.00 ± 0%      7.00 ± 0%     ~     (all equal)
```