### PR TITLE
Simplify unprintable handling in UnpackDomainName

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -405,7 +405,7 @@ Loop:
 				case '"', '\\':
 					s = append(s, '\\', b)
 				default:
-					if b < 32 || b >= 127 { // unprintable, use \DDD
+					if b < ' ' || b > '~' { // unprintable, use \DDD
 						var buf [3]byte
 						bufs := strconv.AppendInt(buf[:0], int64(b), 10)
 						s = append(s, '\\', '0', '0', '0')

--- a/msg.go
+++ b/msg.go
@@ -408,11 +408,8 @@ Loop:
 					if b < 32 || b >= 127 { // unprintable, use \DDD
 						var buf [3]byte
 						bufs := strconv.AppendInt(buf[:0], int64(b), 10)
-						s = append(s, '\\')
-						for i := len(bufs); i < 3; i++ {
-							s = append(s, '0')
-						}
-						s = append(s, bufs...)
+						s = append(s, '\\', '0', '0', '0')
+						copy(s[len(s)-len(bufs):], bufs)
 					} else {
 						s = append(s, b)
 					}


### PR DESCRIPTION
Simplify unprintable handling in `UnpackDomainName`.

These benchmarks were taking after #844 and show a modest improvement:
```
name                                   old time/op    new time/op    delta
UnpackDomainName-12                       122ns ± 4%     125ns ± 4%    ~     (p=0.052 n=10+10)
UnpackDomainNameUnprintable-12            149ns ± 1%     138ns ± 4%  -7.51%  (p=0.000 n=10+10)
UnpackDomainNameLongest-12                552ns ± 2%     550ns ± 5%    ~     (p=0.403 n=10+10)
UnpackDomainNameLongestUnprintable-12    2.96µs ± 1%    2.70µs ± 1%  -8.74%  (p=0.000 n=10+10)

name                                   old alloc/op   new alloc/op   delta
UnpackDomainName-12                       64.0B ± 0%     64.0B ± 0%    ~     (all equal)
UnpackDomainNameUnprintable-12            48.0B ± 0%     48.0B ± 0%    ~     (all equal)
UnpackDomainNameLongest-12                 256B ± 0%      256B ± 0%    ~     (all equal)
UnpackDomainNameLongestUnprintable-12    1.02kB ± 0%    1.02kB ± 0%    ~     (all equal)

name                                   old allocs/op  new allocs/op  delta
UnpackDomainName-12                        1.00 ± 0%      1.00 ± 0%    ~     (all equal)
UnpackDomainNameUnprintable-12             1.00 ± 0%      1.00 ± 0%    ~     (all equal)
UnpackDomainNameLongest-12                 1.00 ± 0%      1.00 ± 0%    ~     (all equal)
UnpackDomainNameLongestUnprintable-12      1.00 ± 0%      1.00 ± 0%    ~     (all equal)
```