### PR TITLE
Use binary.BigEndian.PutUint32 in EDNS0_EXPIRE.pack

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -498,10 +498,7 @@ func (e *EDNS0_EXPIRE) String() string { return strconv.FormatUint(uint64(e.Expi
 
 func (e *EDNS0_EXPIRE) pack() ([]byte, error) {
 	b := make([]byte, 4)
-	b[0] = byte(e.Expire >> 24)
-	b[1] = byte(e.Expire >> 16)
-	b[2] = byte(e.Expire >> 8)
-	b[3] = byte(e.Expire)
+	binary.BigEndian.PutUint32(b, e.Expire)
 	return b, nil
 }
 


### PR DESCRIPTION
This now matches EDNS0_EXPIRE.unpack.