### PR TITLE
Be stricter when parsing zone files

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -53,7 +53,7 @@ func (zp *ZoneParser) generate(l lex) (RR, bool) {
 		return zp.setParseError("bad range in $GENERATE range", l)
 	}
 
-	zp.c.Next() // _BLANK
+	zp.c.Expect(zBlank)
 
 	// Create a complete new string, which we then parse again.
 	var s string

--- a/generate.go
+++ b/generate.go
@@ -53,7 +53,9 @@ func (zp *ZoneParser) generate(l lex) (RR, bool) {
 		return zp.setParseError("bad range in $GENERATE range", l)
 	}
 
-	zp.c.Expect(zBlank)
+	if l, _ := zp.c.Expect(zBlank); l.err {
+		return zp.setParseError("bad data in $GENERATE directive", l)
+	}
 
 	// Create a complete new string, which we then parse again.
 	var s string

--- a/parse_test.go
+++ b/parse_test.go
@@ -341,7 +341,7 @@ func TestParseDirectiveMisc(t *testing.T) {
 
 func TestNSEC(t *testing.T) {
 	nsectests := map[string]string{
-		"nl. IN NSEC3PARAM 1 0 5 30923C44C6CBBB8F":                                                                                                 "nl.\t3600\tIN\tNSEC3PARAM\t1 0 5 30923C44C6CBBB8F",
+		"nl. IN NSEC3PARAM 1 0 5 30923C44C6CBBB8F": "nl.\t3600\tIN\tNSEC3PARAM\t1 0 5 30923C44C6CBBB8F",
 		"p2209hipbpnm681knjnu0m1febshlv4e.nl. IN NSEC3 1 1 5 30923C44C6CBBB8F P90DG1KE8QEAN0B01613LHQDG0SOJ0TA NS SOA TXT RRSIG DNSKEY NSEC3PARAM": "p2209hipbpnm681knjnu0m1febshlv4e.nl.\t3600\tIN\tNSEC3\t1 1 5 30923C44C6CBBB8F P90DG1KE8QEAN0B01613LHQDG0SOJ0TA NS SOA TXT RRSIG DNSKEY NSEC3PARAM",
 		"localhost.dnssex.nl. IN NSEC www.dnssex.nl. A RRSIG NSEC":                                                                                 "localhost.dnssex.nl.\t3600\tIN\tNSEC\twww.dnssex.nl. A RRSIG NSEC",
 		"localhost.dnssex.nl. IN NSEC www.dnssex.nl. A RRSIG NSEC TYPE65534":                                                                       "localhost.dnssex.nl.\t3600\tIN\tNSEC\twww.dnssex.nl. A RRSIG NSEC TYPE65534",
@@ -398,16 +398,16 @@ func TestQuotes(t *testing.T) {
 		`t.example.com. IN TXT "a bc"`: "t.example.com.\t3600\tIN\tTXT\t\"a bc\"",
 		`t.example.com. IN TXT "a
  bc"`: "t.example.com.\t3600\tIN\tTXT\t\"a\\010 bc\"",
-		`t.example.com. IN TXT ""`:                                                           "t.example.com.\t3600\tIN\tTXT\t\"\"",
-		`t.example.com. IN TXT "a"`:                                                          "t.example.com.\t3600\tIN\tTXT\t\"a\"",
-		`t.example.com. IN TXT "aa"`:                                                         "t.example.com.\t3600\tIN\tTXT\t\"aa\"",
-		`t.example.com. IN TXT "aaa" ;`:                                                      "t.example.com.\t3600\tIN\tTXT\t\"aaa\"",
-		`t.example.com. IN TXT "abc" "DEF"`:                                                  "t.example.com.\t3600\tIN\tTXT\t\"abc\" \"DEF\"",
-		`t.example.com. IN TXT "abc" ( "DEF" )`:                                              "t.example.com.\t3600\tIN\tTXT\t\"abc\" \"DEF\"",
-		`t.example.com. IN TXT aaa ;`:                                                        "t.example.com.\t3600\tIN\tTXT\t\"aaa\"",
-		`t.example.com. IN TXT aaa aaa;`:                                                     "t.example.com.\t3600\tIN\tTXT\t\"aaa\" \"aaa\"",
-		`t.example.com. IN TXT aaa aaa`:                                                      "t.example.com.\t3600\tIN\tTXT\t\"aaa\" \"aaa\"",
-		`t.example.com. IN TXT aaa`:                                                          "t.example.com.\t3600\tIN\tTXT\t\"aaa\"",
+		`t.example.com. IN TXT ""`:              "t.example.com.\t3600\tIN\tTXT\t\"\"",
+		`t.example.com. IN TXT "a"`:             "t.example.com.\t3600\tIN\tTXT\t\"a\"",
+		`t.example.com. IN TXT "aa"`:            "t.example.com.\t3600\tIN\tTXT\t\"aa\"",
+		`t.example.com. IN TXT "aaa" ;`:         "t.example.com.\t3600\tIN\tTXT\t\"aaa\"",
+		`t.example.com. IN TXT "abc" "DEF"`:     "t.example.com.\t3600\tIN\tTXT\t\"abc\" \"DEF\"",
+		`t.example.com. IN TXT "abc" ( "DEF" )`: "t.example.com.\t3600\tIN\tTXT\t\"abc\" \"DEF\"",
+		`t.example.com. IN TXT aaa ;`:           "t.example.com.\t3600\tIN\tTXT\t\"aaa\"",
+		`t.example.com. IN TXT aaa aaa;`:        "t.example.com.\t3600\tIN\tTXT\t\"aaa\" \"aaa\"",
+		`t.example.com. IN TXT aaa aaa`:         "t.example.com.\t3600\tIN\tTXT\t\"aaa\" \"aaa\"",
+		`t.example.com. IN TXT aaa`:             "t.example.com.\t3600\tIN\tTXT\t\"aaa\"",
 		"cid.urn.arpa. NAPTR 100 50 \"s\" \"z3950+I2L+I2C\"    \"\" _z3950._tcp.gatech.edu.": "cid.urn.arpa.\t3600\tIN\tNAPTR\t100 50 \"s\" \"z3950+I2L+I2C\" \"\" _z3950._tcp.gatech.edu.",
 		"cid.urn.arpa. NAPTR 100 50 \"s\" \"rcds+I2C\"         \"\" _rcds._udp.gatech.edu.":  "cid.urn.arpa.\t3600\tIN\tNAPTR\t100 50 \"s\" \"rcds+I2C\" \"\" _rcds._udp.gatech.edu.",
 		"cid.urn.arpa. NAPTR 100 50 \"s\" \"http+I2L+I2C+I2R\" \"\" _http._tcp.gatech.edu.":  "cid.urn.arpa.\t3600\tIN\tNAPTR\t100 50 \"s\" \"http+I2L+I2C+I2R\" \"\" _http._tcp.gatech.edu.",
@@ -1579,5 +1579,14 @@ func TestNULLRecord(t *testing.T) {
 	}
 	if _, ok := msg.Answer[0].(*NULL); !ok {
 		t.Fatalf("Expected packet to contain NULL record")
+	}
+}
+
+func TestBadDirective(t *testing.T) {
+	rr, err := NewRR("$INVALID directive\nfoo IN A 127.0.0.1")
+	if err == nil {
+		t.Errorf("expected error, got record: %v", rr)
+	} else if expect := `dns: bad owner name: "$INVALID" at line: 1:9`; err.Error() != expect {
+		t.Errorf("expected error %q, got %q", expect, err.Error())
 	}
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -1586,7 +1586,7 @@ func TestBadDirective(t *testing.T) {
 	rr, err := NewRR("$INVALID directive\nfoo IN A 127.0.0.1")
 	if err == nil {
 		t.Errorf("expected error, got record: %v", rr)
-	} else if expect := `dns: bad owner name: "$INVALID" at line: 1:9`; err.Error() != expect {
+	} else if expect := `dns: unknown directive: "$INVALID" at line: 1:9`; err.Error() != expect {
 		t.Errorf("expected error %q, got %q", expect, err.Error())
 	}
 }

--- a/privaterr.go
+++ b/privaterr.go
@@ -110,26 +110,29 @@ func PrivateHandle(rtypestr string, rtype uint16, generator func() PrivateRdata)
 	}
 
 	setPrivateRR := func(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
-		rr := mkPrivateRR(h.Rrtype)
-		rr.Hdr = h
-
-		var l lex
 		text := make([]string, 0, 2) // could be 0..N elements, median is probably 1
-	Fetch:
-		for {
-			// TODO(miek): we could also be returning _QUOTE, this might or might not
+
+		start, ok := c.Next()
+		for l := start; ok; l, ok = c.Next() {
+			if l.err {
+				return nil, &ParseError{f, l.token, l}
+			}
+			if l.value == zNewline || l.value == zEOF {
+				break
+			}
+
+			// TODO(miek): we could also be returning zQUOTE, this might or might not
 			// be an issue (basically parsing TXT becomes hard)
-			switch l, _ = c.Next(); l.value {
-			case zNewline, zEOF:
-				break Fetch
-			case zString:
+			if l.value == zString {
 				text = append(text, l.token)
 			}
 		}
 
-		err := rr.Data.Parse(text)
-		if err != nil {
-			return nil, &ParseError{f, err.Error(), l}
+		rr := mkPrivateRR(h.Rrtype)
+		rr.Hdr = h
+
+		if err := rr.Data.Parse(text); err != nil {
+			return nil, &ParseError{f, err.Error(), start}
 		}
 
 		return rr, nil

--- a/privaterr.go
+++ b/privaterr.go
@@ -117,7 +117,7 @@ func PrivateHandle(rtypestr string, rtype uint16, generator func() PrivateRdata)
 			if l.err {
 				return nil, &ParseError{f, l.token, l}
 			}
-			if l.value == zNewline || l.value == zEOF {
+			if l.value == zNewline {
 				break
 			}
 

--- a/scan.go
+++ b/scan.go
@@ -41,24 +41,24 @@ const (
 	zValue
 	zKey
 
-	zExpectOwnerDir      // Ownername
-	zExpectOwnerBl       // Whitespace after the ownername
-	zExpectAny           // Expect rrtype, ttl or class
-	zExpectAnyNoClass    // Expect rrtype or ttl
-	zExpectAnyNoClassBl  // The whitespace after _EXPECT_ANY_NOCLASS
-	zExpectAnyNoTTL      // Expect rrtype or class
-	zExpectAnyNoTTLBl    // Whitespace after _EXPECT_ANY_NOTTL
-	zExpectRrtype        // Expect rrtype
-	zExpectRrtypeBl      // Whitespace BEFORE rrtype
-	zExpectRdata         // The first element of the rdata
-	zExpectDirTTLBl      // Space after directive $TTL
-	zExpectDirTTL        // Directive $TTL
-	zExpectDirOriginBl   // Space after directive $ORIGIN
-	zExpectDirOrigin     // Directive $ORIGIN
-	zExpectDirIncludeBl  // Space after directive $INCLUDE
-	zExpectDirInclude    // Directive $INCLUDE
-	zExpectDirGenerate   // Directive $GENERATE
-	zExpectDirGenerateBl // Space after directive $GENERATE
+	zExpectOwnerDir      = iota // Ownername
+	zExpectOwnerBl              // Whitespace after the ownername
+	zExpectAny                  // Expect rrtype, ttl or class
+	zExpectAnyNoClass           // Expect rrtype or ttl
+	zExpectAnyNoClassBl         // The whitespace after _EXPECT_ANY_NOCLASS
+	zExpectAnyNoTTL             // Expect rrtype or class
+	zExpectAnyNoTTLBl           // Whitespace after _EXPECT_ANY_NOTTL
+	zExpectRrtype               // Expect rrtype
+	zExpectRrtypeBl             // Whitespace BEFORE rrtype
+	zExpectRdata                // The first element of the rdata
+	zExpectDirTTLBl             // Space after directive $TTL
+	zExpectDirTTL               // Directive $TTL
+	zExpectDirOriginBl          // Space after directive $ORIGIN
+	zExpectDirOrigin            // Directive $ORIGIN
+	zExpectDirIncludeBl         // Space after directive $INCLUDE
+	zExpectDirInclude           // Directive $INCLUDE
+	zExpectDirGenerate          // Directive $GENERATE
+	zExpectDirGenerateBl        // Space after directive $GENERATE
 )
 
 // ParseError is a parsing error. It contains the parse error and the location in the io.Reader

--- a/scan.go
+++ b/scan.go
@@ -1152,6 +1152,9 @@ func (zl *zlexer) Next() (lex, bool) {
 func (zl *zlexer) Expect(typ lexerValue) (lex, bool) {
 	l, ok := zl.Next()
 	if ok && !l.err && l.value != typ {
+		// This will never be hit for zEOF, as ok will always
+		// be false whenever l.value == zEOF.
+
 		zl.nextL = false
 
 		l := &zl.l

--- a/scan.go
+++ b/scan.go
@@ -526,7 +526,7 @@ func (zp *ZoneParser) Next() (RR, bool) {
 
 	// The setRR code may not have checked for error in all paths, we
 	// check here to be sure we surface the error and not a broken RR.
-	if l := zp.c.LastToken(); l.err {
+	if l := zp.c.LastToken(); l.err || zp.c.Err() != nil {
 		return zp.setParseError("error parsing RR", l)
 	}
 

--- a/scan.go
+++ b/scan.go
@@ -17,7 +17,7 @@ const maxTok = 2048 // Largest token we can return.
 const maxIncludeDepth = 7
 
 type (
-	lexerValue      uint8
+	lexerValue      uint16
 	zoneParserState uint8
 )
 
@@ -29,8 +29,8 @@ type (
 // * Handle braces - anywhere.
 const (
 	// Zonefile
-	zEOF lexerValue = iota
-	zString
+	zEOF    lexerValue = 0
+	zString lexerValue = 1 << iota
 	zBlank
 	zQuote
 	zNewline
@@ -1151,14 +1151,14 @@ func (zl *zlexer) Next() (lex, bool) {
 
 func (zl *zlexer) Expect(typ lexerValue) (lex, bool) {
 	l, ok := zl.Next()
-	if ok && !l.err && l.value != typ {
+	if ok && !l.err && l.value&typ == 0 {
 		// This will never be hit for zEOF, as ok will always
 		// be false whenever l.value == zEOF.
 
 		zl.nextL = false
 
 		l := &zl.l
-		l.token = fmt.Sprintf("unexpected type %d lexer token, wanted type %d", l.value, typ)
+		l.token = fmt.Sprintf("unexpected type %#x lexer token, wanted bitmask %#x", l.value, typ)
 		l.err = true
 		return *l, true
 	}

--- a/scan.go
+++ b/scan.go
@@ -531,9 +531,7 @@ func (zp *ZoneParser) Next() (RR, bool) {
 		}
 	}
 
-	// If we get here, we and the h.Rrtype is still zero, we haven't parsed anything, this
-	// is not an error, because an empty zone file is still a zone file.
-	return nil, false
+	return zp.setParseError("unexpected end of file", zp.c.LastToken())
 }
 
 func (zp *ZoneParser) directive(l lex) (RR, bool) {

--- a/scan.go
+++ b/scan.go
@@ -756,7 +756,8 @@ func (zl *zlexer) Next() (lex, bool) {
 	}
 	if l.err {
 		// Parsing errors should be sticky.
-		return lex{value: zEOF}, false
+		l.value = zEOF
+		return *l, false
 	}
 
 	var (

--- a/scan.go
+++ b/scan.go
@@ -383,14 +383,14 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			return zp.setParseError("bad owner name", l)
 		}
 
-		l, _ = zp.c.Expect(zBlank)
-		if l.err {
+		l, ok = zp.c.Expect(zBlank)
+		if !ok || l.err {
 			return zp.setParseError("no blank after owner", l)
 		}
 
 		st = zExpectAny
 	case zDirective:
-		if l, _ := zp.c.Expect(zBlank); l.err {
+		if l, ok := zp.c.Expect(zBlank); !ok || l.err {
 			return zp.setParseError("no blank after directive", l)
 		}
 
@@ -402,8 +402,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 	case zClass:
 		h.Class = l.torc
 
-		l, _ = zp.c.Expect(zBlank)
-		if l.err {
+		l, ok = zp.c.Expect(zBlank)
+		if !ok || l.err {
 			return zp.setParseError("no blank after class", l)
 		}
 
@@ -420,8 +420,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			zp.defttl = &ttlState{ttl, false}
 		}
 
-		l, _ = zp.c.Expect(zBlank)
-		if l.err {
+		l, ok = zp.c.Expect(zBlank)
+		if !ok || l.err {
 			return zp.setParseError("no blank after TTL", l)
 		}
 
@@ -455,8 +455,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 
 				h.Class = l.torc
 
-				l, _ = zp.c.Expect(zBlank)
-				if l.err {
+				l, ok = zp.c.Expect(zBlank)
+				if !ok || l.err {
 					return zp.setParseError("no blank after class", l)
 				}
 
@@ -478,8 +478,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 					zp.defttl = &ttlState{ttl, false}
 				}
 
-				l, _ = zp.c.Expect(zBlank)
-				if l.err {
+				l, ok = zp.c.Expect(zBlank)
+				if !ok || l.err {
 					return zp.setParseError("no blank after TTl", l)
 				}
 
@@ -497,8 +497,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			}
 
 			if expectRRType {
-				l, _ = zp.c.Expect(zRrtpe)
-				if l.err {
+				l, ok = zp.c.Expect(zRrtpe)
+				if !ok || l.err {
 					return zp.setParseError("unknown RR type", l)
 				}
 
@@ -539,8 +539,8 @@ func (zp *ZoneParser) Next() (RR, bool) {
 func (zp *ZoneParser) directive(l lex) (RR, bool) {
 	switch strings.ToUpper(l.token) {
 	case "$TTL":
-		l, _ = zp.c.Expect(zString)
-		if l.err {
+		l, ok := zp.c.Expect(zString)
+		if !ok || l.err {
 			return zp.setParseError("expecting $TTL value, not this...", l)
 		}
 
@@ -557,8 +557,8 @@ func (zp *ZoneParser) directive(l lex) (RR, bool) {
 
 		return zp.Next()
 	case "$ORIGIN":
-		l, _ = zp.c.Expect(zString)
-		if l.err {
+		l, ok := zp.c.Expect(zString)
+		if !ok || l.err {
 			return zp.setParseError("expecting $ORIGIN value, not this...", l)
 		}
 
@@ -575,15 +575,15 @@ func (zp *ZoneParser) directive(l lex) (RR, bool) {
 
 		return zp.Next()
 	case "$INCLUDE":
-		l, _ = zp.c.Expect(zString)
-		if l.err {
+		l, ok := zp.c.Expect(zString)
+		if !ok || l.err {
 			return zp.setParseError("expecting $INCLUDE value, not this...", l)
 		}
 
 		return zp.include(l)
 	case "$GENERATE":
-		l, _ = zp.c.Expect(zString)
-		if l.err {
+		l, ok := zp.c.Expect(zString)
+		if !ok || l.err {
 			return zp.setParseError("expecting $GENERATE value, not this...", l)
 		}
 
@@ -598,13 +598,13 @@ func (zp *ZoneParser) include(l lex) (RR, bool) {
 	// if not use current one.
 	neworigin := zp.origin
 
-	l2, _ := zp.c.Expect(zBlank | zNewline)
-	if l2.err {
+	l2, ok := zp.c.Expect(zBlank | zNewline)
+	if !ok || l2.err {
 		return zp.setParseError("garbage after $INCLUDE", l2)
 	}
 	if l2.value == zBlank {
-		l, _ := zp.c.Expect(zString | zNewline)
-		if l.err {
+		l, ok := zp.c.Expect(zString | zNewline)
+		if !ok || l.err {
 			return zp.setParseError("garbage after $INCLUDE", l)
 		}
 		if l.value == zString {

--- a/scan.go
+++ b/scan.go
@@ -514,9 +514,9 @@ func (zp *ZoneParser) Next() (RR, bool) {
 
 	r, err := setRR(*h, zp.c, zp.origin, zp.file)
 	if err != nil {
-		// If e.lex is nil than we have encounter a unknown RR type
-		// in that case we substitute our current lex token
-		if err.lex.token == "" && err.lex.value == 0 {
+		// If err.lex is nil than we have encounter a unknown RR
+		// type in that case we substitute our current lex token.
+		if err.lex == (lex{}) {
 			err.lex = l // Uh, dirty
 		}
 

--- a/scan.go
+++ b/scan.go
@@ -381,12 +381,10 @@ func (zp *ZoneParser) Next() (RR, bool) {
 			case zNewline:
 				st = zExpectOwnerDir
 			case zOwner:
-				name, ok := toAbsoluteName(l.token, zp.origin)
+				h.Name, ok = toAbsoluteName(l.token, zp.origin)
 				if !ok {
 					return zp.setParseError("bad owner name", l)
 				}
-
-				h.Name = name
 
 				l, _ = zp.c.Expect(zBlank)
 				if l.err {
@@ -430,12 +428,10 @@ func (zp *ZoneParser) Next() (RR, bool) {
 						return nil, false
 					}
 
-					name, ok := toAbsoluteName(l.token, zp.origin)
+					zp.origin, ok = toAbsoluteName(l.token, zp.origin)
 					if !ok {
 						return zp.setParseError("bad origin name", l)
 					}
-
-					zp.origin = name
 
 					st = zExpectOwnerDir
 				case "$INCLUDE":

--- a/scan.go
+++ b/scan.go
@@ -1337,18 +1337,17 @@ func locCheckEast(token string, longitude uint32) (uint32, bool) {
 
 // "Eat" the rest of the "line"
 func slurpRemainder(c *zlexer, f string) *ParseError {
-	l, _ := c.Next()
-	switch l.value {
-	case zBlank:
-		l, _ = c.Next()
-		if l.value != zNewline && l.value != zEOF {
-			return &ParseError{f, "garbage after rdata", l}
-		}
-	case zNewline:
-	case zEOF:
-	default:
+	l, ok := c.Expect(zBlank | zNewline)
+	if l.value == zBlank {
+		l, ok = c.Expect(zNewline)
+	}
+	if ok && l.value != zNewline {
+		// We could use l.err here, but it would cause a less
+		// obvious error message for sticky errors. Instead we
+		// defer the error checking until ZoneParser.Next.
 		return &ParseError{f, "garbage after rdata", l}
 	}
+
 	return nil
 }
 

--- a/scan.go
+++ b/scan.go
@@ -1137,6 +1137,20 @@ func (zl *zlexer) Next() (lex, bool) {
 	return lex{value: zEOF}, false
 }
 
+func (zl *zlexer) Expect(typ uint8) (lex, bool) {
+	l, ok := zl.Next()
+	if ok && !l.err && l.value != typ {
+		zl.nextL = false
+
+		l := &zl.l
+		l.token = fmt.Sprintf("unexpected type %d lexer token, wanted type %d", l.value, typ)
+		l.err = true
+		return *l, true
+	}
+
+	return l, ok
+}
+
 func (zl *zlexer) Comment() string {
 	if zl.l.err {
 		return ""

--- a/scan.go
+++ b/scan.go
@@ -599,16 +599,17 @@ func (zp *ZoneParser) include(l lex) (RR, bool) {
 	// if not use current one.
 	neworigin := zp.origin
 
-	l2, ok := zp.c.Expect(zBlank | zNewline)
-	if !ok || l2.err {
+	l2, _ := zp.c.Expect(zBlank | zNewline)
+	if l2.err {
 		return zp.setParseError("garbage after $INCLUDE", l2)
 	}
 	if l2.value == zBlank {
-		l, ok := zp.c.Expect(zString | zNewline)
-		if !ok || l.err {
+		l, _ := zp.c.Expect(zString | zNewline)
+		if l.err {
 			return zp.setParseError("garbage after $INCLUDE", l)
 		}
 		if l.value == zString {
+			var ok bool
 			neworigin, ok = toAbsoluteName(l.token, zp.origin)
 			if !ok {
 				return zp.setParseError("bad origin name", l)

--- a/scan.go
+++ b/scan.go
@@ -608,12 +608,10 @@ func (zp *ZoneParser) include(l lex) (RR, bool) {
 			return zp.setParseError("garbage after $INCLUDE", l)
 		}
 		if l.value == zString {
-			name, ok := toAbsoluteName(l.token, zp.origin)
+			neworigin, ok = toAbsoluteName(l.token, zp.origin)
 			if !ok {
 				return zp.setParseError("bad origin name", l)
 			}
-
-			neworigin = name
 		}
 	}
 

--- a/scan.go
+++ b/scan.go
@@ -280,17 +280,19 @@ func (zp *ZoneParser) SetIncludeAllowed(v bool) {
 // Err returns the first non-EOF error that was encountered by the
 // ZoneParser.
 func (zp *ZoneParser) Err() error {
+	if err := zp.c.Err(); err != nil {
+		return err
+	}
+
 	if zp.parseErr != nil {
 		return zp.parseErr
 	}
 
 	if zp.sub != nil {
-		if err := zp.sub.Err(); err != nil {
-			return err
-		}
+		return zp.sub.Err()
 	}
 
-	return zp.c.Err()
+	return nil
 }
 
 func (zp *ZoneParser) setParseError(err string, l lex) (RR, bool) {

--- a/scan.go
+++ b/scan.go
@@ -1112,6 +1112,20 @@ func (zl *zlexer) Expect(typ lexerValue) (lex, bool) {
 	return l, ok
 }
 
+func (zl *zlexer) ExpectUntil(want, valid lexerValue) (lex, bool) {
+	if valid&^want == 0 {
+		panic("dns: internal error: caller should have used Expect")
+	}
+
+	valid |= want // This makes call sites shorter and easier to read.
+
+	for l, ok := zl.Expect(valid); ; l, ok = zl.Expect(valid) {
+		if !ok || l.err || l.value&want != 0 {
+			return l, ok
+		}
+	}
+}
+
 func (zl *zlexer) Comment() string {
 	if zl.l.err {
 		return ""

--- a/scan.go
+++ b/scan.go
@@ -49,13 +49,19 @@ type ParseError struct {
 	lex  lex
 }
 
-func (e *ParseError) Error() (s string) {
+func (e *ParseError) Error() string {
+	var s string
 	if e.file != "" {
 		s = e.file + ": "
 	}
-	s += "dns: " + e.err + ": " + strconv.QuoteToASCII(e.lex.token) + " at line: " +
+
+	token := e.lex.token
+	if token == "" && e.lex.value == zEOF && e.lex != (lex{}) {
+		token = "unexpected end of file"
+	}
+
+	return s + "dns: " + e.err + ": " + strconv.QuoteToASCII(token) + " at line: " +
 		strconv.Itoa(e.lex.line) + ":" + strconv.Itoa(e.lex.column)
-	return
 }
 
 type lex struct {

--- a/scan.go
+++ b/scan.go
@@ -667,6 +667,12 @@ func (zp *ZoneParser) Next() (RR, bool) {
 				return nil, false
 			}
 
+			// The setRR code may not have checked for error in all paths, we
+			// check here to be sure we surface the error and not a broken RR.
+			if l := zp.c.LastToken(); l.err {
+				return zp.setParseError("error parsing RR", l)
+			}
+
 			return r, true
 		}
 	}
@@ -1163,6 +1169,10 @@ func (zl *zlexer) Comment() string {
 	}
 
 	return zl.comment
+}
+
+func (zl *zlexer) LastToken() lex {
+	return zl.l
 }
 
 // Extract the class number from CLASSxx

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -893,11 +893,11 @@ Altitude:
 
 	// And now optionally the other values
 	l, ok = c.ExpectUntil(zString|zNewline, zBlank)
-	if !ok || l.err {
-		return nil, &ParseError{f, "bad LOC Size", l}
-	}
-	if l.value == zNewline {
+	if !ok || l.value == zNewline {
 		return rr, nil
+	}
+	if l.err {
+		return nil, &ParseError{f, "bad LOC Size", l}
 	}
 
 	s, m, ok := stringToCm(l.token)
@@ -907,11 +907,11 @@ Altitude:
 	rr.Size = s&0x0f | m<<4&0xf0
 
 	l, ok = c.ExpectUntil(zString|zNewline, zBlank)
-	if !ok || l.err {
-		return nil, &ParseError{f, "bad LOC HorizPre", l}
-	}
-	if l.value == zNewline {
+	if !ok || l.value == zNewline {
 		return rr, nil
+	}
+	if l.err {
+		return nil, &ParseError{f, "bad LOC HorizPre", l}
 	}
 
 	hp, m, ok := stringToCm(l.token)
@@ -921,11 +921,11 @@ Altitude:
 	rr.HorizPre = hp&0x0f | m<<4&0xf0
 
 	l, ok = c.ExpectUntil(zString|zNewline, zBlank)
-	if !ok || l.err {
-		return nil, &ParseError{f, "bad LOC VertPre", l}
-	}
-	if l.value == zNewline {
+	if !ok || l.value == zNewline {
 		return rr, nil
+	}
+	if l.err {
+		return nil, &ParseError{f, "bad LOC VertPre", l}
 	}
 
 	vp, m, ok := stringToCm(l.token)

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -50,7 +50,7 @@ func endingToString(c *zlexer, errstr, f string) (string, *ParseError) {
 		if l.err {
 			return s, &ParseError{f, errstr, l}
 		}
-		if l.value == zNewline || l.value == zEOF {
+		if l.value == zNewline {
 			break
 		}
 

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -46,11 +46,14 @@ func setRR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 // or an error
 func endingToString(c *zlexer, errstr, f string) (string, *ParseError) {
 	var s string
-	l, _ := c.Next()
-	for l.value != zNewline && l.value != zEOF {
+	for l, ok := c.Next(); ok; l, ok = c.Next() {
 		if l.err {
 			return s, &ParseError{f, errstr, l}
 		}
+		if l.value == zNewline || l.value == zEOF {
+			break
+		}
+
 		switch l.value {
 		case zString:
 			s += l.token
@@ -58,7 +61,6 @@ func endingToString(c *zlexer, errstr, f string) (string, *ParseError) {
 		default:
 			return "", &ParseError{f, errstr, l}
 		}
-		l, _ = c.Next()
 	}
 
 	return s, nil

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -46,7 +46,7 @@ func setRR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 // or an error
 func endingToString(c *zlexer, errstr, f string) (string, *ParseError) {
 	var s string
-	l, _ := c.Next() // zString
+	l, _ := c.Next()
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
 			return s, &ParseError{f, errstr, l}
@@ -229,7 +229,7 @@ func setRP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Mbox = mbox
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	rr.Txt = l.token
 
@@ -338,7 +338,7 @@ func setMINFO(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Rmail = rmail
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	rr.Email = l.token
 
@@ -402,8 +402,8 @@ func setMX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Preference = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Mx = l.token
 
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -430,8 +430,8 @@ func setRT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Preference = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Host = l.token
 
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -458,8 +458,8 @@ func setAFSDB(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Subtype = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Hostname = l.token
 
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -501,8 +501,8 @@ func setKX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Preference = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Exchanger = l.token
 
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -565,7 +565,7 @@ func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Ns = ns
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	rr.Mbox = l.token
 
@@ -575,7 +575,7 @@ func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Mbox = mbox
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 
 	var (
 		v  uint32
@@ -602,16 +602,16 @@ func setSOA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		switch i {
 		case 0:
 			rr.Serial = v
-			c.Next() // zBlank
+			c.Expect(zBlank)
 		case 1:
 			rr.Refresh = v
-			c.Next() // zBlank
+			c.Expect(zBlank)
 		case 2:
 			rr.Retry = v
-			c.Next() // zBlank
+			c.Expect(zBlank)
 		case 3:
 			rr.Expire = v
-			c.Next() // zBlank
+			c.Expect(zBlank)
 		case 4:
 			rr.Minttl = v
 		}
@@ -634,24 +634,24 @@ func setSRV(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Priority = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SRV Weight", l}
 	}
 	rr.Weight = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SRV Port", l}
 	}
 	rr.Port = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Target = l.token
 
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -677,8 +677,8 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Order = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NAPTR Preference", l}
@@ -686,7 +686,7 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	rr.Preference = uint16(i)
 
 	// Flags
-	c.Next()        // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
 		return nil, &ParseError{f, "bad NAPTR Flags", l}
@@ -705,7 +705,7 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 
 	// Service
-	c.Next()        // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
 		return nil, &ParseError{f, "bad NAPTR Service", l}
@@ -724,7 +724,7 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 
 	// Regexp
-	c.Next()        // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next() // _QUOTE
 	if l.value != zQuote {
 		return nil, &ParseError{f, "bad NAPTR Regexp", l}
@@ -743,8 +743,8 @@ func setNAPTR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 
 	// After quote no space??
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Replacement = l.token
 
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -771,7 +771,7 @@ func setTALINK(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.PreviousName = previousName
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	rr.NextName = l.token
 
@@ -804,7 +804,7 @@ func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Latitude = 1000 * 60 * 60 * uint32(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	// Either number, 'N' or 'S'
 	l, _ = c.Next()
 	if rr.Latitude, ok = locCheckNorth(l.token, rr.Latitude); ok {
@@ -816,14 +816,14 @@ func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Latitude += 1000 * 60 * uint32(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, e := strconv.ParseFloat(l.token, 32); e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Latitude seconds", l}
 	} else {
 		rr.Latitude += uint32(1000 * i)
 	}
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	// Either number, 'N' or 'S'
 	l, _ = c.Next()
 	if rr.Latitude, ok = locCheckNorth(l.token, rr.Latitude); ok {
@@ -834,14 +834,14 @@ func setLOC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 
 East:
 	// East
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, e := strconv.ParseUint(l.token, 10, 32); e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Longitude", l}
 	} else {
 		rr.Longitude = 1000 * 60 * 60 * uint32(i)
 	}
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	// Either number, 'E' or 'W'
 	l, _ = c.Next()
 	if rr.Longitude, ok = locCheckEast(l.token, rr.Longitude); ok {
@@ -852,14 +852,14 @@ East:
 	} else {
 		rr.Longitude += 1000 * 60 * uint32(i)
 	}
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, e := strconv.ParseFloat(l.token, 32); e != nil || l.err {
 		return nil, &ParseError{f, "bad LOC Longitude seconds", l}
 	} else {
 		rr.Longitude += uint32(1000 * i)
 	}
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	// Either number, 'E' or 'W'
 	l, _ = c.Next()
 	if rr.Longitude, ok = locCheckEast(l.token, rr.Longitude); ok {
@@ -869,7 +869,7 @@ East:
 	return nil, &ParseError{f, "bad LOC Longitude East/West", l}
 
 Altitude:
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if len(l.token) == 0 || l.err {
 		return nil, &ParseError{f, "bad LOC Altitude", l}
@@ -936,16 +936,16 @@ func setHIP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.PublicKeyAlgorithm = uint8(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	if len(l.token) == 0 || l.err {
 		return nil, &ParseError{f, "bad HIP Hit", l}
 	}
 	rr.Hit = l.token // This can not contain spaces, see RFC 5205 Section 6.
 	rr.HitLength = uint8(len(rr.Hit)) / 2
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	if len(l.token) == 0 || l.err {
 		return nil, &ParseError{f, "bad HIP PublicKey", l}
 	}
@@ -991,15 +991,15 @@ func setCERT(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	} else {
 		rr.Type = uint16(i)
 	}
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad CERT KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	if v, ok := StringToAlgorithm[l.token]; ok {
 		rr.Algorithm = v
 	} else if i, e := strconv.ParseUint(l.token, 10, 8); e != nil {
@@ -1042,7 +1042,7 @@ func setCSYNC(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Serial = uint32(j)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 
 	l, _ = c.Next()
 	j, e = strconv.ParseUint(l.token, 10, 16)
@@ -1110,7 +1110,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		rr.TypeCovered = t
 	}
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, err := strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
@@ -1118,7 +1118,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Algorithm = uint8(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 8)
 	if err != nil || l.err {
@@ -1126,7 +1126,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Labels = uint8(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 32)
 	if err != nil || l.err {
@@ -1134,7 +1134,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.OrigTtl = uint32(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, err := StringToTime(l.token); err != nil {
 		// Try to see if all numeric and use it as epoch
@@ -1148,7 +1148,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		rr.Expiration = i
 	}
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, err := StringToTime(l.token); err != nil {
 		if i, err := strconv.ParseInt(l.token, 10, 64); err == nil {
@@ -1160,7 +1160,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		rr.Inception = i
 	}
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, err = strconv.ParseUint(l.token, 10, 16)
 	if err != nil || l.err {
@@ -1168,7 +1168,7 @@ func setRRSIG(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.KeyTag = uint16(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	rr.SignerName = l.token
 	name, nameOk := toAbsoluteName(l.token, o)
@@ -1242,14 +1242,14 @@ func setNSEC3(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad NSEC3 Hash", l}
 	}
 	rr.Hash = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3 Flags", l}
 	}
 	rr.Flags = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
@@ -1314,21 +1314,21 @@ func setNSEC3PARAM(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad NSEC3PARAM Hash", l}
 	}
 	rr.Hash = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3PARAM Flags", l}
 	}
 	rr.Flags = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad NSEC3PARAM Iterations", l}
 	}
 	rr.Iterations = uint16(i)
-	c.Next()
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if l.token != "-" {
 		rr.SaltLength = uint8(len(l.token))
@@ -1417,14 +1417,14 @@ func setSSHFP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad SSHFP Algorithm", l}
 	}
 	rr.Algorithm = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SSHFP Type", l}
 	}
 	rr.Type = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	s, e1 := endingToString(c, "bad SSHFP Fingerprint", f)
 	if e1 != nil {
 		return nil, e1
@@ -1447,15 +1447,15 @@ func setDNSKEYs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad " + typ + " Flags", l}
 	}
 	rr.Flags = uint16(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " Protocol", l}
 	}
 	rr.Protocol = uint8(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad " + typ + " Algorithm", l}
@@ -1503,15 +1503,15 @@ func setRKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad RKEY Flags", l}
 	}
 	rr.Flags = uint16(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad RKEY Protocol", l}
 	}
 	rr.Protocol = uint8(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad RKEY Algorithm", l}
@@ -1561,14 +1561,14 @@ func setGPOS(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad GPOS Longitude", l}
 	}
 	rr.Longitude = l.token
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	_, e = strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad GPOS Latitude", l}
 	}
 	rr.Latitude = l.token
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	_, e = strconv.ParseFloat(l.token, 64)
 	if e != nil || l.err {
@@ -1592,7 +1592,7 @@ func setDSs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad " + typ + " KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, e = strconv.ParseUint(l.token, 10, 8); e != nil {
 		tokenUpper := strings.ToUpper(l.token)
@@ -1604,7 +1604,7 @@ func setDSs(h RR_Header, c *zlexer, o, f, typ string) (RR, *ParseError) {
 	} else {
 		rr.Algorithm = uint8(i)
 	}
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
@@ -1653,7 +1653,7 @@ func setTA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad TA KeyTag", l}
 	}
 	rr.KeyTag = uint16(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if i, e := strconv.ParseUint(l.token, 10, 8); e != nil {
 		tokenUpper := strings.ToUpper(l.token)
@@ -1665,7 +1665,7 @@ func setTA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	} else {
 		rr.Algorithm = uint8(i)
 	}
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
@@ -1694,14 +1694,14 @@ func setTLSA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad TLSA Usage", l}
 	}
 	rr.Usage = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad TLSA Selector", l}
 	}
 	rr.Selector = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
@@ -1731,14 +1731,14 @@ func setSMIMEA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad SMIMEA Usage", l}
 	}
 	rr.Usage = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
 		return nil, &ParseError{f, "bad SMIMEA Selector", l}
 	}
 	rr.Selector = uint8(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 8)
 	if e != nil || l.err {
@@ -1763,7 +1763,7 @@ func setRFC3597(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad RFC3597 Rdata", l}
 	}
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	rdlength, e := strconv.Atoi(l.token)
 	if e != nil || l.err {
@@ -1845,7 +1845,7 @@ func setURI(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad URI Priority", l}
 	}
 	rr.Priority = uint16(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	i, e = strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
@@ -1853,7 +1853,7 @@ func setURI(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Weight = uint16(i)
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	s, err := endingToTxtSlice(c, "bad URI Target", f)
 	if err != nil {
 		return nil, err
@@ -1892,8 +1892,8 @@ func setNID(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad NID Preference", l}
 	}
 	rr.Preference = uint16(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	u, err := stringToNodeID(l)
 	if err != nil || l.err {
 		return nil, err
@@ -1916,8 +1916,8 @@ func setL32(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad L32 Preference", l}
 	}
 	rr.Preference = uint16(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Locator32 = net.ParseIP(l.token)
 	if rr.Locator32 == nil || l.err {
 		return nil, &ParseError{f, "bad L32 Locator", l}
@@ -1940,8 +1940,8 @@ func setLP(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Preference = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Fqdn = l.token
 	name, nameOk := toAbsoluteName(l.token, o)
 	if l.err || !nameOk {
@@ -1966,8 +1966,8 @@ func setL64(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad L64 Preference", l}
 	}
 	rr.Preference = uint16(i)
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	u, err := stringToNodeID(l)
 	if err != nil || l.err {
 		return nil, err
@@ -2040,8 +2040,8 @@ func setPX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Preference = uint16(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Map822 = l.token
 	map822, map822Ok := toAbsoluteName(l.token, o)
 	if l.err || !map822Ok {
@@ -2049,8 +2049,8 @@ func setPX(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Map822 = map822
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	rr.Mapx400 = l.token
 	mapx400, mapx400Ok := toAbsoluteName(l.token, o)
 	if l.err || !mapx400Ok {
@@ -2076,14 +2076,14 @@ func setCAA(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	}
 	rr.Flag = uint8(i)
 
-	c.Next()        // zBlank
-	l, _ = c.Next() // zString
+	c.Expect(zBlank)
+	l, _ = c.Expect(zString)
 	if l.value != zString {
 		return nil, &ParseError{f, "bad CAA Tag", l}
 	}
 	rr.Tag = l.token
 
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	s, e := endingToTxtSlice(c, "bad CAA Value", f)
 	if e != nil {
 		return nil, e
@@ -2106,7 +2106,7 @@ func setTKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad TKEY algorithm", l}
 	}
 	rr.Algorithm = l.token
-	c.Next() // zBlank
+	c.Expect(zBlank)
 
 	// Get the key length and key values
 	l, _ = c.Next()
@@ -2115,13 +2115,13 @@ func setTKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad TKEY key length", l}
 	}
 	rr.KeySize = uint16(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if l.value != zString {
 		return nil, &ParseError{f, "bad TKEY key", l}
 	}
 	rr.Key = l.token
-	c.Next() // zBlank
+	c.Expect(zBlank)
 
 	// Get the otherdata length and string data
 	l, _ = c.Next()
@@ -2130,7 +2130,7 @@ func setTKEY(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 		return nil, &ParseError{f, "bad TKEY otherdata length", l}
 	}
 	rr.OtherLen = uint16(i)
-	c.Next() // zBlank
+	c.Expect(zBlank)
 	l, _ = c.Next()
 	if l.value != zString {
 		return nil, &ParseError{f, "bad TKEY otherday", l}

--- a/scan_test.go
+++ b/scan_test.go
@@ -135,7 +135,7 @@ func TestZLexerExpect(t *testing.T) {
 	rr, err := NewRR("example.com. 42 IN SOA ns1.example.com.\"hostmaster.example.com.\"1 86400 60 86400 3600")
 	if err == nil {
 		t.Errorf("expected error, got record: %v", rr)
-	} else if expect := `dns: bad SOA Mbox: "unexpected type 3 lexer token, wanted type 2" at line: 1:40`; err.Error() != expect {
+	} else if expect := `dns: bad SOA Mbox: "unexpected type 0x8 lexer token, wanted bitmask 0x4" at line: 1:40`; err.Error() != expect {
 		t.Errorf("expected error %q, got %q", expect, err.Error())
 	}
 }
@@ -144,7 +144,7 @@ func TestZLexerUncheckedError(t *testing.T) {
 	rr, err := NewRR("nl. IN NSEC3PARAM 1 0 5\"\"")
 	if err == nil {
 		t.Errorf("expected error, got record: %v", rr)
-	} else if expect := `dns: error parsing RR: "unexpected type 3 lexer token, wanted type 2" at line: 1:24`; err.Error() != expect {
+	} else if expect := `dns: error parsing RR: "unexpected type 0x8 lexer token, wanted bitmask 0x4" at line: 1:24`; err.Error() != expect {
 		t.Errorf("expected error %q, got %q", expect, err.Error())
 	}
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -140,6 +140,15 @@ func TestZLexerExpect(t *testing.T) {
 	}
 }
 
+func TestZLexerUncheckedError(t *testing.T) {
+	rr, err := NewRR("nl. IN NSEC3PARAM 1 0 5\"\"")
+	if err == nil {
+		t.Errorf("expected error, got record: %v", rr)
+	} else if expect := `dns: error parsing RR: "unexpected type 3 lexer token, wanted type 2" at line: 1:24`; err.Error() != expect {
+		t.Errorf("expected error %q, got %q", expect, err.Error())
+	}
+}
+
 var errTestReadError = &Error{"test error"}
 
 type errReader struct{}

--- a/scan_test.go
+++ b/scan_test.go
@@ -131,6 +131,15 @@ func TestParseTA(t *testing.T) {
 	}
 }
 
+func TestZLexerExpect(t *testing.T) {
+	rr, err := NewRR("example.com. 42 IN SOA ns1.example.com.\"hostmaster.example.com.\"1 86400 60 86400 3600")
+	if err == nil {
+		t.Errorf("expected error, got record: %v", rr)
+	} else if expect := `dns: bad SOA Mbox: "unexpected type 3 lexer token, wanted type 2" at line: 1:40`; err.Error() != expect {
+		t.Errorf("expected error %q, got %q", expect, err.Error())
+	}
+}
+
 var errTestReadError = &Error{"test error"}
 
 type errReader struct{}


### PR DESCRIPTION
**DO NOT MERGE**: This is still very much a work in progress.

This is an attempt to make the `ZoneParser` & `zlexer` stricter. Currently they're unintentionally quite permissive. For example both of the following records parse despite being invalid:
```
example.com. 42 IN SOA ns1.example.com."hostmaster.example.com."1 86400 60 86400 3600
nl. IN NSEC3PARAM 1 0 5""
```

This also has the benefit of eliminating the `ZoneParser` state machine which leaves much simpler and easier to understand code.

This still has lots of rough edges and corner cases that need to be addressed, but it should be ready for a least a curious once over.