### PR TITLE
ZoneParser: error on parsing an IPv6 address in an A record

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -233,7 +233,7 @@ func BenchmarkUnpackMX(b *testing.B) {
 }
 
 func BenchmarkPackAAAAA(b *testing.B) {
-	aaaa := testRR(". IN A ::1")
+	aaaa := testRR(". IN AAAA ::1")
 
 	buf := make([]byte, Len(aaaa))
 	b.ReportAllocs()
@@ -244,7 +244,7 @@ func BenchmarkPackAAAAA(b *testing.B) {
 }
 
 func BenchmarkUnpackAAAA(b *testing.B) {
-	aaaa := testRR(". IN A ::1")
+	aaaa := testRR(". IN AAAA ::1")
 
 	buf := make([]byte, Len(aaaa))
 	PackRR(aaaa, buf, 0, nil, false)

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -133,7 +133,8 @@ func (rr *A) parse(c *zlexer, o, f string) *ParseError {
 	}
 
 	rr.A = net.ParseIP(l.token)
-	if rr.A == nil || l.err {
+	isIPv6 := strings.Contains(l.token, ":")
+	if rr.A == nil || isIPv6 || l.err {
 		return &ParseError{f, "bad A A", l}
 	}
 	return slurpRemainder(c, f)
@@ -146,7 +147,8 @@ func (rr *AAAA) parse(c *zlexer, o, f string) *ParseError {
 	}
 
 	rr.AAAA = net.ParseIP(l.token)
-	if rr.AAAA == nil || l.err {
+	isIPv6 := strings.Contains(l.token, ":")
+	if rr.AAAA == nil || !isIPv6 || l.err {
 		return &ParseError{f, "bad AAAA AAAA", l}
 	}
 	return slurpRemainder(c, f)

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -133,8 +133,12 @@ func (rr *A) parse(c *zlexer, o, f string) *ParseError {
 	}
 
 	rr.A = net.ParseIP(l.token)
-	isIPv6 := strings.Contains(l.token, ":")
-	if rr.A == nil || isIPv6 || l.err {
+	// IPv4 addresses cannot include ":".
+	// We do this rather than use net.IP's To4() because
+	// To4() treats IPv4-mapped IPv6 addresses as being
+	// IPv4.
+	isIPv4 := !strings.Contains(l.token, ":")
+	if rr.A == nil || !isIPv4 || l.err {
 		return &ParseError{f, "bad A A", l}
 	}
 	return slurpRemainder(c, f)
@@ -147,6 +151,8 @@ func (rr *AAAA) parse(c *zlexer, o, f string) *ParseError {
 	}
 
 	rr.AAAA = net.ParseIP(l.token)
+	// IPv6 addresses must include ":", and IPv4
+	// addresses cannot include ":".
 	isIPv6 := strings.Contains(l.token, ":")
 	if rr.AAAA == nil || !isIPv6 || l.err {
 		return &ParseError{f, "bad AAAA AAAA", l}

--- a/scan_test.go
+++ b/scan_test.go
@@ -121,6 +121,59 @@ func TestZoneParserIncludeDisallowed(t *testing.T) {
 	}
 }
 
+func TestZoneParserAddressAAAA(t *testing.T) {
+	zone := `
+1.example.org. 600 IN AAAA ::1
+2.example.org. 600 IN AAAA ::FFFF:127.0.0.1`
+
+	wantRRs := []*AAAA{
+		&AAAA{Hdr: RR_Header{Name: "1.example.org."}, AAAA: net.IPv6loopback},
+		&AAAA{Hdr: RR_Header{Name: "2.example.org."}, AAAA: net.ParseIP("::FFFF:127.0.0.1")},
+	}
+
+	wantIdx := 0
+	zp := NewZoneParser(strings.NewReader(zone), "", "")
+	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
+		if wantIdx >= len(wantRRs) {
+			t.Fatalf("expected %d RRs, but got more", len(wantRRs))
+		}
+		if got, want := rr.Header().Name, wantRRs[wantIdx].Header().Name; got != want {
+			t.Fatalf("expected name %s, but got %s", want, got)
+		}
+		aaaa, ok := rr.(*AAAA)
+		if !ok {
+			t.Fatalf("expected *AAAA RR, but got %T", aaaa)
+		}
+		if got, want := aaaa.AAAA, wantRRs[wantIdx].AAAA; !got.Equal(want) {
+			t.Fatalf("expected AAAA with IP %v, but got %v", got, want)
+		}
+		wantIdx++
+	}
+
+	if wantIdx != len(wantRRs) {
+		t.Errorf("too few records, expected %d, got %d", len(wantRRs), wantIdx)
+	}
+}
+
+func TestZoneParserAddressBad(t *testing.T) {
+	zones := []string{
+		"1.bad.example.org. 600 IN A ::1",
+		"2.bad.example.org. 600 IN A ::FFFF:127.0.0.1",
+		"3.bad.example.org. 600 IN AAAA 127.0.0.1",
+	}
+
+	for _, zone := range zones {
+		zp := NewZoneParser(strings.NewReader(zone), "", "")
+		for _, ok := zp.Next(); ok; _, ok = zp.Next() {
+		}
+
+		const expect = "bad A"
+		if err := zp.Err(); err == nil || !strings.Contains(err.Error(), expect) {
+			t.Errorf("expected error to contain %q, got %v", expect, err)
+		}
+	}
+}
+
 func TestParseTA(t *testing.T) {
 	rr, err := NewRR(` Ta 0 0 0`)
 	if err != nil {


### PR DESCRIPTION
And vice versa for IPv4 with AAAA.

The implementation of isIPv6 is inspired by https://github.com/golang/go/blob/e341bae08d75611adea6566c1d01c1e3a0de57f9/src/net/ip.go#L678-L681 .