### PR TITLE
Use for range loops instead of manual for loops

### DIFF
--- a/clientconfig.go
+++ b/clientconfig.go
@@ -68,14 +68,10 @@ func ClientConfigFromReader(resolvconf io.Reader) (*ClientConfig, error) {
 			}
 
 		case "search": // set search path to given servers
-			c.Search = make([]string, len(f)-1)
-			for i := 0; i < len(c.Search); i++ {
-				c.Search[i] = f[i+1]
-			}
+			c.Search = append([]string(nil), f[1:]...)
 
 		case "options": // magic options
-			for i := 1; i < len(f); i++ {
-				s := f[i]
+			for _, s := range f[1:] {
 				switch {
 				case len(s) >= 6 && s[:6] == "ndots:":
 					n, _ := strconv.Atoi(s[6:])

--- a/dnssec.go
+++ b/dnssec.go
@@ -556,9 +556,9 @@ func (k *DNSKEY) publicKeyRSA() *rsa.PublicKey {
 	pubkey := new(rsa.PublicKey)
 
 	var expo uint64
-	for i := 0; i < int(explen); i++ {
+	for _, v := range keybuf[keyoff:modoff] {
 		expo <<= 8
-		expo |= uint64(keybuf[keyoff+i])
+		expo |= uint64(v)
 	}
 	if expo > 1<<31-1 {
 		// Larger exponent than supported by the crypto package.

--- a/dnssec.go
+++ b/dnssec.go
@@ -556,6 +556,7 @@ func (k *DNSKEY) publicKeyRSA() *rsa.PublicKey {
 	pubkey := new(rsa.PublicKey)
 
 	var expo uint64
+	// The exponent of length explen is between keyoff and modoff.
 	for _, v := range keybuf[keyoff:modoff] {
 		expo <<= 8
 		expo |= uint64(v)

--- a/edns.go
+++ b/edns.go
@@ -80,9 +80,9 @@ func (rr *OPT) String() string {
 
 func (rr *OPT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	for i := 0; i < len(rr.Option); i++ {
+	for _, o := range rr.Option {
 		l += 4 // Account for 2-byte option code and 2-byte option length.
-		lo, _ := rr.Option[i].pack()
+		lo, _ := o.pack()
 		l += len(lo)
 	}
 	return l
@@ -453,11 +453,11 @@ func (e *EDNS0_DAU) unpack(b []byte) error { e.AlgCode = b; return nil }
 
 func (e *EDNS0_DAU) String() string {
 	s := ""
-	for i := 0; i < len(e.AlgCode); i++ {
-		if a, ok := AlgorithmToString[e.AlgCode[i]]; ok {
+	for _, alg := range e.AlgCode {
+		if a, ok := AlgorithmToString[alg]; ok {
 			s += " " + a
 		} else {
-			s += " " + strconv.Itoa(int(e.AlgCode[i]))
+			s += " " + strconv.Itoa(int(alg))
 		}
 	}
 	return s
@@ -477,11 +477,11 @@ func (e *EDNS0_DHU) unpack(b []byte) error { e.AlgCode = b; return nil }
 
 func (e *EDNS0_DHU) String() string {
 	s := ""
-	for i := 0; i < len(e.AlgCode); i++ {
-		if a, ok := HashToString[e.AlgCode[i]]; ok {
+	for _, alg := range e.AlgCode {
+		if a, ok := HashToString[alg]; ok {
 			s += " " + a
 		} else {
-			s += " " + strconv.Itoa(int(e.AlgCode[i]))
+			s += " " + strconv.Itoa(int(alg))
 		}
 	}
 	return s
@@ -502,11 +502,11 @@ func (e *EDNS0_N3U) unpack(b []byte) error { e.AlgCode = b; return nil }
 func (e *EDNS0_N3U) String() string {
 	// Re-use the hash map
 	s := ""
-	for i := 0; i < len(e.AlgCode); i++ {
-		if a, ok := HashToString[e.AlgCode[i]]; ok {
+	for _, alg := range e.AlgCode {
+		if a, ok := HashToString[alg]; ok {
 			s += " " + a
 		} else {
-			s += " " + strconv.Itoa(int(e.AlgCode[i]))
+			s += " " + strconv.Itoa(int(alg))
 		}
 	}
 	return s

--- a/labels.go
+++ b/labels.go
@@ -28,9 +28,7 @@ func SplitDomainName(s string) (labels []string) {
 	case 1:
 		// no-op
 	default:
-		end := 0
-		for i := 1; i < len(idx); i++ {
-			end = idx[i]
+		for _, end := range idx[1:] {
 			labels = append(labels, s[begin:end-1])
 			begin = end
 		}

--- a/msg.go
+++ b/msg.go
@@ -429,8 +429,8 @@ Loop:
 			if budget <= 0 {
 				return "", lenmsg, ErrLongDomain
 			}
-			for j := off; j < off+c; j++ {
-				switch b := msg[j]; b {
+			for _, b := range msg[off : off+c] {
+				switch b {
 				case '.', '(', ')', ';', ' ', '@':
 					fallthrough
 				case '"', '\\':
@@ -489,11 +489,11 @@ func packTxt(txt []string, msg []byte, offset int, tmp []byte) (int, error) {
 		return offset, nil
 	}
 	var err error
-	for i := range txt {
-		if len(txt[i]) > len(tmp) {
+	for _, s := range txt {
+		if len(s) > len(tmp) {
 			return offset, ErrBuf
 		}
-		offset, err = packTxtString(txt[i], msg, offset, tmp)
+		offset, err = packTxtString(s, msg, offset, tmp)
 		if err != nil {
 			return offset, err
 		}
@@ -934,31 +934,31 @@ func (dns *Msg) String() string {
 	s += "ADDITIONAL: " + strconv.Itoa(len(dns.Extra)) + "\n"
 	if len(dns.Question) > 0 {
 		s += "\n;; QUESTION SECTION:\n"
-		for i := 0; i < len(dns.Question); i++ {
-			s += dns.Question[i].String() + "\n"
+		for _, r := range dns.Question {
+			s += r.String() + "\n"
 		}
 	}
 	if len(dns.Answer) > 0 {
 		s += "\n;; ANSWER SECTION:\n"
-		for i := 0; i < len(dns.Answer); i++ {
-			if dns.Answer[i] != nil {
-				s += dns.Answer[i].String() + "\n"
+		for _, r := range dns.Answer {
+			if r != nil {
+				s += r.String() + "\n"
 			}
 		}
 	}
 	if len(dns.Ns) > 0 {
 		s += "\n;; AUTHORITY SECTION:\n"
-		for i := 0; i < len(dns.Ns); i++ {
-			if dns.Ns[i] != nil {
-				s += dns.Ns[i].String() + "\n"
+		for _, r := range dns.Ns {
+			if r != nil {
+				s += r.String() + "\n"
 			}
 		}
 	}
 	if len(dns.Extra) > 0 {
 		s += "\n;; ADDITIONAL SECTION:\n"
-		for i := 0; i < len(dns.Extra); i++ {
-			if dns.Extra[i] != nil {
-				s += dns.Extra[i].String() + "\n"
+		for _, r := range dns.Extra {
+			if r != nil {
+				s += r.String() + "\n"
 			}
 		}
 	}

--- a/msg.go
+++ b/msg.go
@@ -1091,33 +1091,20 @@ func (dns *Msg) CopyTo(r1 *Msg) *Msg {
 	}
 
 	rrArr := make([]RR, len(dns.Answer)+len(dns.Ns)+len(dns.Extra))
-	var rri int
+	r1.Answer, rrArr = rrArr[:0:len(dns.Answer)], rrArr[len(dns.Answer):]
+	r1.Ns, rrArr = rrArr[:0:len(dns.Ns)], rrArr[len(dns.Ns):]
+	r1.Extra = rrArr[:0:len(dns.Extra)]
 
-	if len(dns.Answer) > 0 {
-		rrbegin := rri
-		for i := 0; i < len(dns.Answer); i++ {
-			rrArr[rri] = dns.Answer[i].copy()
-			rri++
-		}
-		r1.Answer = rrArr[rrbegin:rri:rri]
+	for _, r := range dns.Answer {
+		r1.Answer = append(r1.Answer, r.copy())
 	}
 
-	if len(dns.Ns) > 0 {
-		rrbegin := rri
-		for i := 0; i < len(dns.Ns); i++ {
-			rrArr[rri] = dns.Ns[i].copy()
-			rri++
-		}
-		r1.Ns = rrArr[rrbegin:rri:rri]
+	for _, r := range dns.Ns {
+		r1.Ns = append(r1.Ns, r.copy())
 	}
 
-	if len(dns.Extra) > 0 {
-		rrbegin := rri
-		for i := 0; i < len(dns.Extra); i++ {
-			rrArr[rri] = dns.Extra[i].copy()
-			rri++
-		}
-		r1.Extra = rrArr[rrbegin:rri:rri]
+	for _, r := range dns.Extra {
+		r1.Extra = append(r1.Extra, r.copy())
 	}
 
 	return r1

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -553,8 +553,7 @@ func unpackDataNsec(msg []byte, off int) ([]uint16, int, error) {
 		}
 
 		// Walk the bytes in the window and extract the type bits
-		for j := 0; j < length; j++ {
-			b := msg[off+j]
+		for j, b := range msg[off : off+length] {
 			// Check the bits one by one, and set the type
 			if b&0x80 == 0x80 {
 				nsec = append(nsec, uint16(window*256+j*8+0))
@@ -592,8 +591,7 @@ func packDataNsec(bitmap []uint16, msg []byte, off int) (int, error) {
 		return off, nil
 	}
 	var lastwindow, lastlength uint16
-	for j := 0; j < len(bitmap); j++ {
-		t := bitmap[j]
+	for _, t := range bitmap {
 		window := t / 256
 		length := (t-window*256)/8 + 1
 		if window > lastwindow && lastlength != 0 { // New window, jump to the new offset
@@ -639,8 +637,8 @@ func unpackDataDomainNames(msg []byte, off, end int) ([]string, int, error) {
 
 func packDataDomainNames(names []string, msg []byte, off int, compression compressionMap, compress bool) (int, error) {
 	var err error
-	for j := 0; j < len(names); j++ {
-		off, err = packDomainName(names[j], msg, off, compression, compress)
+	for _, name := range names {
+		off, err = packDomainName(name, msg, off, compression, compress)
 		if err != nil {
 			return len(msg), err
 		}

--- a/types.go
+++ b/types.go
@@ -845,8 +845,8 @@ type NSEC struct {
 
 func (rr *NSEC) String() string {
 	s := rr.Hdr.String() + sprintName(rr.NextDomain)
-	for i := 0; i < len(rr.TypeBitMap); i++ {
-		s += " " + Type(rr.TypeBitMap[i]).String()
+	for _, t := range rr.TypeBitMap {
+		s += " " + Type(t).String()
 	}
 	return s
 }
@@ -1011,8 +1011,8 @@ func (rr *NSEC3) String() string {
 		" " + strconv.Itoa(int(rr.Iterations)) +
 		" " + saltToString(rr.Salt) +
 		" " + rr.NextDomain
-	for i := 0; i < len(rr.TypeBitMap); i++ {
-		s += " " + Type(rr.TypeBitMap[i]).String()
+	for _, t := range rr.TypeBitMap {
+		s += " " + Type(t).String()
 	}
 	return s
 }
@@ -1335,8 +1335,8 @@ type CSYNC struct {
 func (rr *CSYNC) String() string {
 	s := rr.Hdr.String() + strconv.FormatInt(int64(rr.Serial), 10) + " " + strconv.Itoa(int(rr.Flags))
 
-	for i := 0; i < len(rr.TypeBitMap); i++ {
-		s += " " + Type(rr.TypeBitMap[i]).String()
+	for _, t := range rr.TypeBitMap {
+		s += " " + Type(t).String()
 	}
 	return s
 }


### PR DESCRIPTION
This replaces the use of manual `for i := 0; i < len(...); i++` loops with simpler and more idiomatic `for range` loops.

`Msg.CopyTo` had a slight reorganisation of it's logic which leaves it much simpler: 5bab01b0a655730908f4523a5b2510d80a515167.