### PR TITLE
Simplify PrivateRR copying

### DIFF
--- a/privaterr.go
+++ b/privaterr.go
@@ -1,9 +1,6 @@
 package dns
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 // PrivateRdata is an interface used for implementing "Private Use" RR types, see
 // RFC 6895. This allows one to experiment with new RR types, without requesting an
@@ -18,7 +15,7 @@ type PrivateRdata interface {
 	// Unpack is used when unpacking a private RR from a buffer.
 	// TODO(miek): diff. signature than Pack, see edns0.go for instance.
 	Unpack([]byte) (int, error)
-	// Copy copies the Rdata.
+	// Copy copies the Rdata into the PrivateRdata argument.
 	Copy(PrivateRdata) error
 	// Len returns the length in octets of the Rdata.
 	Len() int
@@ -29,22 +26,8 @@ type PrivateRdata interface {
 type PrivateRR struct {
 	Hdr  RR_Header
 	Data PrivateRdata
-}
 
-func mkPrivateRR(rrtype uint16) *PrivateRR {
-	// Panics if RR is not an instance of PrivateRR.
-	rrfunc, ok := TypeToRR[rrtype]
-	if !ok {
-		panic(fmt.Sprintf("dns: invalid operation with Private RR type %d", rrtype))
-	}
-
-	anyrr := rrfunc()
-	rr, ok := anyrr.(*PrivateRR)
-	if !ok {
-		panic(fmt.Sprintf("dns: RR is not a PrivateRR, TypeToRR[%d] generator returned %T", rrtype, anyrr))
-	}
-
-	return rr
+	generator func() PrivateRdata // for copy
 }
 
 // Header return the RR header of r.
@@ -61,13 +44,12 @@ func (r *PrivateRR) len(off int, compression map[string]struct{}) int {
 
 func (r *PrivateRR) copy() RR {
 	// make new RR like this:
-	rr := mkPrivateRR(r.Hdr.Rrtype)
-	rr.Hdr = r.Hdr
+	rr := &PrivateRR{r.Hdr, r.generator(), r.generator}
 
-	err := r.Data.Copy(rr.Data)
-	if err != nil {
-		panic("dns: got value that could not be used to copy Private rdata")
+	if err := r.Data.Copy(rr.Data); err != nil {
+		panic("dns: got value that could not be used to copy Private rdata: " + err.Error())
 	}
+
 	return rr
 }
 
@@ -116,7 +98,7 @@ func (r1 *PrivateRR) isDuplicate(r2 RR) bool { return false }
 func PrivateHandle(rtypestr string, rtype uint16, generator func() PrivateRdata) {
 	rtypestr = strings.ToUpper(rtypestr)
 
-	TypeToRR[rtype] = func() RR { return &PrivateRR{RR_Header{}, generator()} }
+	TypeToRR[rtype] = func() RR { return &PrivateRR{RR_Header{}, generator(), generator} }
 	TypeToString[rtype] = rtypestr
 	StringToType[rtypestr] = rtype
 }


### PR DESCRIPTION
This code has bugged me for a while, but I couldn't find a clean way to eliminate it until now.

This eliminates `mkPrivateRR` and reduces the risk of panic.