### PR TITLE
Add interface SessionUDP to make UDP handling extensible.

### DIFF
--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ func (f HandlerFunc) ServeDNS(w ResponseWriter, r *Msg) {
 // A ResponseWriter interface is used by an DNS handler to
 // construct an DNS response.
 type ResponseWriter interface {
-	// LocalAddr returns the net.Addr of the server
+	// LocalAddr returns the net.Addr of the server for the current request.
 	LocalAddr() net.Addr
 	// RemoteAddr returns the net.Addr of the client that sent the current request.
 	RemoteAddr() net.Addr
@@ -809,7 +809,7 @@ func (w *response) Write(m []byte) (int, error) {
 func (w *response) LocalAddr() net.Addr {
 	switch {
 	case w.udp != nil:
-		return w.udp.LocalAddr()
+		return w.udpSession.LocalAddr()
 	case w.tcp != nil:
 		return w.tcp.LocalAddr()
 	default:

--- a/server.go
+++ b/server.go
@@ -289,10 +289,6 @@ func (srv *Server) spawnWorker(w *response) {
 	}
 }
 
-func (srv *Server) makeSessionUDP() interface{} {
-	return srv.SessionUDPFactory.CreateSessionUDP(srv.UDPSize)
-}
-
 func (srv *Server) init() {
 	srv.queue = make(chan *response)
 
@@ -309,7 +305,11 @@ func (srv *Server) init() {
 		srv.SessionUDPFactory = defaultSessionUDPFactory
 	}
 
-	srv.udpPool.New = srv.makeSessionUDP
+	udpFactory := srv.SessionUDPFactory
+	udpSize := srv.UDPSize
+	srv.udpPool.New = func () interface{} {
+		return udpFactory.CreateSessionUDP(udpSize)
+	}
 }
 
 func unlockOnce(l sync.Locker) func() {

--- a/server.go
+++ b/server.go
@@ -90,7 +90,7 @@ type response struct {
 	tsigSecret     map[string]string // the tsig secrets
 	udp            *net.UDPConn      // i/o connection if UDP was used
 	tcp            net.Conn          // i/o connection if TCP was used
-	udpSession     *SessionUDP       // oob data to get egress interface right
+	udpSession     SessionUDP        // UDP request context to get egress interface right
 	writer         Writer            // writer to output the raw DNS bits
 	wg             *sync.WaitGroup   // for gracefull shutdown
 }
@@ -153,6 +153,7 @@ type Reader interface {
 	ReadTCP(conn net.Conn, timeout time.Duration) ([]byte, error)
 	// ReadUDP reads a raw message from a UDP connection. Implementations may alter
 	// connection properties, for example the read-deadline.
+	// Returns a pointer to the SessionUDP interface for backwards compatibility
 	ReadUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *SessionUDP, error)
 }
 
@@ -217,6 +218,9 @@ type Server struct {
 	// AcceptMsgFunc will check the incoming message and will reject it early in the process.
 	// By default DefaultMsgAcceptFunc will be used.
 	MsgAcceptFunc MsgAcceptFunc
+	// SessionUDPFactory creates SessionUDP instances. The default implementation will be
+	// used if nil.
+	SessionUDPFactory SessionUDPFactory
 
 	// UDP packet or TCP connection queue
 	queue chan *response
@@ -285,10 +289,8 @@ func (srv *Server) spawnWorker(w *response) {
 	}
 }
 
-func makeUDPBuffer(size int) func() interface{} {
-	return func() interface{} {
-		return make([]byte, size)
-	}
+func (srv *Server) makeSessionUDP() interface{} {
+	return srv.SessionUDPFactory.CreateSessionUDP(srv.UDPSize)
 }
 
 func (srv *Server) init() {
@@ -303,8 +305,11 @@ func (srv *Server) init() {
 	if srv.MsgAcceptFunc == nil {
 		srv.MsgAcceptFunc = defaultMsgAcceptFunc
 	}
+	if srv.SessionUDPFactory == nil {
+		srv.SessionUDPFactory = defaultSessionUDPFactory
+	}
 
-	srv.udpPool.New = makeUDPBuffer(srv.UDPSize)
+	srv.udpPool.New = srv.makeSessionUDP
 }
 
 func unlockOnce(l sync.Locker) func() {
@@ -360,7 +365,7 @@ func (srv *Server) ListenAndServe() error {
 			return err
 		}
 		u := l.(*net.UDPConn)
-		if e := setUDPSocketOptions(u); e != nil {
+		if e := srv.SessionUDPFactory.InitConn(u); e != nil {
 			return e
 		}
 		srv.PacketConn = l
@@ -391,7 +396,7 @@ func (srv *Server) ActivateAndServe() error {
 		// Check PacketConn interface's type is valid and value
 		// is not nil
 		if t, ok := pConn.(*net.UDPConn); ok && t != nil {
-			if e := setUDPSocketOptions(t); e != nil {
+			if e := srv.SessionUDPFactory.InitConn(t); e != nil {
 				return e
 			}
 			srv.started = true
@@ -542,8 +547,8 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 			return err
 		}
 		if len(m) < headerSize {
-			if cap(m) == srv.UDPSize {
-				srv.udpPool.Put(m[:srv.UDPSize])
+			if s != nil && (*s) != nil {
+				srv.udpPool.Put((*s).Clear())
 			}
 			continue
 		}
@@ -552,7 +557,7 @@ func (srv *Server) serveUDP(l *net.UDPConn) error {
 			msg:        m,
 			tsigSecret: srv.TsigSecret,
 			udp:        l,
-			udpSession: s,
+			udpSession: *s,
 			wg:         &wg,
 		})
 	}
@@ -625,8 +630,8 @@ func (srv *Server) serve(w *response) {
 }
 
 func (srv *Server) disposeBuffer(w *response) {
-	if w.udp != nil && cap(w.msg) == srv.UDPSize {
-		srv.udpPool.Put(w.msg[:srv.UDPSize])
+	if w.udpSession != nil {
+		srv.udpPool.Put(w.udpSession.Clear())
 	}
 	w.msg = nil
 }
@@ -677,14 +682,13 @@ func (srv *Server) serveDNS(w *response) {
 		}
 	}
 
-	srv.disposeBuffer(w)
-
 	handler := srv.Handler
 	if handler == nil {
 		handler = DefaultServeMux
 	}
 
 	handler.ServeDNS(w, req) // Writes back to the client
+	srv.disposeBuffer(w)
 }
 
 func (srv *Server) readTCP(conn net.Conn, timeout time.Duration) ([]byte, error) {
@@ -739,14 +743,13 @@ func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *S
 	}
 	srv.lock.RUnlock()
 
-	m := srv.udpPool.Get().([]byte)
-	n, s, err := ReadFromSessionUDP(conn, m)
+	s := srv.udpPool.Get().(SessionUDP)
+	m, err := s.ReadRequest(conn)
 	if err != nil {
-		srv.udpPool.Put(m)
+		srv.udpPool.Put(s.Clear())
 		return nil, nil, err
 	}
-	m = m[:n]
-	return m, s, nil
+	return m, &s, nil
 }
 
 // WriteMsg implements the ResponseWriter.WriteMsg method.
@@ -781,8 +784,8 @@ func (w *response) Write(m []byte) (int, error) {
 	}
 
 	switch {
-	case w.udp != nil:
-		return WriteToSessionUDP(w.udp, m, w.udpSession)
+	case w.udpSession != nil:
+		return w.udpSession.WriteResponse(m)
 	case w.tcp != nil:
 		lm := len(m)
 		if lm < 2 {

--- a/udp.go
+++ b/udp.go
@@ -9,6 +9,32 @@ import (
 	"golang.org/x/net/ipv6"
 )
 
+type SessionUDPFactory interface {
+	// InitConn set's up 'conn' to be used with a SessionUDP.
+	// Must be called before 'conn' is passed to SessionUDP.ReadRequest()
+	InitConn(conn *net.UDPConn) error
+
+	// CreateSessionUDP creates a SessionUDP object which can manage the state
+	// of a single UDP transaction at a time.
+	// Multiple SessionUDP objects may be created on the same underlying 'conn' by
+	// calling this multiple times with the same 'conn'.
+	CreateSessionUDP(msgSize int) SessionUDP
+}
+
+// SessionUDP holds manages a UDP Request/Response transaction.
+type SessionUDP interface {
+	// Clear re-initializes SessionUDP to the same state it was when new.
+	// This is required to enable pooling.
+	Clear() SessionUDP
+	// ReadRequest reads a single request from the UDPSession
+	ReadRequest(conn *net.UDPConn) ([]byte, error)
+	// RemoteAddr returns the remote address of the last read UDP request
+	RemoteAddr() net.Addr
+	// WriteResponse writes a response to the last read UDP request.
+	// The response is sent to the UDP address the request came from.
+	WriteResponse(b []byte) (int, error)
+}
+
 // This is the required size of the OOB buffer to pass to ReadMsgUDP.
 var udpOOBSize = func() int {
 	// We can't know whether we'll get an IPv4 control message or an
@@ -25,35 +51,27 @@ var udpOOBSize = func() int {
 	return len(oob6)
 }()
 
-// SessionUDP holds the remote address and the associated
+// sessionUDP implements the SessionUDP, holding the remote address and the associated
 // out-of-band data.
-type SessionUDP struct {
-	raddr   *net.UDPAddr
-	context []byte
+type sessionUDP struct {
+	conn  *net.UDPConn
+	raddr *net.UDPAddr
+	m     []byte
+	oob   []byte
 }
 
-// RemoteAddr returns the remote network address.
-func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
+type sessionUDPFactory struct{}
 
-// ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
-// net.UDPAddr.
-func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
-	oob := make([]byte, udpOOBSize)
-	n, oobn, _, raddr, err := conn.ReadMsgUDP(b, oob)
-	if err != nil {
-		return n, nil, err
+var defaultSessionUDPFactory *sessionUDPFactory
+
+func (f *sessionUDPFactory) CreateSessionUDP(msgSize int) SessionUDP {
+	return &sessionUDP{
+		m:   make([]byte, msgSize),
+		oob: make([]byte, udpOOBSize),
 	}
-	return n, &SessionUDP{raddr, oob[:oobn]}, err
 }
 
-// WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
-func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
-	oob := correctSource(session.context)
-	n, _, err := conn.WriteMsgUDP(b, oob, session.raddr)
-	return n, err
-}
-
-func setUDPSocketOptions(conn *net.UDPConn) error {
+func (s *sessionUDPFactory) InitConn(conn *net.UDPConn) error {
 	// Try setting the flags for both families and ignore the errors unless they
 	// both error.
 	err6 := ipv6.NewPacketConn(conn).SetControlMessage(ipv6.FlagDst|ipv6.FlagInterface, true)
@@ -62,6 +80,38 @@ func setUDPSocketOptions(conn *net.UDPConn) error {
 		return err4
 	}
 	return nil
+}
+
+// Clear re-initializes sessionUDP to the same state it was when new.
+// Returns the interface for convenience.
+func (s *sessionUDP) Clear() SessionUDP {
+	s.conn = nil
+	s.raddr = nil
+	s.m = s.m[:cap(s.m)]
+	s.oob = s.oob[:cap(s.oob)]
+	return s
+}
+
+// RemoteAddr returns the remote network address.
+func (s *sessionUDP) RemoteAddr() net.Addr { return s.raddr }
+
+// ReadRequest reads a single request from the session and keeps the request context
+func (s *sessionUDP) ReadRequest(conn *net.UDPConn) ([]byte, error) {
+	n, oobn, _, raddr, err := conn.ReadMsgUDP(s.m, s.oob)
+	if err == nil {
+		s.conn = conn
+		s.raddr = raddr
+		s.m = s.m[:n]        // Re-slice to the actual size
+		s.oob = s.oob[:oobn] // Re-slice to the actual size
+	}
+	return s.m, err
+}
+
+// WriteResponse writes a response to a request received earlier
+func (s *sessionUDP) WriteResponse(b []byte) (int, error) {
+	oob := correctSource(s.oob)
+	n, _, err := s.conn.WriteMsgUDP(b, oob, s.raddr)
+	return n, err
 }
 
 // parseDstFromOOB takes oob data and returns the destination IP.

--- a/udp.go
+++ b/udp.go
@@ -30,6 +30,8 @@ type SessionUDP interface {
 	ReadRequest(conn *net.UDPConn) ([]byte, error)
 	// RemoteAddr returns the remote address of the last read UDP request
 	RemoteAddr() net.Addr
+	// LocalAddr returns the local address of the last read UDP request
+	LocalAddr() net.Addr
 	// WriteResponse writes a response to the last read UDP request.
 	// The response is sent to the UDP address the request came from.
 	WriteResponse(b []byte) (int, error)
@@ -92,8 +94,11 @@ func (s *sessionUDP) Clear() SessionUDP {
 	return s
 }
 
-// RemoteAddr returns the remote network address.
+// RemoteAddr returns the remote network address for the current request.
 func (s *sessionUDP) RemoteAddr() net.Addr { return s.raddr }
+
+// LocalAddr returns the local network address for the current request.
+func (s *sessionUDP) LocalAddr() net.Addr { return s.conn.LocalAddr() }
 
 // ReadRequest reads a single request from the session and keeps the request context
 func (s *sessionUDP) ReadRequest(conn *net.UDPConn) ([]byte, error) {


### PR DESCRIPTION
Change `SessionUDP` from a struct to an interface to allow extensible implementations for it. The current implementation is kept as the default (via `struct sessionUDP`). A new field (`SessionUDPFactory`) is added to `Server` though which the user can specify their own factory for `SessionUDP` implementations.

The pooling of UDP buffers is replaced with pooling of `SessionUDP` instances. This removes the need to dynamically allocate the buffer for OOB data for each request.

Extension of the current `SessionUDP` functionality is needed for implementation of Linux TPROXY (transparent proxy) support for the UDP requests. Without going into too much detail here, UDP support for TPROXY requires additional sockets (for responding) and extensions to the control messages being passed via the UDP OOB data.

Unfortunately the required Linux specific control message types are not supported by go libraries, so any implementation of Linux TPROXY needs to replicate some of the control message parsing and serialization code.

An example of use of this new abstraction can be seen [here](https://github.com/cilium/cilium/blob/pr/redirect-with-tproxy/pkg/fqdn/dnsproxy/udp.go).

`ReadUDP()` of the `Reader` interface now returns a pointer to the `SessionUDP` interface instead of the old `SessionUDP` struct. This is strictly speaking not necessary but makes this change backwards compatible with the existing code as this way there is no change in `ReadUDP()` signature. Note that the old `SessionUDP` struct only contained private members, so this change should not be affecting any existing source code.
