### PR TITLE
Add constants for missing registered EDNS option codes

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -71,10 +71,11 @@ func (rr *OPT) String() string {
 			s += "\n; DS HASH UNDERSTOOD: " + o.String()
 		case *EDNS0_N3U:
 			s += "\n; NSEC3 HASH UNDERSTOOD: " + o.String()
-		case *EDNS0_LOCAL:
-			s += "\n; LOCAL OPT: " + o.String()
 		case *EDNS0_PADDING:
 			s += "\n; PADDING: " + o.String()
+
+		case *EDNS0_LOCAL:
+			s += "\n; LOCAL OPT: " + o.String()
 		}
 	}
 	return s
@@ -540,53 +541,6 @@ func (e *EDNS0_EXPIRE) unpack(b []byte) error {
 	return nil
 }
 
-// The EDNS0_LOCAL option is used for local/experimental purposes. The option
-// code is recommended to be within the range [EDNS0LOCALSTART, EDNS0LOCALEND]
-// (RFC6891), although any unassigned code can actually be used.  The content of
-// the option is made available in Data, unaltered.
-// Basic use pattern for creating a local option:
-//
-//	o := new(dns.OPT)
-//	o.Hdr.Name = "."
-//	o.Hdr.Rrtype = dns.TypeOPT
-//	e := new(dns.EDNS0_LOCAL)
-//	e.Code = dns.EDNS0LOCALSTART
-//	e.Data = []byte{72, 82, 74}
-//	o.Option = append(o.Option, e)
-type EDNS0_LOCAL struct {
-	Code uint16
-	Data []byte
-}
-
-// Option implements the EDNS0 interface.
-func (e *EDNS0_LOCAL) Option() uint16 { return e.Code }
-func (e *EDNS0_LOCAL) String() string {
-	return strconv.FormatInt(int64(e.Code), 10) + ":0x" + hex.EncodeToString(e.Data)
-}
-func (e *EDNS0_LOCAL) copy() EDNS0 {
-	b := make([]byte, len(e.Data))
-	copy(b, e.Data)
-	return &EDNS0_LOCAL{e.Code, b}
-}
-
-func (e *EDNS0_LOCAL) pack() ([]byte, error) {
-	b := make([]byte, len(e.Data))
-	copied := copy(b, e.Data)
-	if copied != len(e.Data) {
-		return nil, ErrBuf
-	}
-	return b, nil
-}
-
-func (e *EDNS0_LOCAL) unpack(b []byte) error {
-	e.Data = make([]byte, len(b))
-	copied := copy(e.Data, b)
-	if copied != len(b) {
-		return ErrBuf
-	}
-	return nil
-}
-
 // EDNS0_TCP_KEEPALIVE is an EDNS0 option that instructs the server to keep
 // the TCP connection alive. See RFC 7828.
 type EDNS0_TCP_KEEPALIVE struct {
@@ -658,4 +612,51 @@ func (e *EDNS0_PADDING) copy() EDNS0 {
 	b := make([]byte, len(e.Padding))
 	copy(b, e.Padding)
 	return &EDNS0_PADDING{b}
+}
+
+// The EDNS0_LOCAL option is used for local/experimental purposes. The option
+// code is recommended to be within the range [EDNS0LOCALSTART, EDNS0LOCALEND]
+// (RFC6891), although any unassigned code can actually be used.  The content of
+// the option is made available in Data, unaltered.
+// Basic use pattern for creating a local option:
+//
+//	o := new(dns.OPT)
+//	o.Hdr.Name = "."
+//	o.Hdr.Rrtype = dns.TypeOPT
+//	e := new(dns.EDNS0_LOCAL)
+//	e.Code = dns.EDNS0LOCALSTART
+//	e.Data = []byte{72, 82, 74}
+//	o.Option = append(o.Option, e)
+type EDNS0_LOCAL struct {
+	Code uint16
+	Data []byte
+}
+
+// Option implements the EDNS0 interface.
+func (e *EDNS0_LOCAL) Option() uint16 { return e.Code }
+func (e *EDNS0_LOCAL) String() string {
+	return strconv.FormatInt(int64(e.Code), 10) + ":0x" + hex.EncodeToString(e.Data)
+}
+func (e *EDNS0_LOCAL) copy() EDNS0 {
+	b := make([]byte, len(e.Data))
+	copy(b, e.Data)
+	return &EDNS0_LOCAL{e.Code, b}
+}
+
+func (e *EDNS0_LOCAL) pack() ([]byte, error) {
+	b := make([]byte, len(e.Data))
+	copied := copy(b, e.Data)
+	if copied != len(e.Data) {
+		return nil, ErrBuf
+	}
+	return b, nil
+}
+
+func (e *EDNS0_LOCAL) unpack(b []byte) error {
+	e.Data = make([]byte, len(b))
+	copied := copy(e.Data, b)
+	if copied != len(b) {
+		return ErrBuf
+	}
+	return nil
 }

--- a/edns.go
+++ b/edns.go
@@ -22,6 +22,8 @@ const (
 	EDNS0COOKIE       = 0xa     // EDNS0 Cookie
 	EDNS0TCPKEEPALIVE = 0xb     // EDNS0 tcp keep alive (See RFC 7828)
 	EDNS0PADDING      = 0xc     // EDNS0 padding (See RFC 7830)
+	EDNS0CHAIN        = 0xd     // EDNS0 CHAIN (See RFC 7901)
+	EDNS0KEYTAG       = 0xe     // EDNS0 key-tag (See RFC 8145)
 	EDNS0LOCALSTART   = 0xFDE9  // Beginning of range reserved for local/experimental use (See RFC 6891)
 	EDNS0LOCALEND     = 0xFFFE  // End of range reserved for local/experimental use (See RFC 6891)
 	_DO               = 1 << 15 // DNSSEC OK

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -474,6 +474,8 @@ Option:
 		}
 		edns = append(edns, e)
 		off += int(optlen)
+
+	// Process any unrecognized option code as a local/experimental option.
 	default:
 		e := new(EDNS0_LOCAL)
 		e.Code = code


### PR DESCRIPTION
https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-11

Value | Name | Status | Reference
-- | -- | -- | --
13 | CHAIN | Standard | [[RFC7901](https://tools.ietf.org/html/rfc7901)]
14 | edns-key-tag | Optional | [[RFC8145](http://www.iana.org/go/rfc8145)]