### PR TITLE
Rename NULL's Anything field to Data

### DIFF
--- a/types.go
+++ b/types.go
@@ -243,13 +243,13 @@ func (rr *ANY) String() string { return rr.Hdr.String() }
 
 // NULL RR. See RFC 1035.
 type NULL struct {
-	Hdr      RR_Header
-	Anything string `dns:"any"`
+	Hdr  RR_Header
+	Data string `dns:"any"`
 }
 
 func (rr *NULL) String() string {
 	// There is no presentation format; prefix string with a comment.
-	return ";" + rr.Hdr.String() + rr.Anything
+	return ";" + rr.Hdr.String() + rr.Data
 }
 
 // CNAME RR. See RFC 1034.

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -619,7 +619,7 @@ func isDuplicateNSEC3PARAM(r1, r2 *NSEC3PARAM) bool {
 }
 
 func isDuplicateNULL(r1, r2 *NULL) bool {
-	if r1.Anything != r2.Anything {
+	if r1.Data != r2.Data {
 		return false
 	}
 	return true

--- a/zmsg.go
+++ b/zmsg.go
@@ -807,7 +807,7 @@ func (rr *NULL) pack(msg []byte, off int, compression compressionMap, compress b
 	if err != nil {
 		return headerEnd, off, err
 	}
-	off, err = packStringAny(rr.Anything, msg, off)
+	off, err = packStringAny(rr.Data, msg, off)
 	if err != nil {
 		return headerEnd, off, err
 	}
@@ -2571,7 +2571,7 @@ func unpackNULL(h RR_Header, msg []byte, off int) (RR, int, error) {
 	rdStart := off
 	_ = rdStart
 
-	rr.Anything, off, err = unpackStringAny(msg, off, rdStart+int(rr.Hdr.Rdlength))
+	rr.Data, off, err = unpackStringAny(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
 		return rr, off, err
 	}

--- a/ztypes.go
+++ b/ztypes.go
@@ -477,7 +477,7 @@ func (rr *NSEC3PARAM) len(off int, compression map[string]struct{}) int {
 }
 func (rr *NULL) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += len(rr.Anything)
+	l += len(rr.Data)
 	return l
 }
 func (rr *OPENPGPKEY) len(off int, compression map[string]struct{}) int {
@@ -791,7 +791,7 @@ func (rr *NSEC3PARAM) copy() RR {
 	return &NSEC3PARAM{rr.Hdr, rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt}
 }
 func (rr *NULL) copy() RR {
-	return &NULL{rr.Hdr, rr.Anything}
+	return &NULL{rr.Hdr, rr.Data}
 }
 func (rr *OPENPGPKEY) copy() RR {
 	return &OPENPGPKEY{rr.Hdr, rr.PublicKey}


### PR DESCRIPTION
The NULL record has yet to make it into an actual release and I'd like to propose renaming the `Anything` field to `Data`. I think `Data` is clearer than `Anything` about what the actual contents of the RR is.

I know RFC 1035 describes the NULL record as:
```
3.3.10. NULL RDATA format (EXPERIMENTAL)

    +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
    /                  <anything>                   /
    /                                               /
    +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+

Anything at all may be in the RDATA field so long as it is 65535 octets
or less.
```
but I don't think naming it `Anything` is clearer. See for example the definition of the NS record and how the field is named (note the lack of angled brackets):
```
3.3.11. NS RDATA format

    +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
    /                   NSDNAME                     /
    /                                               /
    +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+

where:

NSDNAME         A <domain-name> which specifies a host which should be
                authoritative for the specified class and domain.
```

The RFC's intention was that it should represent an arbitrary RDATA which I think is better reflected by `Data` than `Anything`. Obviously this is a judgement call.