### PR TITLE
Flatten goroutine inside goroutine in Transfer.In

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -39,26 +39,26 @@ func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 	if t.DialTimeout != 0 {
 		timeout = t.DialTimeout
 	}
+
 	if t.Conn == nil {
 		t.Conn, err = DialTimeout("tcp", a, timeout)
 		if err != nil {
 			return nil, err
 		}
 	}
+
 	if err := t.WriteMsg(q); err != nil {
 		return nil, err
 	}
+
 	env = make(chan *Envelope)
-	go func() {
-		if q.Question[0].Qtype == TypeAXFR {
-			go t.inAxfr(q, env)
-			return
-		}
-		if q.Question[0].Qtype == TypeIXFR {
-			go t.inIxfr(q, env)
-			return
-		}
-	}()
+	switch q.Question[0].Qtype {
+	case TypeAXFR:
+		go t.inAxfr(q, env)
+	case TypeIXFR:
+		go t.inIxfr(q, env)
+	}
+
 	return env, nil
 }
 

--- a/xfr.go
+++ b/xfr.go
@@ -35,6 +35,12 @@ type Transfer struct {
 //	channel, err := transfer.In(message, master)
 //
 func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
+	switch q.Question[0].Qtype {
+	case TypeAXFR, TypeIXFR:
+	default:
+		return nil, &Error{"unsupported question type"}
+	}
+
 	timeout := dnsTimeout
 	if t.DialTimeout != 0 {
 		timeout = t.DialTimeout


### PR DESCRIPTION
I'm not sure how this ended up like it did, but it was obviously unintentional.

While I'm here, return an error for unknown question types. Previously this would just be silently ignored leaving nothing to close the returned channel or return an error.