### PR TITLE
RFC 1996 allows SOA in answer in notify

### DIFF
--- a/acceptfunc.go
+++ b/acceptfunc.go
@@ -45,7 +45,7 @@ func defaultMsgAcceptFunc(dh Header) MsgAcceptAction {
 	if dh.Ancount > 1 {
 		return MsgReject
 	}
-	// IXFR request could have one SOA RR in the NS section. See RFC 1995, section 3
+	// IXFR request could have one SOA RR in the NS section. See RFC 1995, section 3.
 	if dh.Nscount > 1 {
 		return MsgReject
 	}

--- a/acceptfunc.go
+++ b/acceptfunc.go
@@ -10,7 +10,7 @@ type MsgAcceptFunc func(dh Header) MsgAcceptAction
 // * opcode isn't OpcodeQuery or OpcodeNotify
 // * Zero bit isn't zero
 // * has more than 1 question in the question section
-// * has more than 0 RRs in the Answer section
+// * has more than 1 RR in the Answer section
 // * has more than 0 RRs in the Authority section
 // * has more than 2 RRs in the Additional section
 var DefaultMsgAcceptFunc MsgAcceptFunc = defaultMsgAcceptFunc
@@ -41,11 +41,11 @@ func defaultMsgAcceptFunc(dh Header) MsgAcceptAction {
 	if dh.Qdcount != 1 {
 		return MsgReject
 	}
-	if dh.Ancount != 0 {
+	// NOTIFY requests can have a SOA in the ANSWER section. See RFC 1996 Section 3.7 and 3.11.
+	if dh.Ancount > 1 {
 		return MsgReject
 	}
-	// IXFR request could have one SOA RR in the NS section
-	// RFC 1995, section 3
+	// IXFR request could have one SOA RR in the NS section. See RFC 1995, section 3
 	if dh.Nscount > 1 {
 		return MsgReject
 	}

--- a/acceptfunc_test.go
+++ b/acceptfunc_test.go
@@ -1,0 +1,35 @@
+package dns
+
+import (
+	"testing"
+)
+
+func TestAcceptNotify(t *testing.T) {
+	HandleFunc("example.org.", handleNotify)
+	s, addrstr, err := RunLocalUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(Msg)
+	m.SetNotify("example.org.")
+	// Set a SOA hint in the answer section, this is allowed according to RFC 1996.
+	soa, _ := NewRR("example.org. IN SOA sns.dns.icann.org. noc.dns.icann.org. 2018112827 7200 3600 1209600 3600")
+	m.Answer = []RR{soa}
+
+	c := new(Client)
+	resp, _, err := c.Exchange(m, addrstr)
+	if err != nil {
+		t.Errorf("failed to exchange: %v", err)
+	}
+	if resp.Rcode != RcodeSuccess {
+		t.Errorf("expected %s, got %s", RcodeToString[RcodeSuccess], RcodeToString[resp.Rcode])
+	}
+}
+
+func handleNotify(w ResponseWriter, req *Msg) {
+	m := new(Msg)
+	m.SetReply(req)
+	w.WriteMsg(m)
+}


### PR DESCRIPTION
The answer section of a notify can contain a SOA record that we should
not ignore in the DefaultAcceptFunc.