### PR TITLE
Move compress=false out of packDataDomainNames into caller

### DIFF
--- a/msg_generate.go
+++ b/msg_generate.go
@@ -106,7 +106,7 @@ return off, err
 				case `dns:"nsec"`:
 					o("off, err = packDataNsec(rr.%s, msg, off)\n")
 				case `dns:"domain-name"`:
-					o("off, err = packDataDomainNames(rr.%s, msg, off, compression, compress)\n")
+					o("off, err = packDataDomainNames(rr.%s, msg, off, compression, false)\n")
 				default:
 					log.Fatalln(name, st.Field(i).Name(), st.Tag(i))
 				}

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -624,7 +624,7 @@ func unpackDataDomainNames(msg []byte, off, end int) ([]string, int, error) {
 func packDataDomainNames(names []string, msg []byte, off int, compression map[string]int, compress bool) (int, error) {
 	var err error
 	for j := 0; j < len(names); j++ {
-		off, err = PackDomainName(names[j], msg, off, compression, false && compress)
+		off, err = PackDomainName(names[j], msg, off, compression, compress)
 		if err != nil {
 			return len(msg), err
 		}

--- a/zmsg.go
+++ b/zmsg.go
@@ -438,7 +438,7 @@ func (rr *HIP) pack(msg []byte, off int, compression map[string]int, compress bo
 	if err != nil {
 		return off, err
 	}
-	off, err = packDataDomainNames(rr.RendezvousServers, msg, off, compression, compress)
+	off, err = packDataDomainNames(rr.RendezvousServers, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}


### PR DESCRIPTION
This PR makes `packDataDomainNames` more consistent with `PackDomainName` where it will only be called with `compress = true` for <code>\`dns:"cdomain-name"\`</code>. This change is purely cosmetic.