### PR TITLE
Reduce allocations in UnpackDomainName by better sizing slice

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -128,6 +128,36 @@ func BenchmarkUnpackDomainNameUnprintable(b *testing.B) {
 	}
 }
 
+func BenchmarkUnpackDomainNameLongest(b *testing.B) {
+	buf := make([]byte, len(longestDomain)+1)
+	n, err := PackDomainName(longestDomain, buf, 0, nil, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if n != maxDomainNameWireOctets {
+		b.Fatalf("name wrong size in wire format, expected %d, got %d", maxDomainNameWireOctets, n)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = UnpackDomainName(buf, 0)
+	}
+}
+
+func BenchmarkUnpackDomainNameLongestEscaped(b *testing.B) {
+	buf := make([]byte, len(longestUnprintableDomain)+1)
+	n, err := PackDomainName(longestUnprintableDomain, buf, 0, nil, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if n != maxDomainNameWireOctets {
+		b.Fatalf("name wrong size in wire format, expected %d, got %d", maxDomainNameWireOctets, n)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = UnpackDomainName(buf, 0)
+	}
+}
+
 func BenchmarkCopy(b *testing.B) {
 	b.ReportAllocs()
 	m := new(Msg)

--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -143,7 +143,7 @@ func BenchmarkUnpackDomainNameLongest(b *testing.B) {
 	}
 }
 
-func BenchmarkUnpackDomainNameLongestEscaped(b *testing.B) {
+func BenchmarkUnpackDomainNameLongestUnprintable(b *testing.B) {
 	buf := make([]byte, len(longestUnprintableDomain)+1)
 	n, err := PackDomainName(longestUnprintableDomain, buf, 0, nil, false)
 	if err != nil {

--- a/msg.go
+++ b/msg.go
@@ -36,6 +36,9 @@ const (
 	// not something a well written implementation should ever do, so we leave them
 	// to trip the maximum compression pointer check.
 	maxCompressionPointers = (maxDomainNameWireOctets+1)/2 - 2
+
+	// This is the maximum length of a domain name in presentation format.
+	maxDomainNamePresentationLength = 61*4 + 1 + 63*4 + 1 + 63*4 + 1 + 63*4 + 1
 )
 
 // Errors defined in this package.
@@ -372,7 +375,7 @@ func isRootLabel(s string, bs []byte, off, end int) bool {
 // When an error is encountered, the unpacked name will be discarded
 // and len(msg) will be returned as the offset.
 func UnpackDomainName(msg []byte, off int) (string, int, error) {
-	s := make([]byte, 0, 64)
+	s := make([]byte, 0, maxDomainNamePresentationLength)
 	off1 := 0
 	lenmsg := len(msg)
 	budget := maxDomainNameWireOctets

--- a/msg.go
+++ b/msg.go
@@ -37,7 +37,12 @@ const (
 	// to trip the maximum compression pointer check.
 	maxCompressionPointers = (maxDomainNameWireOctets+1)/2 - 2
 
-	// This is the maximum length of a domain name in presentation format.
+	// This is the maximum length of a domain name in presentation format. The
+	// maximum wire length of a domain name is 255 octets (see above), with the
+	// maximum label length being 63. The wire format requires one extra byte over
+	// the presentation format, reducing the number of octets by 1. Each label in
+	// the name will be separated by a single period, with each octet in the label
+	// expanding to at most 4 bytes (\DDD).
 	maxDomainNamePresentationLength = 61*4 + 1 + 63*4 + 1 + 63*4 + 1 + 63*4 + 1
 )
 

--- a/msg.go
+++ b/msg.go
@@ -42,7 +42,9 @@ const (
 	// maximum label length being 63. The wire format requires one extra byte over
 	// the presentation format, reducing the number of octets by 1. Each label in
 	// the name will be separated by a single period, with each octet in the label
-	// expanding to at most 4 bytes (\DDD).
+	// expanding to at most 4 bytes (\DDD). If all other labels are of the maximum
+	// length, then the final label can only be 61 octets long to not exceed the
+	// maximum allowed wire length.
 	maxDomainNamePresentationLength = 61*4 + 1 + 63*4 + 1 + 63*4 + 1 + 63*4 + 1
 )
 

--- a/msg_test.go
+++ b/msg_test.go
@@ -13,6 +13,7 @@ const maxPrintableLabel = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0
 var (
 	longDomain = maxPrintableLabel[:53] + strings.TrimSuffix(
 		strings.Join([]string{".", ".", ".", ".", "."}, maxPrintableLabel[:49]), ".")
+
 	reChar              = regexp.MustCompile(`.`)
 	i                   = -1
 	maxUnprintableLabel = reChar.ReplaceAllStringFunc(maxPrintableLabel, func(ch string) string {
@@ -21,6 +22,10 @@ var (
 		}
 		return fmt.Sprintf("\\%03d", i)
 	})
+
+	// These are the longest possible domain names in presentation format.
+	longestDomain            = maxPrintableLabel[:61] + strings.Join([]string{".", ".", ".", "."}, maxPrintableLabel)
+	longestUnprintableDomain = maxUnprintableLabel[:61*4] + strings.Join([]string{".", ".", ".", "."}, maxUnprintableLabel)
 )
 
 func TestPackNoSideEffect(t *testing.T) {


### PR DESCRIPTION
This simple change greatly improves the performance and memory consumption of `UnpackDomainName`. It's perfectly safe to size `s` this large as it never escapes and will be stack allocated.

After this PR, `UnpackDomainName` will never be the source of memory garbage.

In terms of number of allocations and allocated memory, this is absolutely the best possible results, *i.e.* `UnpackDomainName` can never be more efficient with regards to memory usage.

```
name                                   old time/op    new time/op    delta
UnpackDomainName-12                       169ns ±13%     167ns ±19%     ~     (p=0.955 n=10+10)
UnpackDomainNameUnprintable-12            150ns ±13%     160ns ± 6%   +6.61%  (p=0.015 n=10+10)
UnpackDomainNameLongest-12               1.45µs ±30%    0.74µs ± 7%  -48.74%  (p=0.000 n=10+9)
UnpackDomainNameLongestUnprintable-12    6.05µs ±16%    3.21µs ± 7%  -47.00%  (p=0.000 n=10+10)

name                                   old alloc/op   new alloc/op   delta
UnpackDomainName-12                       64.0B ± 0%     64.0B ± 0%     ~     (all equal)
UnpackDomainNameUnprintable-12            48.0B ± 0%     48.0B ± 0%     ~     (all equal)
UnpackDomainNameLongest-12                 640B ± 0%      256B ± 0%  -60.00%  (p=0.000 n=10+10)
UnpackDomainNameLongestUnprintable-12    2.94kB ± 0%    1.02kB ± 0%  -65.22%  (p=0.000 n=10+10)

name                                   old allocs/op  new allocs/op  delta
UnpackDomainName-12                        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
UnpackDomainNameUnprintable-12             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
UnpackDomainNameLongest-12                 3.00 ± 0%      1.00 ± 0%  -66.67%  (p=0.000 n=10+10)
UnpackDomainNameLongestUnprintable-12      5.00 ± 0%      1.00 ± 0%  -80.00%  (p=0.000 n=10+10)
```

/cc @semihalev (for https://github.com/miekg/dns/issues/836#issuecomment-442413416 & https://github.com/miekg/dns/pull/839#discussion_r237073104)