### PR TITLE
Test for escaped dots in IsFqdn

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -253,7 +253,18 @@ func IsMsg(buf []byte) error {
 
 // IsFqdn checks if a domain name is fully qualified.
 func IsFqdn(s string) bool {
-	return strings.HasSuffix(s, ".")
+	s2 := strings.TrimSuffix(s, ".")
+	if s == s2 {
+		return false
+	}
+
+	i := strings.LastIndexFunc(s2, func(r rune) bool {
+		return r != '\\'
+	})
+
+	// Test whether we have an even number of escape sequences before
+	// the dot or none.
+	return (len(s2)-i)%2 != 0
 }
 
 // IsRRset checks if a set of RRs is a valid RRset as defined by RFC 2181.

--- a/labels_test.go
+++ b/labels_test.go
@@ -174,6 +174,42 @@ func TestIsDomainName(t *testing.T) {
 	}
 }
 
+func TestIsFqdnEscaped(t *testing.T) {
+	for s, expect := range map[string]bool{
+		".":                  true,
+		"\\.":                false,
+		"\\\\.":              true,
+		"\\\\\\.":            false,
+		"\\\\\\\\.":          true,
+		"a.":                 true,
+		"a\\.":               false,
+		"a\\\\.":             true,
+		"a\\\\\\.":           false,
+		"ab.":                true,
+		"ab\\.":              false,
+		"ab\\\\.":            true,
+		"ab\\\\\\.":          false,
+		"..":                 true,
+		".\\.":               false,
+		".\\\\.":             true,
+		".\\\\\\.":           false,
+		"example.org.":       true,
+		"example.org\\.":     false,
+		"example.org\\\\.":   true,
+		"example.org\\\\\\.": false,
+		"example\\.org.":     true,
+		"example\\\\.org.":   true,
+		"example\\\\\\.org.": true,
+		"\\example.org.":     true,
+		"\\\\example.org.":   true,
+		"\\\\\\example.org.": true,
+	} {
+		if got := IsFqdn(s); got != expect {
+			t.Errorf("IsFqdn(%q) = %t, expected %t", s, got, expect)
+		}
+	}
+}
+
 func BenchmarkSplitLabels(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Split("www.example.com.")


### PR DESCRIPTION
This catches situations where the final dot in a name is actually escaped. This was causing problems when packing these domain names.

Fixes #851