### PR TITLE
Fix String formatting of RP record

### DIFF
--- a/types.go
+++ b/types.go
@@ -404,7 +404,7 @@ type RP struct {
 }
 
 func (rr *RP) String() string {
-	return rr.Hdr.String() + rr.Mbox + " " + sprintTxt([]string{rr.Txt})
+	return rr.Hdr.String() + sprintName(rr.Mbox) + " " + sprintName(rr.Txt)
 }
 
 // SOA RR. See RFC 1035.

--- a/types_test.go
+++ b/types_test.go
@@ -100,6 +100,29 @@ func TestSprintTxt(t *testing.T) {
 	}
 }
 
+func TestRPStringer(t *testing.T) {
+	rp := &RP{
+		Hdr: RR_Header{
+			Name:   "test.example.com.",
+			Rrtype: TypeRP,
+			Class:  ClassINET,
+			Ttl:    600,
+		},
+		Mbox: "\x05first.example.com.",
+		Txt:  "second.\x07example.com.",
+	}
+
+	const expected = "test.example.com.\t600\tIN\tRP\t\\005first.example.com. second.\\007example.com."
+	if rp.String() != expected {
+		t.Errorf("expected %v, got %v", expected, rp)
+	}
+
+	_, err := NewRR(rp.String())
+	if err != nil {
+		t.Fatalf("error parsing %q: %v", rp, err)
+	}
+}
+
 func BenchmarkSprintName(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		got := sprintName("abc\\.def\007\"\127@\255\x05\xef\\")


### PR DESCRIPTION
This fixes the `String` formatting of RP records. The use of `sprintName` is consistent with other `String` functions in `types.go`.

Fixes #913 

/cc @paulf69487623