### PR TITLE
Stop using packDomainName in IsDomainName

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -164,8 +164,8 @@ func (dns *Msg) IsEdns0() *OPT {
 // the number of labels.  When false is returned the number of labels is not
 // defined.  Also note that this function is extremely liberal; almost any
 // string is a valid domain name as the DNS is 8 bit protocol. It checks if each
-// label fits in 63 characters, but there is no length check for the entire
-// string s. I.e.  a domain name longer than 255 characters is considered valid.
+// label fits in 63 characters and that the entire name will fit into the 255
+// octet wire format limit.
 func IsDomainName(s string) (labels int, ok bool) {
 	// XXX: The logic in this function was copied from packDomainName and
 	// should be kept in sync with that function.

--- a/defaults.go
+++ b/defaults.go
@@ -252,11 +252,7 @@ func IsMsg(buf []byte) error {
 
 // IsFqdn checks if a domain name is fully qualified.
 func IsFqdn(s string) bool {
-	l := len(s)
-	if l == 0 {
-		return false
-	}
-	return s[l-1] == '.'
+	return strings.HasSuffix(s, ".")
 }
 
 // IsRRset checks if a set of RRs is a valid RRset as defined by RFC 2181.

--- a/defaults.go
+++ b/defaults.go
@@ -167,6 +167,9 @@ func (dns *Msg) IsEdns0() *OPT {
 // label fits in 63 characters, but there is no length check for the entire
 // string s. I.e.  a domain name longer than 255 characters is considered valid.
 func IsDomainName(s string) (labels int, ok bool) {
+	// XXX: The logic in this function was copied from packDomainName and
+	// should be kept in sync with that function.
+
 	const lenmsg = 256
 
 	if len(s) == 0 { // Ok, for instance when dealing with update RR without any rdata.

--- a/defaults.go
+++ b/defaults.go
@@ -252,7 +252,11 @@ func IsMsg(buf []byte) error {
 
 // IsFqdn checks if a domain name is fully qualified.
 func IsFqdn(s string) bool {
-	return strings.HasSuffix(s, ".")
+	l := len(s)
+	if l == 0 {
+		return false
+	}
+	return s[l-1] == '.'
 }
 
 // IsRRset checks if a set of RRs is a valid RRset as defined by RFC 2181.

--- a/defaults.go
+++ b/defaults.go
@@ -214,12 +214,10 @@ func IsDomainName(s string) (labels int, ok bool) {
 
 			// off can already (we're in a loop) be bigger than lenmsg
 			// this happens when a name isn't fully qualified
-			if off+1+labelLen > lenmsg {
+			off += 1 + labelLen
+			if off > lenmsg {
 				return labels, false
 			}
-
-			// The following is covered by the length check above.
-			off += 1 + labelLen
 
 			labels++
 			begin = i + 1

--- a/defaults.go
+++ b/defaults.go
@@ -193,35 +193,20 @@ func packDomainName2(s string) (labels int, err error) {
 	var (
 		off    int
 		begin  int
-		bs     []byte
 		wasDot bool
 	)
 	for i := 0; i < ls; i++ {
-		var c byte
-		if bs == nil {
-			c = s[i]
-		} else {
-			c = bs[i]
-		}
-
-		switch c {
+		switch s[i] {
 		case '\\':
 			if off+1 > lenmsg {
 				return labels, ErrBuf
 			}
 
-			if bs == nil {
-				bs = []byte(s)
-			}
-
 			// check for \DDD
-			if i+3 < ls && isDigit(bs[i+1]) && isDigit(bs[i+2]) && isDigit(bs[i+3]) {
-				bs[i] = dddToByte(bs[i+1:])
-				copy(bs[i+1:ls-3], bs[i+4:])
-				ls -= 3
+			if i+3 < ls && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
+				i += 3
 			} else {
-				copy(bs[i:ls-1], bs[i+1:])
-				ls--
+				i++
 			}
 
 			wasDot = false
@@ -254,7 +239,7 @@ func packDomainName2(s string) (labels int, err error) {
 	}
 
 	// Root label is special
-	if isRootLabel(s, bs, 0, ls) {
+	if isRootLabel(s, nil, 0, ls) {
 		return labels, nil
 	}
 

--- a/defaults.go
+++ b/defaults.go
@@ -195,8 +195,10 @@ func IsDomainName(s string) (labels int, ok bool) {
 			// check for \DDD
 			if i+3 < len(s) && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
 				i += 3
+				begin += 3
 			} else {
 				i++
+				begin++
 			}
 
 			wasDot = false

--- a/defaults.go
+++ b/defaults.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"strconv"
+	"strings"
 )
 
 const hexDigit = "0123456789abcdef"
@@ -168,15 +169,13 @@ func (dns *Msg) IsEdns0() *OPT {
 func IsDomainName(s string) (labels int, ok bool) {
 	lenmsg := 256
 
-	ls := len(s)
-	if ls == 0 { // Ok, for instance when dealing with update RR without any rdata.
+	if len(s) == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return 0, false
 	}
 
 	// If not fully qualified, error out, but only if msg != nil #ugly
-	if s[ls-1] != '.' {
+	if !strings.HasSuffix(s, ".") {
 		s += "."
-		ls++
 	}
 
 	// Each dot ends a segment of the name.
@@ -190,7 +189,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 		begin  int
 		wasDot bool
 	)
-	for i := 0; i < ls; i++ {
+	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '\\':
 			if off+1 > lenmsg {
@@ -198,7 +197,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 			}
 
 			// check for \DDD
-			if i+3 < ls && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
+			if i+3 < len(s) && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
 				i += 3
 			} else {
 				i++

--- a/defaults.go
+++ b/defaults.go
@@ -167,23 +167,19 @@ func (dns *Msg) IsEdns0() *OPT {
 // label fits in 63 characters, but there is no length check for the entire
 // string s. I.e.  a domain name longer than 255 characters is considered valid.
 func IsDomainName(s string) (labels int, ok bool) {
-	lenmsg := 256
+	const lenmsg = 256
 
 	if len(s) == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return 0, false
 	}
 
-	// If not fully qualified, error out, but only if msg != nil #ugly
 	if !strings.HasSuffix(s, ".") {
 		s += "."
 	}
 
-	// Each dot ends a segment of the name.
-	// We trade each dot byte for a length byte.
-	// Except for escaped dots (\.), which are normal dots.
-	// There is also a trailing zero.
+	// Each dot ends a segment of the name. Except for escaped dots (\.), which
+	// are normal dots.
 
-	// Emit sequence of counted strings, chopping at dots.
 	var (
 		off    int
 		begin  int
@@ -216,7 +212,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 				return labels, false
 			}
 
-			// off can already (we're in a loop) be bigger than len(msg)
+			// off can already (we're in a loop) be bigger than lenmsg
 			// this happens when a name isn't fully qualified
 			if off+1+labelLen > lenmsg {
 				return labels, false

--- a/defaults.go
+++ b/defaults.go
@@ -233,11 +233,6 @@ func IsDomainName(s string) (labels int, ok bool) {
 		}
 	}
 
-	// Root label is special
-	if isRootLabel(s, nil, 0, ls) {
-		return labels, true
-	}
-
 	return labels, true
 }
 

--- a/labels_test.go
+++ b/labels_test.go
@@ -155,13 +155,15 @@ func TestIsDomainName(t *testing.T) {
 		lab int
 	}
 	names := map[string]*ret{
-		"..":               {false, 1},
-		"@.":               {true, 1},
-		"www.example.com":  {true, 3},
-		"www.e%ample.com":  {true, 3},
-		"www.example.com.": {true, 3},
-		"mi\\k.nl.":        {true, 2},
-		"mi\\k.nl":         {true, 2},
+		"..":                     {false, 1},
+		"@.":                     {true, 1},
+		"www.example.com":        {true, 3},
+		"www.e%ample.com":        {true, 3},
+		"www.example.com.":       {true, 3},
+		"mi\\k.nl.":              {true, 2},
+		"mi\\k.nl":               {true, 2},
+		longestDomain:            {true, 4},
+		longestUnprintableDomain: {true, 4},
 	}
 	for d, ok := range names {
 		l, k := IsDomainName(d)

--- a/msg.go
+++ b/msg.go
@@ -235,6 +235,9 @@ func PackDomainName(s string, msg []byte, off int, compression map[string]int, c
 }
 
 func packDomainName(s string, msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	// XXX: A logical copy of this function exists in IsDomainName and
+	// should be kept in sync with this function.
+
 	ls := len(s)
 	if ls == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return off, nil

--- a/msg.go
+++ b/msg.go
@@ -236,8 +236,6 @@ func PackDomainName(s string, msg []byte, off int, compression map[string]int, c
 }
 
 func packDomainName(s string, msg []byte, off int, compression compressionMap, compress bool) (off1 int, labels int, err error) {
-	lenmsg := len(msg)
-
 	ls := len(s)
 	if ls == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return off, 0, nil
@@ -245,7 +243,7 @@ func packDomainName(s string, msg []byte, off int, compression compressionMap, c
 
 	// If not fully qualified, error out.
 	if s[ls-1] != '.' {
-		return lenmsg, 0, ErrFqdn
+		return len(msg), 0, ErrFqdn
 	}
 
 	// Each dot ends a segment of the name.
@@ -275,8 +273,8 @@ loop:
 
 		switch c {
 		case '\\':
-			if off+1 > lenmsg {
-				return lenmsg, labels, ErrBuf
+			if off+1 > len(msg) {
+				return len(msg), labels, ErrBuf
 			}
 
 			if bs == nil {
@@ -299,19 +297,19 @@ loop:
 		case '.':
 			if wasDot {
 				// two dots back to back is not legal
-				return lenmsg, labels, ErrRdata
+				return len(msg), labels, ErrRdata
 			}
 			wasDot = true
 
 			labelLen := i - begin
 			if labelLen >= 1<<6 { // top two bits of length must be clear
-				return lenmsg, labels, ErrRdata
+				return len(msg), labels, ErrRdata
 			}
 
 			// off can already (we're in a loop) be bigger than len(msg)
 			// this happens when a name isn't fully qualified
-			if off+1+labelLen > lenmsg {
-				return lenmsg, labels, ErrBuf
+			if off+1+labelLen > len(msg) {
+				return len(msg), labels, ErrBuf
 			}
 
 			// Don't try to compress '.'
@@ -365,7 +363,7 @@ loop:
 		return off + 2, labels, nil
 	}
 
-	if off < lenmsg {
+	if off < len(msg) {
 		msg[off] = 0
 	}
 

--- a/msg.go
+++ b/msg.go
@@ -236,24 +236,16 @@ func PackDomainName(s string, msg []byte, off int, compression map[string]int, c
 }
 
 func packDomainName(s string, msg []byte, off int, compression compressionMap, compress bool) (off1 int, labels int, err error) {
-	// special case if msg == nil
-	lenmsg := 256
-	if msg != nil {
-		lenmsg = len(msg)
-	}
+	lenmsg := len(msg)
 
 	ls := len(s)
 	if ls == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return off, 0, nil
 	}
 
-	// If not fully qualified, error out, but only if msg != nil #ugly
+	// If not fully qualified, error out.
 	if s[ls-1] != '.' {
-		if msg != nil {
-			return lenmsg, 0, ErrFqdn
-		}
-		s += "."
-		ls++
+		return lenmsg, 0, ErrFqdn
 	}
 
 	// Each dot ends a segment of the name.
@@ -344,14 +336,12 @@ loop:
 			}
 
 			// The following is covered by the length check above.
-			if msg != nil {
-				msg[off] = byte(labelLen)
+			msg[off] = byte(labelLen)
 
-				if bs == nil {
-					copy(msg[off+1:], s[begin:i])
-				} else {
-					copy(msg[off+1:], bs[begin:i])
-				}
+			if bs == nil {
+				copy(msg[off+1:], s[begin:i])
+			} else {
+				copy(msg[off+1:], bs[begin:i])
 			}
 			off += 1 + labelLen
 
@@ -371,12 +361,11 @@ loop:
 	// If we did compression and we find something add the pointer here
 	if pointer != -1 {
 		// We have two bytes (14 bits) to put the pointer in
-		// if msg == nil, we will never do compression
 		binary.BigEndian.PutUint16(msg[off:], uint16(pointer^0xC000))
 		return off + 2, labels, nil
 	}
 
-	if msg != nil && off < lenmsg {
+	if off < lenmsg {
 		msg[off] = 0
 	}
 

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -115,9 +115,9 @@ return headerEnd, off, err
 			switch {
 			case st.Tag(i) == `dns:"-"`: // ignored
 			case st.Tag(i) == `dns:"cdomain-name"`:
-				o("off, _, err = packDomainName(rr.%s, msg, off, compression, compress)\n")
+				o("off, err = packDomainName(rr.%s, msg, off, compression, compress)\n")
 			case st.Tag(i) == `dns:"domain-name"`:
-				o("off, _, err = packDomainName(rr.%s, msg, off, compression, false)\n")
+				o("off, err = packDomainName(rr.%s, msg, off, compression, false)\n")
 			case st.Tag(i) == `dns:"a"`:
 				o("off, err = packDataA(rr.%s, msg, off)\n")
 			case st.Tag(i) == `dns:"aaaa"`:

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -106,7 +106,7 @@ func (hdr RR_Header) pack(msg []byte, off int, compression compressionMap, compr
 		return off, off, nil
 	}
 
-	off, _, err := packDomainName(hdr.Name, msg, off, compression, compress)
+	off, err := packDomainName(hdr.Name, msg, off, compression, compress)
 	if err != nil {
 		return off, len(msg), err
 	}
@@ -624,7 +624,7 @@ func unpackDataDomainNames(msg []byte, off, end int) ([]string, int, error) {
 func packDataDomainNames(names []string, msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	var err error
 	for j := 0; j < len(names); j++ {
-		off, _, err = packDomainName(names[j], msg, off, compression, compress)
+		off, err = packDomainName(names[j], msg, off, compression, compress)
 		if err != nil {
 			return len(msg), err
 		}

--- a/zmsg.go
+++ b/zmsg.go
@@ -37,7 +37,7 @@ func (rr *AFSDB) pack(msg []byte, off int, compression compressionMap, compress 
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Hostname, msg, off, compression, false)
+	off, err = packDomainName(rr.Hostname, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -161,7 +161,7 @@ func (rr *CNAME) pack(msg []byte, off int, compression compressionMap, compress 
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Target, msg, off, compression, compress)
+	off, err = packDomainName(rr.Target, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -229,7 +229,7 @@ func (rr *DNAME) pack(msg []byte, off int, compression compressionMap, compress 
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Target, msg, off, compression, false)
+	off, err = packDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -433,7 +433,7 @@ func (rr *KX) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Exchanger, msg, off, compression, false)
+	off, err = packDomainName(rr.Exchanger, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -517,7 +517,7 @@ func (rr *LP) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Fqdn, msg, off, compression, false)
+	off, err = packDomainName(rr.Fqdn, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -529,7 +529,7 @@ func (rr *MB) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mb, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mb, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -541,7 +541,7 @@ func (rr *MD) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Md, msg, off, compression, compress)
+	off, err = packDomainName(rr.Md, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -553,7 +553,7 @@ func (rr *MF) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mf, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mf, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -565,7 +565,7 @@ func (rr *MG) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mg, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mg, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -577,11 +577,11 @@ func (rr *MINFO) pack(msg []byte, off int, compression compressionMap, compress 
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Rmail, msg, off, compression, compress)
+	off, err = packDomainName(rr.Rmail, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Email, msg, off, compression, compress)
+	off, err = packDomainName(rr.Email, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -593,7 +593,7 @@ func (rr *MR) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mr, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mr, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -609,7 +609,7 @@ func (rr *MX) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mx, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mx, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -641,7 +641,7 @@ func (rr *NAPTR) pack(msg []byte, off int, compression compressionMap, compress 
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Replacement, msg, off, compression, false)
+	off, err = packDomainName(rr.Replacement, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -693,7 +693,7 @@ func (rr *NS) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Ns, msg, off, compression, compress)
+	off, err = packDomainName(rr.Ns, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -705,7 +705,7 @@ func (rr *NSAPPTR) pack(msg []byte, off int, compression compressionMap, compres
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Ptr, msg, off, compression, false)
+	off, err = packDomainName(rr.Ptr, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -717,7 +717,7 @@ func (rr *NSEC) pack(msg []byte, off int, compression compressionMap, compress b
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.NextDomain, msg, off, compression, false)
+	off, err = packDomainName(rr.NextDomain, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -831,7 +831,7 @@ func (rr *PTR) pack(msg []byte, off int, compression compressionMap, compress bo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Ptr, msg, off, compression, compress)
+	off, err = packDomainName(rr.Ptr, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -847,11 +847,11 @@ func (rr *PX) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Map822, msg, off, compression, false)
+	off, err = packDomainName(rr.Map822, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mapx400, msg, off, compression, false)
+	off, err = packDomainName(rr.Mapx400, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -899,11 +899,11 @@ func (rr *RP) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mbox, msg, off, compression, false)
+	off, err = packDomainName(rr.Mbox, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Txt, msg, off, compression, false)
+	off, err = packDomainName(rr.Txt, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -943,7 +943,7 @@ func (rr *RRSIG) pack(msg []byte, off int, compression compressionMap, compress 
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.SignerName, msg, off, compression, false)
+	off, err = packDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -963,7 +963,7 @@ func (rr *RT) pack(msg []byte, off int, compression compressionMap, compress boo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Host, msg, off, compression, false)
+	off, err = packDomainName(rr.Host, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -1003,7 +1003,7 @@ func (rr *SIG) pack(msg []byte, off int, compression compressionMap, compress bo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.SignerName, msg, off, compression, false)
+	off, err = packDomainName(rr.SignerName, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -1043,11 +1043,11 @@ func (rr *SOA) pack(msg []byte, off int, compression compressionMap, compress bo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Ns, msg, off, compression, compress)
+	off, err = packDomainName(rr.Ns, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Mbox, msg, off, compression, compress)
+	off, err = packDomainName(rr.Mbox, msg, off, compression, compress)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -1103,7 +1103,7 @@ func (rr *SRV) pack(msg []byte, off int, compression compressionMap, compress bo
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Target, msg, off, compression, false)
+	off, err = packDomainName(rr.Target, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -1159,11 +1159,11 @@ func (rr *TALINK) pack(msg []byte, off int, compression compressionMap, compress
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.PreviousName, msg, off, compression, false)
+	off, err = packDomainName(rr.PreviousName, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.NextName, msg, off, compression, false)
+	off, err = packDomainName(rr.NextName, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -1175,7 +1175,7 @@ func (rr *TKEY) pack(msg []byte, off int, compression compressionMap, compress b
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Algorithm, msg, off, compression, false)
+	off, err = packDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -1243,7 +1243,7 @@ func (rr *TSIG) pack(msg []byte, off int, compression compressionMap, compress b
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, _, err = packDomainName(rr.Algorithm, msg, off, compression, false)
+	off, err = packDomainName(rr.Algorithm, msg, off, compression, false)
 	if err != nil {
 		return headerEnd, off, err
 	}


### PR DESCRIPTION
I'm not sure if this is worth doing, but @miekg mentioned it in https://github.com/miekg/dns/pull/818#issuecomment-442355376. `IsDomainName` is documented as being incredibly liberal, so it may be possible to make it simpler at the expense of strictness.