### PR TITLE
udp: Add UDP extensibility. (v2)

### DIFF
--- a/listen_go111.go
+++ b/listen_go111.go
@@ -1,4 +1,4 @@
-// +build go1.11
+// +build go1.11 go1.12
 // +build aix darwin dragonfly freebsd linux netbsd openbsd
 
 package dns

--- a/listen_go_not111.go
+++ b/listen_go_not111.go
@@ -1,4 +1,4 @@
-// +build !go1.11 !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
+// +build !go1.11,!go1.12 !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
 
 package dns
 

--- a/udp_test.go
+++ b/udp_test.go
@@ -25,15 +25,16 @@ func TestSetUDPSocketOptions(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err := setUDPSocketOptions(c); err != nil {
+		sf := defaultSessionUDPFactory
+		sf.InitPool(1)
+		if err := sf.SetSocketOptions(c); err != nil {
 			t.Fatalf("failed to set socket options: %v", err)
 		}
-		ch := make(chan *SessionUDP)
+		ch := make(chan SessionUDP)
 		go func() {
 			// Set some deadline so this goroutine doesn't hang forever
 			c.SetReadDeadline(time.Now().Add(time.Minute))
-			b := make([]byte, 1)
-			_, sess, err := ReadFromSessionUDP(c, b)
+			_, sess, err := sf.ReadRequest(c)
 			if err != nil {
 				t.Errorf("failed to read from conn: %v", err)
 				// fallthrough to chan send below
@@ -48,15 +49,15 @@ func TestSetUDPSocketOptions(t *testing.T) {
 		if _, err := c2.Write([]byte{1}); err != nil {
 			t.Fatalf("failed to write to conn: %v", err)
 		}
-		sess := <-ch
+		sess := (<-ch).(*sessionUDP)
 		if sess == nil {
 			// t.Error was already called in the goroutine above.
 			t.FailNow()
 		}
-		if len(sess.context) == 0 {
+		if len(sess.oob) == 0 {
 			t.Fatalf("empty session context: %v", sess)
 		}
-		ip := parseDstFromOOB(sess.context)
+		ip := parseDstFromOOB(sess.oob)
 		if ip == nil {
 			t.Fatalf("failed to parse dst: %v", sess)
 		}


### PR DESCRIPTION
This is an update on #918, addressing all the feedback and striving to make the changes as simple as possible. While a new option is added to `Server`, the UDP message pooling implementation is moved to udp.go, thus simplifying the server implementation.

This PR allows users to replace the UDP implementation by supplying am instance of the new interface
SessionUDPFactory.  A default implementation without any behavioral changes is provided and used when user does not provide their own implementation.

The SessionUDPs are pooled, replacing the buffer pooling so that space for OOB/control data does not need to be dynamically allocated for each request. This should make this version perform better. The pooling logic is moved from server.go to udp.go, simplifying the server code a bit.

SessionUDP interface contains a LocalAddr() function, the default implementation of which returns the address the server is listening on (no functional change). This allows specialized implementations to
return the address the request was sent to when, e.g., the server is listening on the IPv6 unspecified address ([::]).

This extensibility is needed to allow transparent proxying, where the listening socket receives requests originally sent to a different address/port. See https://www.kernel.org/doc/Documentation/networking/tproxy.txt for reference and https://github.com/cilium/dns/blob/udp-interface-1.1.8/udp.go for an example of TPROXY SessionUDP implementation. While the implementation referred to here is Linux specific, I'd be willing to upstream that as well if you think it would be useful.

Signed-off-by: Jarno Rajahalme <jarno@covalent.io>
