### PR TITLE
Ignore empty lines when parsing private keys

### DIFF
--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -322,6 +322,11 @@ func (kl *klexer) Next() (lex, bool) {
 				commt = false
 			}
 
+			if kl.key && str.Len() == 0 {
+				// ignore empty lines
+				break
+			}
+
 			kl.key = true
 
 			l.value = zValue


### PR DESCRIPTION
When migrating zones to CoreDNS, it did not accept private key files
the former bind setup gracefully accepted. It turned out they had a
trailing newline for whateveer reason. The dns library should handle
them gracefully, too.