### PR TITLE
Provide more control over server writing and make UDP support extendable

### DIFF
--- a/server.go
+++ b/server.go
@@ -205,6 +205,8 @@ type Server struct {
 	// Whether to set the SO_REUSEPORT socket option, allowing multiple listeners to be bound to a single address.
 	// It is only supported on go1.11+ and when using ListenAndServe.
 	ReusePort bool
+	// Whether to disable setting socket options in ActivateAndServer.
+	DisableSocketOptions bool
 	// AcceptMsgFunc will check the incoming message and will reject it early in the process.
 	// By default DefaultMsgAcceptFunc will be used.
 	MsgAcceptFunc MsgAcceptFunc
@@ -331,8 +333,10 @@ func (srv *Server) ActivateAndServe() error {
 		// Check PacketConn interface's type is valid and value
 		// is not nil
 		if t, ok := pConn.(*net.UDPConn); ok && t != nil {
-			if e := setUDPSocketOptions(t); e != nil {
-				return e
+			if !srv.DisableSocketOptions {
+				if e := setUDPSocketOptions(t); e != nil {
+					return e
+				}
 			}
 			srv.started = true
 			unlock()

--- a/udp.go
+++ b/udp.go
@@ -28,12 +28,12 @@ var udpOOBSize = func() int {
 // SessionUDP holds the remote address and the associated
 // out-of-band data.
 type SessionUDP struct {
-	raddr   *net.UDPAddr
-	context []byte
+	Addr    *net.UDPAddr
+	Context []byte
 }
 
 // RemoteAddr returns the remote network address.
-func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
+func (s *SessionUDP) RemoteAddr() net.Addr { return s.Addr }
 
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
@@ -48,8 +48,8 @@ func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 
 // WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
 func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
-	oob := correctSource(session.context)
-	n, _, err := conn.WriteMsgUDP(b, oob, session.raddr)
+	oob := correctSource(session.Context)
+	n, _, err := conn.WriteMsgUDP(b, oob, session.Addr)
 	return n, err
 }
 

--- a/udp_test.go
+++ b/udp_test.go
@@ -53,10 +53,10 @@ func TestSetUDPSocketOptions(t *testing.T) {
 			// t.Error was already called in the goroutine above.
 			t.FailNow()
 		}
-		if len(sess.context) == 0 {
+		if len(sess.Context) == 0 {
 			t.Fatalf("empty session context: %v", sess)
 		}
-		ip := parseDstFromOOB(sess.context)
+		ip := parseDstFromOOB(sess.Context)
 		if ip == nil {
 			t.Fatalf("failed to parse dst: %v", sess)
 		}

--- a/udp_windows.go
+++ b/udp_windows.go
@@ -6,11 +6,12 @@ import "net"
 
 // SessionUDP holds the remote address
 type SessionUDP struct {
-	raddr *net.UDPAddr
+	Addr    *net.UDPAddr
+	Context []byte
 }
 
 // RemoteAddr returns the remote network address.
-func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
+func (s *SessionUDP) RemoteAddr() net.Addr { return s.Addr }
 
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
@@ -20,13 +21,13 @@ func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 	if err != nil {
 		return n, nil, err
 	}
-	return n, &SessionUDP{raddr.(*net.UDPAddr)}, err
+	return n, &SessionUDP{raddr.(*net.UDPAddr), nil}, err
 }
 
 // WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
 // TODO(fastest963): Once go1.10 is released, use WriteMsgUDP.
 func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
-	return conn.WriteTo(b, session.raddr)
+	return conn.WriteTo(b, session.Addr)
 }
 
 // TODO(fastest963): Once go1.10 is released and we can use *MsgUDP methods


### PR DESCRIPTION
This replaces the much more complicated interface proposed in #918 (see https://github.com/miekg/dns/pull/918#issuecomment-470321738) with a different approach that should allow all the same control over the server.

**Note:** This is still lacking tests and so isn't ready to merge yet.

Closes #918

/cc @jrajahalme