### PR TITLE
Remove pointless cast in Conn.Read

### DIFF
--- a/client.go
+++ b/client.go
@@ -270,8 +270,7 @@ func (co *Conn) Read(p []byte) (n int, err error) {
 			return 0, io.ErrShortBuffer
 		}
 
-		n, err := io.ReadFull(co.Conn, p[:length])
-		return int(n), err
+		return io.ReadFull(co.Conn, p[:length])
 	}
 
 	// UDP connection


### PR DESCRIPTION
This was accidentally added in #935, though I'm not quite sure why I ended up with this cast.