### PR TITLE
corrected default value of Server.MsgAcceptFunc as documented

### DIFF
--- a/server.go
+++ b/server.go
@@ -301,7 +301,7 @@ func (srv *Server) init() {
 		srv.UDPSize = MinMsgSize
 	}
 	if srv.MsgAcceptFunc == nil {
-		srv.MsgAcceptFunc = defaultMsgAcceptFunc
+		srv.MsgAcceptFunc = DefaultMsgAcceptFunc
 	}
 
 	srv.udpPool.New = makeUDPBuffer(srv.UDPSize)


### PR DESCRIPTION
the description states

	// By default DefaultMsgAcceptFunc will be used.

but actually defaultMsgAcceptFunc (not visible outside of the package) was used.

At least the description and code should be consistent.  The proposed change assumes the description is correct.