### PR TITLE
Add go1.12 to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 go:
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - tip
 
 before_install:


### PR DESCRIPTION
This adds the newly released go1.12 to the Travis build.

Do we still intend to support go1.10 or would you like that removed @miekg?