### PR TITLE
Use (net.IP).Equal in isDuplicate functions

### DIFF
--- a/duplicate_generate.go
+++ b/duplicate_generate.go
@@ -103,7 +103,7 @@ func main() {
 
 			// For some reason, a and aaaa don't pop up as *types.Slice here (mostly like because the are
 			// *indirectly* defined as a slice in the net package).
-			if _, ok := st.Field(i).Type().(*types.Slice); ok || st.Tag(i) == `dns:"a"` || st.Tag(i) == `dns:"aaaa"` {
+			if _, ok := st.Field(i).Type().(*types.Slice); ok {
 				o2("if len(r1.%s) != len(r2.%s) {\nreturn false\n}")
 
 				if st.Tag(i) == `dns:"cdomain-name"` || st.Tag(i) == `dns:"domain-name"` {
@@ -128,6 +128,8 @@ func main() {
 			switch st.Tag(i) {
 			case `dns:"-"`:
 				// ignored
+			case `dns:"a"`, `dns:"aaaa"`:
+				o2("if !r1.%s.Equal(r2.%s) {\nreturn false\n}")
 			case `dns:"cdomain-name"`, `dns:"domain-name"`:
 				o2("if !isDulicateName(r1.%s, r2.%s) {\nreturn false\n}")
 			default:

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -138,25 +138,15 @@ func isDuplicateRdata(r1, r2 RR) bool {
 // isDuplicate() functions
 
 func isDuplicateA(r1, r2 *A) bool {
-	if len(r1.A) != len(r2.A) {
+	if !r1.A.Equal(r2.A) {
 		return false
-	}
-	for i := 0; i < len(r1.A); i++ {
-		if r1.A[i] != r2.A[i] {
-			return false
-		}
 	}
 	return true
 }
 
 func isDuplicateAAAA(r1, r2 *AAAA) bool {
-	if len(r1.AAAA) != len(r2.AAAA) {
+	if !r1.AAAA.Equal(r2.AAAA) {
 		return false
-	}
-	for i := 0; i < len(r1.AAAA); i++ {
-		if r1.AAAA[i] != r2.AAAA[i] {
-			return false
-		}
 	}
 	return true
 }
@@ -375,13 +365,8 @@ func isDuplicateL32(r1, r2 *L32) bool {
 	if r1.Preference != r2.Preference {
 		return false
 	}
-	if len(r1.Locator32) != len(r2.Locator32) {
+	if !r1.Locator32.Equal(r2.Locator32) {
 		return false
-	}
-	for i := 0; i < len(r1.Locator32); i++ {
-		if r1.Locator32[i] != r2.Locator32[i] {
-			return false
-		}
 	}
 	return true
 }


### PR DESCRIPTION
This is clearer, faster and more correct. The packing code for A records will convert IPv4-in-v6 address to IPv4 address which wasn't handled by the previous code, but is handled by `(net.IP).Equal`.