### PR TITLE
Use headerSize const instead of hardcoded 12

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -243,7 +243,7 @@ func IsSubDomain(parent, child string) bool {
 // The checking is performed on the binary payload.
 func IsMsg(buf []byte) error {
 	// Header
-	if len(buf) < 12 {
+	if len(buf) < headerSize {
 		return errors.New("dns: bad message header")
 	}
 	// Header: Opcode

--- a/msg.go
+++ b/msg.go
@@ -988,7 +988,7 @@ func (dns *Msg) Len() int {
 }
 
 func msgLenWithCompressionMap(dns *Msg, compression map[string]struct{}) int {
-	l := 12 // Message header is always 12 bytes
+	l := headerSize
 
 	for _, r := range dns.Question {
 		l += r.len(l, compression)

--- a/sig0.go
+++ b/sig0.go
@@ -103,7 +103,7 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 	anc := binary.BigEndian.Uint16(buf[6:])
 	auc := binary.BigEndian.Uint16(buf[8:])
 	adc := binary.BigEndian.Uint16(buf[10:])
-	offset := 12
+	offset := headerSize
 	var err error
 	for i := uint16(0); i < qdc && offset < buflen; i++ {
 		_, offset, err = UnpackDomainName(buf, offset)


### PR DESCRIPTION
This is cosmetic but makes the code clearer. There weren't many instances where the length had been hardcoded.