### PR TITLE
Reduce allocations in ReverseAddr

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -244,9 +244,16 @@ func ReverseAddr(addr string) (arpa string, err error) {
 	if ip == nil {
 		return "", &Error{err: "unrecognized address: " + addr}
 	}
-	if ip.To4() != nil {
-		return strconv.Itoa(int(ip[15])) + "." + strconv.Itoa(int(ip[14])) + "." + strconv.Itoa(int(ip[13])) + "." +
-			strconv.Itoa(int(ip[12])) + ".in-addr.arpa.", nil
+	if v4 := ip.To4(); v4 != nil {
+		buf := make([]byte, 0, net.IPv4len*4+len("in-addr.arpa."))
+		// Add it, in reverse, to the buffer
+		for i := len(v4) - 1; i >= 0; i-- {
+			buf = strconv.AppendInt(buf, int64(v4[i]), 10)
+			buf = append(buf, '.')
+		}
+		// Append "in-addr.arpa." and return (buf already has the final .)
+		buf = append(buf, "in-addr.arpa."...)
+		return string(buf), nil
 	}
 	// Must be IPv6
 	buf := make([]byte, 0, net.IPv6len*4+len("ip6.arpa."))

--- a/defaults.go
+++ b/defaults.go
@@ -249,7 +249,7 @@ func ReverseAddr(addr string) (arpa string, err error) {
 			strconv.Itoa(int(ip[12])) + ".in-addr.arpa.", nil
 	}
 	// Must be IPv6
-	buf := make([]byte, 0, len(ip)*4+len("ip6.arpa."))
+	buf := make([]byte, 0, net.IPv6len*4+len("ip6.arpa."))
 	// Add it, in reverse, to the buffer
 	for i := len(ip) - 1; i >= 0; i-- {
 		v := ip[i]

--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -346,18 +346,24 @@ func BenchmarkIdGeneration(b *testing.B) {
 func BenchmarkReverseAddr(b *testing.B) {
 	b.Run("IP4", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := ReverseAddr("192.0.2.1")
+			addr, err := ReverseAddr("192.0.2.1")
 			if err != nil {
 				b.Fatal(err)
+			}
+			if expect := "1.2.0.192.in-addr.arpa."; addr != expect {
+				b.Fatalf("invalid reverse address, expected %q, got %q", expect, addr)
 			}
 		}
 	})
 
 	b.Run("IP6", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			_, err := ReverseAddr("2001:db8::68")
+			addr, err := ReverseAddr("2001:db8::68")
 			if err != nil {
 				b.Fatal(err)
+			}
+			if expect := "8.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."; addr != expect {
+				b.Fatalf("invalid reverse address, expected %q, got %q", expect, addr)
 			}
 		}
 	})

--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -342,3 +342,23 @@ func BenchmarkIdGeneration(b *testing.B) {
 		_ = id()
 	}
 }
+
+func BenchmarkReverseAddr(b *testing.B) {
+	b.Run("IP4", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			_, err := ReverseAddr("192.0.2.1")
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("IP6", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			_, err := ReverseAddr("2001:db8::68")
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
The IPv6 change in this PR is really trivial, while the IPv4 change is less so. The IPv4 code is quite similar to the IPv6 code now.

```
name                old time/op    new time/op    delta
ReverseAddr/IP4-12     175ns ± 5%     140ns ±13%  -19.94%  (p=0.000 n=10+10)
ReverseAddr/IP6-12     364ns ±14%     218ns ±22%  -40.23%  (p=0.000 n=10+10)

name                old alloc/op   new alloc/op   delta
ReverseAddr/IP4-12     51.0B ± 0%     48.0B ± 0%   -5.88%  (p=0.000 n=10+10)
ReverseAddr/IP6-12      176B ± 0%       96B ± 0%  -45.45%  (p=0.000 n=10+10)

name                old allocs/op  new allocs/op  delta
ReverseAddr/IP4-12      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
ReverseAddr/IP6-12      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```