### PR TITLE
Correct Close() check in Server.serve

### DIFF
--- a/server.go
+++ b/server.go
@@ -523,7 +523,7 @@ func (srv *Server) serve(w *response, wg *sync.WaitGroup) {
 			break
 		}
 		srv.serveDNS(w)
-		if w.tcp == nil {
+		if w.closed {
 			break // Close() was called
 		}
 		if w.hijacked {


### PR DESCRIPTION
This was changed in #808, but I missed this function. Apparently no one noticed, I'm not sure how this hasn't been caught :man_shrugging:.