### PR TITLE
Avoid calling RR.Header more than once per RR

### DIFF
--- a/sanitize.go
+++ b/sanitize.go
@@ -15,10 +15,11 @@ func Dedup(rrs []RR, m map[string]RR) []RR {
 	for _, r := range rrs {
 		key := normalizedString(r)
 		keys = append(keys, &key)
-		if _, ok := m[key]; ok {
+		if mr, ok := m[key]; ok {
 			// Shortest TTL wins.
-			if m[key].Header().Ttl > r.Header().Ttl {
-				m[key].Header().Ttl = r.Header().Ttl
+			rh, mrh := r.Header(), mr.Header()
+			if mrh.Ttl > rh.Ttl {
+				mrh.Ttl = rh.Ttl
 			}
 			continue
 		}

--- a/sig0.go
+++ b/sig0.go
@@ -21,10 +21,11 @@ func (rr *SIG) Sign(k crypto.Signer, m *Msg) ([]byte, error) {
 	if rr.KeyTag == 0 || len(rr.SignerName) == 0 || rr.Algorithm == 0 {
 		return nil, ErrKey
 	}
-	rr.Header().Rrtype = TypeSIG
-	rr.Header().Class = ClassANY
-	rr.Header().Ttl = 0
-	rr.Header().Name = "."
+	h := rr.Header()
+	h.Rrtype = TypeSIG
+	h.Class = ClassANY
+	h.Ttl = 0
+	h.Name = "."
 	rr.OrigTtl = 0
 	rr.TypeCovered = 0
 	rr.Labels = 0

--- a/sig0.go
+++ b/sig0.go
@@ -21,14 +21,9 @@ func (rr *SIG) Sign(k crypto.Signer, m *Msg) ([]byte, error) {
 	if rr.KeyTag == 0 || len(rr.SignerName) == 0 || rr.Algorithm == 0 {
 		return nil, ErrKey
 	}
-	h := rr.Header()
-	h.Rrtype = TypeSIG
-	h.Class = ClassANY
-	h.Ttl = 0
-	h.Name = "."
-	rr.OrigTtl = 0
-	rr.TypeCovered = 0
-	rr.Labels = 0
+
+	rr.Hdr = RR_Header{Name: ".", Rrtype: TypeSIG, Class: ClassANY, Ttl: 0}
+	rr.OrigTtl, rr.TypeCovered, rr.Labels = 0, 0, 0
 
 	buf := make([]byte, m.Len()+Len(rr))
 	mbuf, err := m.PackBuffer(buf)

--- a/update.go
+++ b/update.go
@@ -44,7 +44,8 @@ func (u *Msg) RRsetUsed(rr []RR) {
 		u.Answer = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: r.Header().Name, Ttl: 0, Rrtype: r.Header().Rrtype, Class: ClassANY}})
+		h := r.Header()
+		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: h.Name, Ttl: 0, Rrtype: h.Rrtype, Class: ClassANY}})
 	}
 }
 
@@ -55,7 +56,8 @@ func (u *Msg) RRsetNotUsed(rr []RR) {
 		u.Answer = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: r.Header().Name, Ttl: 0, Rrtype: r.Header().Rrtype, Class: ClassNONE}})
+		h := r.Header()
+		u.Answer = append(u.Answer, &ANY{Hdr: RR_Header{Name: h.Name, Ttl: 0, Rrtype: h.Rrtype, Class: ClassNONE}})
 	}
 }
 
@@ -79,7 +81,8 @@ func (u *Msg) RemoveRRset(rr []RR) {
 		u.Ns = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		u.Ns = append(u.Ns, &ANY{Hdr: RR_Header{Name: r.Header().Name, Ttl: 0, Rrtype: r.Header().Rrtype, Class: ClassANY}})
+		h := r.Header()
+		u.Ns = append(u.Ns, &ANY{Hdr: RR_Header{Name: h.Name, Ttl: 0, Rrtype: h.Rrtype, Class: ClassANY}})
 	}
 }
 
@@ -99,8 +102,9 @@ func (u *Msg) Remove(rr []RR) {
 		u.Ns = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		r.Header().Class = ClassNONE
-		r.Header().Ttl = 0
+		h := r.Header()
+		h.Class = ClassNONE
+		h.Ttl = 0
 		u.Ns = append(u.Ns, r)
 	}
 }


### PR DESCRIPTION
Header is an interface method so there's non-zero overhead when calling it. This should be ever so slightly faster.