### PR TITLE
Use a table lookup for escaping unprintable bytes

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -406,10 +406,7 @@ Loop:
 					s = append(s, '\\', b)
 				default:
 					if b < ' ' || b > '~' { // unprintable, use \DDD
-						var buf [3]byte
-						bufs := strconv.AppendInt(buf[:0], int64(b), 10)
-						s = append(s, '\\', '0', '0', '0')
-						copy(s[len(s)-len(bufs):], bufs)
+						s = append(s, escapeByte(b)...)
 					} else {
 						s = append(s, b)
 					}

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -275,7 +275,7 @@ func unpackString(msg []byte, off int) (string, int, error) {
 			s.WriteByte('\\')
 			s.WriteByte(b)
 		case b < ' ' || b > '~': // unprintable
-			writeEscapedByte(&s, b)
+			s.WriteString(escapeByte(b))
 		default:
 			s.WriteByte(b)
 		}

--- a/types.go
+++ b/types.go
@@ -460,7 +460,7 @@ func sprintTxtOctet(s string) string {
 		case b == '.':
 			dst.WriteByte('.')
 		case b < ' ' || b > '~':
-			writeEscapedByte(&dst, b)
+			dst.WriteString(escapeByte(b))
 		default:
 			dst.WriteByte(b)
 		}
@@ -508,20 +508,44 @@ func writeTXTStringByte(s *strings.Builder, b byte) {
 		s.WriteByte('\\')
 		s.WriteByte(b)
 	case b < ' ' || b > '~':
-		writeEscapedByte(s, b)
+		s.WriteString(escapeByte(b))
 	default:
 		s.WriteByte(b)
 	}
 }
 
-func writeEscapedByte(s *strings.Builder, b byte) {
-	var buf [3]byte
-	bufs := strconv.AppendInt(buf[:0], int64(b), 10)
-	s.WriteByte('\\')
-	for i := len(bufs); i < 3; i++ {
-		s.WriteByte('0')
+const (
+	escapedByteSmall = "" +
+		`\000\001\002\003\004\005\006\007\008\009` +
+		`\010\011\012\013\014\015\016\017\018\019` +
+		`\020\021\022\023\024\025\026\027\028\029` +
+		`\030\031`
+	escapedByteLarge = `\127\128\129` +
+		`\130\131\132\133\134\135\136\137\138\139` +
+		`\140\141\142\143\144\145\146\147\148\149` +
+		`\150\151\152\153\154\155\156\157\158\159` +
+		`\160\161\162\163\164\165\166\167\168\169` +
+		`\170\171\172\173\174\175\176\177\178\179` +
+		`\180\181\182\183\184\185\186\187\188\189` +
+		`\190\191\192\193\194\195\196\197\198\199` +
+		`\200\201\202\203\204\205\206\207\208\209` +
+		`\210\211\212\213\214\215\216\217\218\219` +
+		`\220\221\222\223\224\225\226\227\228\229` +
+		`\230\231\232\233\234\235\236\237\238\239` +
+		`\240\241\242\243\244\245\246\247\248\249` +
+		`\250\251\252\253\254\255`
+)
+
+// escapeByte returns the \DDD escaping of b which must
+// satisfy b < ' ' || b > '~'.
+func escapeByte(b byte) string {
+	if b < ' ' {
+		return escapedByteSmall[b*4 : b*4+4]
 	}
-	s.Write(bufs)
+
+	b -= '~' + 1
+	// The cast here is needed as b*4 may overflow byte.
+	return escapedByteLarge[int(b)*4 : int(b)*4+4]
 }
 
 func nextByte(s string, offset int) (byte, int) {


### PR DESCRIPTION
This PR replaces the `strconv.AppendInt` based unprintable octet escaping with pre-calculated table-lookups. This is also much simpler. It also eliminates the duplication between `writeEscapedByte` and `UnpackDomainName`.

I know I just landed #845, but I didn't realise just what an improvement could be had. `strconv.AppendInt` has a table-lookup optimisation for numbers `< 100`, which is all `UnpackDomainNameLongestUnprintable` has, so for names that have unprintable octets `> 126` this should be an even greater performance improvement.

These benchmarks were taken after #844 and show a very big improvement (memory is the same):
```
name                                   old time/op    new time/op    delta
UnpackDomainName-12                       125ns ± 5%     126ns ± 7%     ~     (p=0.807 n=10+10)
UnpackDomainNameUnprintable-12            138ns ± 2%     102ns ± 5%  -26.24%  (p=0.000 n=10+10)
UnpackDomainNameLongest-12                576ns ± 5%     522ns ± 6%   -9.31%  (p=0.000 n=10+10)
UnpackDomainNameLongestUnprintable-12    2.70µs ± 2%    1.40µs ±10%  -48.09%  (p=0.000 n=10+10)
SprintName-12                             220ns ± 1%     180ns ± 1%  -18.04%  (p=0.000 n=10+10)
SprintTxtOctet-12                         183ns ± 5%     136ns ± 9%  -25.51%  (p=0.000 n=10+10)
SprintTxt-12                              245ns ± 1%     203ns ± 2%  -17.07%  (p=0.000 n=10+10)
```

**Updated**: Here are the benchmark numbers if `maxUnprintableLabel` uses unprintable characters `> 126` and takes the slower path in `strconv.AppendInt`, it shows even greater performance improvements (`UnpackDomainNameLongest` included for reference):
```
name                                   old time/op    new time/op    delta
UnpackDomainNameLongest-12                563ns ± 5%     533ns ± 6%   -5.29%  (p=0.005 n=10+10)
UnpackDomainNameLongestUnprintable-12    4.50µs ± 0%    1.58µs ± 7%  -64.82%  (p=0.000 n=8+10)
```