### PR TITLE
Reduce compression memory use with map[string]uint16

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -166,7 +166,7 @@ func (dns *Msg) IsEdns0() *OPT {
 // label fits in 63 characters, but there is no length check for the entire
 // string s. I.e.  a domain name longer than 255 characters is considered valid.
 func IsDomainName(s string) (labels int, ok bool) {
-	_, labels, err := packDomainName(s, nil, 0, nil, false)
+	_, labels, err := packDomainName(s, nil, 0, compressionMap{}, false)
 	return labels, err == nil
 }
 

--- a/dns.go
+++ b/dns.go
@@ -42,7 +42,7 @@ type RR interface {
 	len(off int, compression map[string]struct{}) int
 
 	// pack packs an RR into wire format.
-	pack([]byte, int, map[string]int, bool) (int, error)
+	pack([]byte, int, compressionMap, bool) (int, error)
 }
 
 // RR_Header is the header all DNS resource records share.

--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -277,6 +277,33 @@ func BenchmarkPackMsg(b *testing.B) {
 	}
 }
 
+func BenchmarkPackMsgMassive(b *testing.B) {
+	makeMsg := func(question string, ans, ns, e []RR) *Msg {
+		msg := new(Msg)
+		msg.SetQuestion(Fqdn(question), TypeANY)
+		msg.Answer = append(msg.Answer, ans...)
+		msg.Ns = append(msg.Ns, ns...)
+		msg.Extra = append(msg.Extra, e...)
+		msg.Compress = true
+		return msg
+	}
+	const name1 = "12345678901234567890123456789012345.12345678.123."
+	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
+	answer := []RR{rrMx, rrMx}
+	for i := 0; i < 128; i++ {
+		rrA := testRR(fmt.Sprintf("example%03d.something%03delse.org. 2311 IN A 127.0.0.1", i/32, i%32))
+		answer = append(answer, rrA)
+	}
+	answer = append(answer, rrMx, rrMx)
+	msg := makeMsg(name1, answer, nil, nil)
+	buf := make([]byte, 512)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = msg.PackBuffer(buf)
+	}
+}
+
 func BenchmarkPackMsgOnlyQuestion(b *testing.B) {
 	msg := new(Msg)
 	msg.SetQuestion(Fqdn("12345678901234567890123456789012345.12345678.123."), TypeANY)

--- a/length_test.go
+++ b/length_test.go
@@ -294,7 +294,7 @@ func TestCompareCompressionMapsForANY(t *testing.T) {
 		lenFake := msgLenWithCompressionMap(msg, compressionFake)
 
 		compressionReal := make(map[string]int)
-		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal, true)
+		buf, err := msg.packBufferWithCompressionMap(nil, compressionMap{ext: compressionReal}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -327,7 +327,7 @@ func TestCompareCompressionMapsForSRV(t *testing.T) {
 		lenFake := msgLenWithCompressionMap(msg, compressionFake)
 
 		compressionReal := make(map[string]int)
-		buf, err := msg.packBufferWithCompressionMap(nil, compressionReal, true)
+		buf, err := msg.packBufferWithCompressionMap(nil, compressionMap{ext: compressionReal}, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -80,7 +80,7 @@ func main() {
 		o := scope.Lookup(name)
 		st, _ := getTypeStruct(o.Type(), scope)
 
-		fmt.Fprintf(b, "func (rr *%s) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {\n", name)
+		fmt.Fprintf(b, "func (rr *%s) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {\n", name)
 		fmt.Fprint(b, `off, err := rr.Hdr.pack(msg, off, compression, compress)
 if err != nil {
 	return off, err
@@ -116,9 +116,9 @@ return off, err
 			switch {
 			case st.Tag(i) == `dns:"-"`: // ignored
 			case st.Tag(i) == `dns:"cdomain-name"`:
-				o("off, err = PackDomainName(rr.%s, msg, off, compression, compress)\n")
+				o("off, _, err = packDomainName(rr.%s, msg, off, compression, compress)\n")
 			case st.Tag(i) == `dns:"domain-name"`:
-				o("off, err = PackDomainName(rr.%s, msg, off, compression, false)\n")
+				o("off, _, err = packDomainName(rr.%s, msg, off, compression, false)\n")
 			case st.Tag(i) == `dns:"a"`:
 				o("off, err = packDataA(rr.%s, msg, off)\n")
 			case st.Tag(i) == `dns:"aaaa"`:

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -101,12 +101,12 @@ func unpackHeader(msg []byte, off int) (rr RR_Header, off1 int, truncmsg []byte,
 
 // pack packs an RR header, returning the offset to the end of the header.
 // See PackDomainName for documentation about the compression.
-func (hdr RR_Header) pack(msg []byte, off int, compression map[string]int, compress bool) (off1 int, err error) {
+func (hdr RR_Header) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	if off == len(msg) {
 		return off, nil
 	}
 
-	off, err = PackDomainName(hdr.Name, msg, off, compression, compress)
+	off, _, err = packDomainName(hdr.Name, msg, off, compression, compress)
 	if err != nil {
 		return len(msg), err
 	}
@@ -621,10 +621,10 @@ func unpackDataDomainNames(msg []byte, off, end int) ([]string, int, error) {
 	return servers, off, nil
 }
 
-func packDataDomainNames(names []string, msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func packDataDomainNames(names []string, msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	var err error
 	for j := 0; j < len(names); j++ {
-		off, err = PackDomainName(names[j], msg, off, compression, compress)
+		off, _, err = packDomainName(names[j], msg, off, compression, compress)
 		if err != nil {
 			return len(msg), err
 		}

--- a/privaterr.go
+++ b/privaterr.go
@@ -69,7 +69,7 @@ func (r *PrivateRR) copy() RR {
 	}
 	return rr
 }
-func (r *PrivateRR) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (r *PrivateRR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := r.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err

--- a/zmsg.go
+++ b/zmsg.go
@@ -4,7 +4,7 @@ package dns
 
 // pack*() functions
 
-func (rr *A) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *A) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -18,7 +18,7 @@ func (rr *A) pack(msg []byte, off int, compression map[string]int, compress bool
 	return off, nil
 }
 
-func (rr *AAAA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *AAAA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -32,7 +32,7 @@ func (rr *AAAA) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *AFSDB) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *AFSDB) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -42,7 +42,7 @@ func (rr *AFSDB) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Hostname, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Hostname, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -50,7 +50,7 @@ func (rr *AFSDB) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *ANY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *ANY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -60,7 +60,7 @@ func (rr *ANY) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *AVC) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *AVC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -74,7 +74,7 @@ func (rr *AVC) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *CAA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *CAA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -96,7 +96,7 @@ func (rr *CAA) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *CDNSKEY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *CDNSKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -122,7 +122,7 @@ func (rr *CDNSKEY) pack(msg []byte, off int, compression map[string]int, compres
 	return off, nil
 }
 
-func (rr *CDS) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *CDS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -148,7 +148,7 @@ func (rr *CDS) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *CERT) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *CERT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -174,13 +174,13 @@ func (rr *CERT) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *CNAME) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *CNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Target, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Target, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -188,7 +188,7 @@ func (rr *CNAME) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *CSYNC) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *CSYNC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -210,7 +210,7 @@ func (rr *CSYNC) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *DHCID) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *DHCID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -224,7 +224,7 @@ func (rr *DHCID) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *DLV) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *DLV) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -250,13 +250,13 @@ func (rr *DLV) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *DNAME) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *DNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Target, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -264,7 +264,7 @@ func (rr *DNAME) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *DNSKEY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *DNSKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -290,7 +290,7 @@ func (rr *DNSKEY) pack(msg []byte, off int, compression map[string]int, compress
 	return off, nil
 }
 
-func (rr *DS) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *DS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -316,7 +316,7 @@ func (rr *DS) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *EID) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *EID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -330,7 +330,7 @@ func (rr *EID) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *EUI48) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *EUI48) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -344,7 +344,7 @@ func (rr *EUI48) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *EUI64) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *EUI64) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -358,7 +358,7 @@ func (rr *EUI64) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *GID) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *GID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -372,7 +372,7 @@ func (rr *GID) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *GPOS) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *GPOS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -394,7 +394,7 @@ func (rr *GPOS) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *HINFO) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *HINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -412,7 +412,7 @@ func (rr *HINFO) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *HIP) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *HIP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -446,7 +446,7 @@ func (rr *HIP) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *KEY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *KEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -472,7 +472,7 @@ func (rr *KEY) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *KX) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *KX) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -482,7 +482,7 @@ func (rr *KX) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Exchanger, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Exchanger, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -490,7 +490,7 @@ func (rr *KX) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *L32) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *L32) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -508,7 +508,7 @@ func (rr *L32) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *L64) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *L64) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -526,7 +526,7 @@ func (rr *L64) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *LOC) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *LOC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -564,7 +564,7 @@ func (rr *LOC) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *LP) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *LP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -574,7 +574,7 @@ func (rr *LP) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Fqdn, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Fqdn, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -582,13 +582,13 @@ func (rr *LP) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *MB) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MB) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Mb, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Mb, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -596,13 +596,13 @@ func (rr *MB) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *MD) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MD) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Md, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Md, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -610,13 +610,13 @@ func (rr *MD) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *MF) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MF) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Mf, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Mf, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -624,13 +624,13 @@ func (rr *MF) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *MG) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Mg, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Mg, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -638,17 +638,17 @@ func (rr *MG) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *MINFO) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Rmail, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Rmail, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Email, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Email, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -656,13 +656,13 @@ func (rr *MINFO) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *MR) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Mr, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Mr, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -670,7 +670,7 @@ func (rr *MR) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *MX) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *MX) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -680,7 +680,7 @@ func (rr *MX) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Mx, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Mx, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -688,7 +688,7 @@ func (rr *MX) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *NAPTR) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NAPTR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -714,7 +714,7 @@ func (rr *NAPTR) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Replacement, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Replacement, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -722,7 +722,7 @@ func (rr *NAPTR) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *NID) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -740,7 +740,7 @@ func (rr *NID) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *NIMLOC) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NIMLOC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -754,7 +754,7 @@ func (rr *NIMLOC) pack(msg []byte, off int, compression map[string]int, compress
 	return off, nil
 }
 
-func (rr *NINFO) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -768,13 +768,13 @@ func (rr *NINFO) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *NS) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NS) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Ns, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Ns, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -782,13 +782,13 @@ func (rr *NS) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *NSAPPTR) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NSAPPTR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Ptr, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Ptr, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -796,13 +796,13 @@ func (rr *NSAPPTR) pack(msg []byte, off int, compression map[string]int, compres
 	return off, nil
 }
 
-func (rr *NSEC) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NSEC) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.NextDomain, msg, off, compression, false)
+	off, _, err = packDomainName(rr.NextDomain, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -814,7 +814,7 @@ func (rr *NSEC) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *NSEC3) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NSEC3) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -859,7 +859,7 @@ func (rr *NSEC3) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *NSEC3PARAM) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *NSEC3PARAM) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -892,7 +892,7 @@ func (rr *NSEC3PARAM) pack(msg []byte, off int, compression map[string]int, comp
 	return off, nil
 }
 
-func (rr *OPENPGPKEY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *OPENPGPKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -906,7 +906,7 @@ func (rr *OPENPGPKEY) pack(msg []byte, off int, compression map[string]int, comp
 	return off, nil
 }
 
-func (rr *OPT) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *OPT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -920,13 +920,13 @@ func (rr *OPT) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *PTR) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *PTR) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Ptr, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Ptr, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -934,7 +934,7 @@ func (rr *PTR) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *PX) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *PX) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -944,11 +944,11 @@ func (rr *PX) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Map822, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Map822, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Mapx400, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Mapx400, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -956,7 +956,7 @@ func (rr *PX) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *RFC3597) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *RFC3597) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -970,7 +970,7 @@ func (rr *RFC3597) pack(msg []byte, off int, compression map[string]int, compres
 	return off, nil
 }
 
-func (rr *RKEY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *RKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -996,17 +996,17 @@ func (rr *RKEY) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *RP) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *RP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Mbox, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Mbox, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Txt, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Txt, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1014,7 +1014,7 @@ func (rr *RP) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *RRSIG) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *RRSIG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1048,7 +1048,7 @@ func (rr *RRSIG) pack(msg []byte, off int, compression map[string]int, compress 
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.SignerName, msg, off, compression, false)
+	off, _, err = packDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1060,7 +1060,7 @@ func (rr *RRSIG) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *RT) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *RT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1070,7 +1070,7 @@ func (rr *RT) pack(msg []byte, off int, compression map[string]int, compress boo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Host, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Host, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1078,7 +1078,7 @@ func (rr *RT) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *SIG) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *SIG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1112,7 +1112,7 @@ func (rr *SIG) pack(msg []byte, off int, compression map[string]int, compress bo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.SignerName, msg, off, compression, false)
+	off, _, err = packDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1124,7 +1124,7 @@ func (rr *SIG) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *SMIMEA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *SMIMEA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1150,17 +1150,17 @@ func (rr *SMIMEA) pack(msg []byte, off int, compression map[string]int, compress
 	return off, nil
 }
 
-func (rr *SOA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *SOA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Ns, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Ns, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Mbox, msg, off, compression, compress)
+	off, _, err = packDomainName(rr.Mbox, msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
@@ -1188,7 +1188,7 @@ func (rr *SOA) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *SPF) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *SPF) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1202,7 +1202,7 @@ func (rr *SPF) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *SRV) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *SRV) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1220,7 +1220,7 @@ func (rr *SRV) pack(msg []byte, off int, compression map[string]int, compress bo
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.Target, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1228,7 +1228,7 @@ func (rr *SRV) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *SSHFP) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *SSHFP) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1250,7 +1250,7 @@ func (rr *SSHFP) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *TA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *TA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1276,17 +1276,17 @@ func (rr *TA) pack(msg []byte, off int, compression map[string]int, compress boo
 	return off, nil
 }
 
-func (rr *TALINK) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *TALINK) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.PreviousName, msg, off, compression, false)
+	off, _, err = packDomainName(rr.PreviousName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
-	off, err = PackDomainName(rr.NextName, msg, off, compression, false)
+	off, _, err = packDomainName(rr.NextName, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1294,13 +1294,13 @@ func (rr *TALINK) pack(msg []byte, off int, compression map[string]int, compress
 	return off, nil
 }
 
-func (rr *TKEY) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *TKEY) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Algorithm, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1340,7 +1340,7 @@ func (rr *TKEY) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *TLSA) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *TLSA) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1366,13 +1366,13 @@ func (rr *TLSA) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *TSIG) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *TSIG) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
 	}
 	headerEnd := off
-	off, err = PackDomainName(rr.Algorithm, msg, off, compression, false)
+	off, _, err = packDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
 		return off, err
 	}
@@ -1412,7 +1412,7 @@ func (rr *TSIG) pack(msg []byte, off int, compression map[string]int, compress b
 	return off, nil
 }
 
-func (rr *TXT) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *TXT) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1426,7 +1426,7 @@ func (rr *TXT) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *UID) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *UID) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1440,7 +1440,7 @@ func (rr *UID) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *UINFO) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *UINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1454,7 +1454,7 @@ func (rr *UINFO) pack(msg []byte, off int, compression map[string]int, compress 
 	return off, nil
 }
 
-func (rr *URI) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *URI) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err
@@ -1476,7 +1476,7 @@ func (rr *URI) pack(msg []byte, off int, compression map[string]int, compress bo
 	return off, nil
 }
 
-func (rr *X25) pack(msg []byte, off int, compression map[string]int, compress bool) (int, error) {
+func (rr *X25) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	off, err := rr.Hdr.pack(msg, off, compression, compress)
 	if err != nil {
 		return off, err


### PR DESCRIPTION
This PR switches the packing code to use a `map[string]uint16` for storing compression pointers while keeping support for external callers who pass in a `map[string]int`. This reduces the per-entry memory consumption of the compression map by 25%. (`(16+2)/(16+8) = 0.75`).

`compressionMap` is passed quite specifically as a value rather than a pointer because `RR.pack` is an interface method call which would cause it to escape and be heap allocated if it were a pointer. As maps are internally represented by a pointer to the runtime's `hmap` struct, the size of `compressionMap` is just 16-bytes anyway.

The benchmarks show a notable improvement in both memory use (alloc/op) and performance (time/op) for packing messages where multiple records are present.

```
name                    old time/op    new time/op    delta
MsgLengthPack-12          1.41µs ± 9%    1.46µs ±10%     ~     (p=0.353 n=10+10)
PackDomainName-12          128ns ± 0%     137ns ± 1%   +6.72%  (p=0.000 n=6+10)
PackA-12                  39.0ns ± 1%    40.1ns ± 1%   +2.69%  (p=0.000 n=8+8)
PackMX-12                 69.6ns ± 1%    72.4ns ± 1%   +4.05%  (p=0.000 n=10+9)
PackAAAAA-12              37.9ns ± 1%    40.0ns ± 1%   +5.68%  (p=0.000 n=10+9)
PackMsg-12                1.01µs ± 5%    0.95µs ± 1%   -5.85%  (p=0.000 n=10+10)
PackMsgOnlyQuestion-12     168ns ± 0%     176ns ± 1%   +4.94%  (p=0.000 n=6+10)
PackMsgMassive-12         67.8µs ±10%    55.1µs ±10%  -18.70%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
MsgLengthPack-12            576B ± 0%      528B ± 0%   -8.33%  (p=0.000 n=10+10)
PackDomainName-12          0.00B          0.00B          ~     (all equal)
PackA-12                   0.00B          0.00B          ~     (all equal)
PackMX-12                  0.00B          0.00B          ~     (all equal)
PackAAAAA-12               0.00B          0.00B          ~     (all equal)
PackMsg-12                  256B ± 0%      208B ± 0%  -18.75%  (p=0.000 n=10+10)
PackMsgOnlyQuestion-12     0.00B          0.00B          ~     (all equal)
PackMsgMassive-12         23.1kB ± 0%    19.0kB ± 0%  -17.88%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
MsgLengthPack-12            3.00 ± 0%      3.00 ± 0%     ~     (all equal)
PackDomainName-12           0.00           0.00          ~     (all equal)
PackA-12                    0.00           0.00          ~     (all equal)
PackMX-12                   0.00           0.00          ~     (all equal)
PackAAAAA-12                0.00           0.00          ~     (all equal)
PackMsg-12                  2.00 ± 0%      2.00 ± 0%     ~     (all equal)
PackMsgOnlyQuestion-12      0.00           0.00          ~     (all equal)
PackMsgMassive-12           12.0 ± 0%      12.0 ± 0%     ~     (all equal)
```

Updates #652 (see https://github.com/miekg/dns/issues/652#issuecomment-443200551).