### PR TITLE
Stop compressing names in RT records

### DIFF
--- a/types.go
+++ b/types.go
@@ -353,7 +353,7 @@ func (rr *X25) String() string {
 type RT struct {
 	Hdr        RR_Header
 	Preference uint16
-	Host       string `dns:"domain-name"`
+	Host       string `dns:"domain-name"` // RFC 3597 prohibits compressing records not defined in RFC 1035.
 }
 
 func (rr *RT) String() string {

--- a/types.go
+++ b/types.go
@@ -353,7 +353,7 @@ func (rr *X25) String() string {
 type RT struct {
 	Hdr        RR_Header
 	Preference uint16
-	Host       string `dns:"cdomain-name"`
+	Host       string `dns:"domain-name"`
 }
 
 func (rr *RT) String() string {

--- a/zmsg.go
+++ b/zmsg.go
@@ -1070,7 +1070,7 @@ func (rr *RT) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Host, msg, off, compression, compress)
+	off, err = PackDomainName(rr.Host, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}

--- a/ztypes.go
+++ b/ztypes.go
@@ -525,7 +525,7 @@ func (rr *RRSIG) len(off int, compression map[string]struct{}) int {
 func (rr *RT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
-	l += domainNameLen(rr.Host, off+l, compression, true)
+	l += domainNameLen(rr.Host, off+l, compression, false)
 	return l
 }
 func (rr *SMIMEA) len(off int, compression map[string]struct{}) int {


### PR DESCRIPTION
Although [RFC 1183](https://tools.ietf.org/html/rfc1183#section-3.3) allows names in the RT record to be compressed with:
```
   The concrete encoding is identical to the MX RR.
```

But [RFC 3597](https://tools.ietf.org/html/rfc3597#section-4) specifically prohibits compressing names in any record not defined in [RFC 1035](https://tools.ietf.org/html/rfc1035#section-3.2).

**Note:** I had to modify the two generated files by hand as they weren't picking up my changes to types.go for some reason. There shouldn't be any changes running `go generate` later though.

Updates #522