### PR TITLE
Remove pointless casts

### DIFF
--- a/client.go
+++ b/client.go
@@ -320,7 +320,7 @@ func (co *Conn) Read(p []byte) (n int, err error) {
 			return 0, err
 		}
 		if l > len(p) {
-			return int(l), io.ErrShortBuffer
+			return l, io.ErrShortBuffer
 		}
 		return tcpRead(r, p[:l])
 	}

--- a/dnssec.go
+++ b/dnssec.go
@@ -555,7 +555,7 @@ func (k *DNSKEY) publicKeyRSA() *rsa.PublicKey {
 
 	pubkey := new(rsa.PublicKey)
 
-	expo := uint64(0)
+	var expo uint64
 	for i := 0; i < int(explen); i++ {
 		expo <<= 8
 		expo |= uint64(keybuf[keyoff+i])

--- a/edns.go
+++ b/edns.go
@@ -183,7 +183,7 @@ func (e *EDNS0_NSID) pack() ([]byte, error) {
 // Option implements the EDNS0 interface.
 func (e *EDNS0_NSID) Option() uint16        { return EDNS0NSID } // Option returns the option code.
 func (e *EDNS0_NSID) unpack(b []byte) error { e.Nsid = hex.EncodeToString(b); return nil }
-func (e *EDNS0_NSID) String() string        { return string(e.Nsid) }
+func (e *EDNS0_NSID) String() string        { return e.Nsid }
 
 // EDNS0_SUBNET is the subnet option that is used to give the remote nameserver
 // an idea of where the client lives. See RFC 7871. It can then give back a different
@@ -411,7 +411,7 @@ func (e *EDNS0_LLQ) unpack(b []byte) error {
 
 func (e *EDNS0_LLQ) String() string {
 	s := strconv.FormatUint(uint64(e.Version), 10) + " " + strconv.FormatUint(uint64(e.Opcode), 10) +
-		" " + strconv.FormatUint(uint64(e.Error), 10) + " " + strconv.FormatUint(uint64(e.Id), 10) +
+		" " + strconv.FormatUint(uint64(e.Error), 10) + " " + strconv.FormatUint(e.Id, 10) +
 		" " + strconv.FormatUint(uint64(e.LeaseLife), 10)
 	return s
 }

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -177,14 +177,14 @@ func unpackUint8(msg []byte, off int) (i uint8, off1 int, err error) {
 	if off+1 > len(msg) {
 		return 0, len(msg), &Error{err: "overflow unpacking uint8"}
 	}
-	return uint8(msg[off]), off + 1, nil
+	return msg[off], off + 1, nil
 }
 
 func packUint8(i uint8, msg []byte, off int) (off1 int, err error) {
 	if off+1 > len(msg) {
 		return len(msg), &Error{err: "overflow packing uint8"}
 	}
-	msg[off] = byte(i)
+	msg[off] = i
 	return off + 1, nil
 }
 

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -399,7 +399,7 @@ func packStringTxt(s []string, msg []byte, off int) (int, error) {
 func unpackDataOpt(msg []byte, off int) ([]EDNS0, int, error) {
 	var edns []EDNS0
 Option:
-	code := uint16(0)
+	var code uint16
 	if off+4 > len(msg) {
 		return nil, len(msg), &Error{err: "overflow unpacking opt"}
 	}

--- a/scan.go
+++ b/scan.go
@@ -1173,8 +1173,7 @@ func typeToInt(token string) (uint16, bool) {
 
 // stringToTTL parses things like 2w, 2m, etc, and returns the time in seconds.
 func stringToTTL(token string) (uint32, bool) {
-	s := uint32(0)
-	i := uint32(0)
+	var s, i uint32
 	for _, c := range token {
 		switch c {
 		case 's', 'S':

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1399,7 +1399,7 @@ func setEUI64(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 	if e != nil {
 		return nil, &ParseError{f, "bad EUI68 Address", l}
 	}
-	rr.Address = uint64(i)
+	rr.Address = i
 	return rr, nil
 }
 

--- a/tsig.go
+++ b/tsig.go
@@ -113,13 +113,13 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 	var h hash.Hash
 	switch strings.ToLower(rr.Algorithm) {
 	case HmacMD5:
-		h = hmac.New(md5.New, []byte(rawsecret))
+		h = hmac.New(md5.New, rawsecret)
 	case HmacSHA1:
-		h = hmac.New(sha1.New, []byte(rawsecret))
+		h = hmac.New(sha1.New, rawsecret)
 	case HmacSHA256:
-		h = hmac.New(sha256.New, []byte(rawsecret))
+		h = hmac.New(sha256.New, rawsecret)
 	case HmacSHA512:
-		h = hmac.New(sha512.New, []byte(rawsecret))
+		h = hmac.New(sha512.New, rawsecret)
 	default:
 		return nil, "", ErrKeyAlg
 	}

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -32,7 +32,7 @@ func TestTsig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	binary.BigEndian.PutUint16(buf[0:2], uint16(42))
+	binary.BigEndian.PutUint16(buf[0:2], 42)
 	err = TsigVerify(buf, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
 	if err != nil {
 		t.Fatal(err)

--- a/xfr.go
+++ b/xfr.go
@@ -117,7 +117,7 @@ func (t *Transfer) inAxfr(q *Msg, c chan *Envelope) {
 }
 
 func (t *Transfer) inIxfr(q *Msg, c chan *Envelope) {
-	serial := uint32(0) // The first serial seen is the current server serial
+	var serial uint32 // The first serial seen is the current server serial
 	axfr := true
 	n := 0
 	qser := q.Ns[0].(*SOA).Serial


### PR DESCRIPTION
These were all caught with [gogrep](https://github.com/mvdan/gogrep) using a query like the following for each type:
```
gogrep -x '[]byte($x)' -x '$x' -a 'type([]byte)'
```