### PR TITLE
Fix compressed length calculations for escaped names

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -99,6 +99,15 @@ func BenchmarkMsgLengthOnlyQuestion(b *testing.B) {
 	}
 }
 
+func BenchmarkMsgLengthEscapedName(b *testing.B) {
+	msg := new(Msg)
+	msg.SetQuestion(`\1\2\3\4\5\6\7\8\9\0\1\2\3\4\5\6\7\8\9\0\1\2\3\4\5\6\7\8\9\0\1\2\3\4\5.\1\2\3\4\5\6\7\8.\1\2\3.`, TypeANY)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		msg.Len()
+	}
+}
+
 func BenchmarkPackDomainName(b *testing.B) {
 	name1 := "12345678901234567890123456789012345.12345678.123."
 	buf := make([]byte, len(name1)+1)

--- a/length_test.go
+++ b/length_test.go
@@ -461,7 +461,7 @@ func TestMsgLengthEscaped(t *testing.T) {
 func TestMsgCompressLengthEscaped(t *testing.T) {
 	msg := new(Msg)
 	msg.Compress = true
-	msg.SetQuestion(`www.example.org.`, TypeA)
+	msg.SetQuestion("www.example.org.", TypeA)
 	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: `\000\001\002.example.org.`, Rrtype: TypeNS, Class: ClassINET}, Ns: `ns.\e\x\a\m\p\l\e.org.`})
 	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: `www.\e\x\a\m\p\l\e.org.`, Rrtype: TypeNS, Class: ClassINET}, Ns: "ns.example.org."})
 

--- a/length_test.go
+++ b/length_test.go
@@ -462,7 +462,8 @@ func TestMsgCompressLengthEscaped(t *testing.T) {
 	msg := new(Msg)
 	msg.Compress = true
 	msg.SetQuestion(`www.example.org.`, TypeA)
-	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: `\000\001\002.example.org.`, Rrtype: TypeNS, Class: ClassINET}, Ns: "ns.example.org."})
+	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: `\000\001\002.example.org.`, Rrtype: TypeNS, Class: ClassINET}, Ns: `ns.\e\x\a\m\p\l\e.org.`})
+	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: `www.\e\x\a\m\p\l\e.org.`, Rrtype: TypeNS, Class: ClassINET}, Ns: "ns.example.org."})
 
 	predicted := msg.Len()
 	buf, err := msg.Pack()

--- a/length_test.go
+++ b/length_test.go
@@ -439,9 +439,37 @@ func TestMsgCompressLengthEscapingMatch(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// Len doesn't account for escaping when calculating the length *yet* so
-	// we're off by three here. This will be fixed in a follow up change.
-	if predicted != len(buf)+3 {
+	if predicted != len(buf) {
+		t.Fatalf("predicted compressed length is wrong: predicted %d, actual %d", predicted, len(buf))
+	}
+}
+
+func TestMsgLengthEscaped(t *testing.T) {
+	msg := new(Msg)
+	msg.SetQuestion(`\000\001\002.\003\004\005\006\007\008\009.\a\b\c.`, TypeA)
+
+	predicted := msg.Len()
+	buf, err := msg.Pack()
+	if err != nil {
+		t.Error(err)
+	}
+	if predicted != len(buf) {
+		t.Fatalf("predicted compressed length is wrong: predicted %d, actual %d", predicted, len(buf))
+	}
+}
+
+func TestMsgCompressLengthEscaped(t *testing.T) {
+	msg := new(Msg)
+	msg.Compress = true
+	msg.SetQuestion(`www.example.org.`, TypeA)
+	msg.Answer = append(msg.Answer, &NS{Hdr: RR_Header{Name: `\000\001\002.example.org.`, Rrtype: TypeNS, Class: ClassINET}, Ns: "ns.example.org."})
+
+	predicted := msg.Len()
+	buf, err := msg.Pack()
+	if err != nil {
+		t.Error(err)
+	}
+	if predicted != len(buf) {
 		t.Fatalf("predicted compressed length is wrong: predicted %d, actual %d", predicted, len(buf))
 	}
 }

--- a/msg.go
+++ b/msg.go
@@ -968,32 +968,27 @@ func domainNameLen(s string, off int, compression map[string]struct{}, compress 
 
 	escaped := strings.Contains(s, "\\")
 
-	nameLen := len(s) + 1
-	if escaped {
-		nameLen = escapedNameLen(s)
-	}
-
-	if compression == nil {
-		return nameLen
-	}
-
-	if compress || off < maxCompressionOffset {
+	if compression != nil && (compress || off < maxCompressionOffset) {
 		// compressionLenSearch will insert the entry into the compression
 		// map if it doesn't contain it.
 		if l, ok := compressionLenSearch(compression, s, off); ok && compress {
 			if escaped {
-				nameLen = escapedNameLen(s[:l]) - 1 + 2
-			} else {
-				nameLen = l + 2
+				return escapedNameLen(s[:l]) + 2
 			}
+
+			return l + 2
 		}
 	}
 
-	return nameLen
+	if escaped {
+		return escapedNameLen(s) + 1
+	}
+
+	return len(s) + 1
 }
 
 func escapedNameLen(s string) int {
-	nameLen := len(s) + 1
+	nameLen := len(s)
 	for i := 0; i < len(s); i++ {
 		if s[i] != '\\' {
 			continue

--- a/msg.go
+++ b/msg.go
@@ -966,8 +966,10 @@ func domainNameLen(s string, off int, compression map[string]struct{}, compress 
 		return 1
 	}
 
+	escaped := strings.Contains(s, "\\")
+
 	nameLen := len(s) + 1
-	if strings.Contains(s, "\\") {
+	if escaped {
 		nameLen = escapedNameLen(s)
 	}
 
@@ -979,9 +981,11 @@ func domainNameLen(s string, off int, compression map[string]struct{}, compress 
 		// compressionLenSearch will insert the entry into the compression
 		// map if it doesn't contain it.
 		if l, ok := compressionLenSearch(compression, s, off); ok && compress {
-			// nameLen = l + 2, but this doesn't mess up escapedNameLen
-			// above.
-			nameLen += l - len(s) + 1
+			if escaped {
+				nameLen = escapedNameLen(s[:l]) - 1 + 2
+			} else {
+				nameLen = l + 2
+			}
 		}
 	}
 


### PR DESCRIPTION
*Performance hit incoming.*

`Len` will now take escaping into account and return the correct length regardless of escaping.

These are the benchmarks:
```
name                       old time/op    new time/op    delta
MsgLength-12                  349ns ± 4%     387ns ± 2%   +10.92%  (p=0.000 n=9+9)
MsgLengthNoCompression-12    28.0ns ± 1%    63.3ns ± 2%  +125.91%  (p=0.000 n=10+10)
MsgLengthPack-12             1.10µs ± 8%    1.12µs ± 4%      ~     (p=0.138 n=10+10)
MsgLengthMassive-12          26.1µs ± 2%    27.3µs ± 6%    +4.85%  (p=0.000 n=9+10)
MsgLengthOnlyQuestion-12     10.0ns ± 3%    17.1ns ± 2%   +72.14%  (p=0.000 n=10+9)
MsgLengthEscapedName-12      9.25ns ± 1%   96.08ns ± 1%  +938.58%  (p=0.000 n=9+10)
PackMsg-12                    957ns ± 1%    1015ns ± 1%    +6.10%  (p=0.000 n=10+9)
PackMsgOnlyQuestion-12        173ns ± 2%     182ns ± 2%    +5.08%  (p=0.000 n=9+10)
```

Fixes #841