### PR TITLE
Add support for the Proposed DNS XPF RR

### DIFF
--- a/duplicate_generate.go
+++ b/duplicate_generate.go
@@ -57,7 +57,7 @@ func main() {
 			continue
 		}
 
-		if name == "PrivateRR" || name == "OPT" {
+		if name == "PrivateRR" || name == "OPT" || name == "XPF" {
 			continue
 		}
 

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -117,6 +117,8 @@ return off, err
 				o("off, err = packDataA(rr.%s, msg, off)\n")
 			case st.Tag(i) == `dns:"aaaa"`:
 				o("off, err = packDataAAAA(rr.%s, msg, off)\n")
+			case st.Tag(i) == `dns:"xpf"`:
+				o("off, err = packDataXpf(rr.%s, msg, off)\n")
 			case st.Tag(i) == `dns:"uint48"`:
 				o("off, err = packUint48(rr.%s, msg, off)\n")
 			case st.Tag(i) == `dns:"txt"`:
@@ -241,6 +243,8 @@ return off, err
 				o("rr.%s, off, err = unpackDataA(msg, off)\n")
 			case `dns:"aaaa"`:
 				o("rr.%s, off, err = unpackDataAAAA(msg, off)\n")
+			case `dns:"xpf"`:
+				o("rr.%s, off, err = unpackDataXpf(msg, off)\n")
 			case `dns:"uint48"`:
 				o("rr.%s, off, err = unpackUint48(msg, off)\n")
 			case `dns:"txt"`:

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -34,7 +34,7 @@ func setRR(h RR_Header, c *zlexer, o, f string) (RR, *ParseError) {
 // according to RFC 3597 because they lack a presentation format.
 func canParseAsRR(rrtype uint16) bool {
 	switch rrtype {
-	case TypeANY, TypeNULL, TypeOPT, TypeTSIG:
+	case TypeANY, TypeNULL, TypeOPT, TypeTSIG, TypeXPF:
 		return false
 	default:
 		return true

--- a/types.go
+++ b/types.go
@@ -249,6 +249,25 @@ func (rr *XPF) parse(c *zlexer, origin, file string) *ParseError {
 	panic("dns: internal error: parse should never be called on XPF")
 }
 
+func (rr *XPF) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
+	l += 1 // IpVersion
+	l += 1 // Protocol
+	switch rr.IpVersion {
+	case 4:
+		l += 4 // SrcAddr
+		l += 4 // DestAddr
+
+	case 6:
+		l += 8 // SrcAddr
+		l += 8 // DestAddr
+	}
+	l += 2 // SrcPort
+	l += 2 // DestPort
+	//
+	return l
+}
+
 // ANY is a wildcard record. See RFC 1035, Section 3.2.3. ANY
 // is named "*" there.
 type ANY struct {

--- a/types.go
+++ b/types.go
@@ -106,6 +106,7 @@ const (
 
 	TypeTA       uint16 = 32768
 	TypeDLV      uint16 = 32769
+	TypeXPF      uint16 = 65422
 	TypeReserved uint16 = 65535
 
 	// valid Question.Qclass
@@ -227,6 +228,25 @@ func (q *Question) String() (s string) {
 	s += Class(q.Qclass).String() + "\t"
 	s += " " + Type(q.Qtype).String()
 	return s
+}
+
+// XPF RR. See https://tools.ietf.org/html/draft-bellis-dnsop-xpf-04
+type XPF struct {
+	Hdr         RR_Header
+	IpVersion   uint8
+	Protocol    uint8
+	SrcAddress  net.IP `dns:"a"`
+	DestAddress net.IP `dns:"a"`
+	SrcPort     uint16
+	DestPort    uint16
+}
+
+func (rr *XPF) String() string {
+	return fmt.Sprintf("%v Source=%v:%v Destination=%v:%v", rr.Hdr.String(), rr.SrcAddress, rr.SrcPort, rr.DestAddress, rr.DestPort)
+}
+
+func (rr *XPF) parse(c *zlexer, origin, file string) *ParseError {
+	panic("dns: internal error: parse should never be called on XPF")
 }
 
 // ANY is a wildcard record. See RFC 1035, Section 3.2.3. ANY

--- a/types.go
+++ b/types.go
@@ -230,44 +230,6 @@ func (q *Question) String() (s string) {
 	return s
 }
 
-// XPF RR. See https://tools.ietf.org/html/draft-bellis-dnsop-xpf-04
-type XPF struct {
-	Hdr         RR_Header
-	IpVersion   uint8
-	Protocol    uint8
-	SrcAddress  net.IP `dns:"a"`
-	DestAddress net.IP `dns:"a"`
-	SrcPort     uint16
-	DestPort    uint16
-}
-
-func (rr *XPF) String() string {
-	return fmt.Sprintf("%v Source=%v:%v Destination=%v:%v", rr.Hdr.String(), rr.SrcAddress, rr.SrcPort, rr.DestAddress, rr.DestPort)
-}
-
-func (rr *XPF) parse(c *zlexer, origin, file string) *ParseError {
-	panic("dns: internal error: parse should never be called on XPF")
-}
-
-func (rr *XPF) len(off int, compression map[string]struct{}) int {
-	l := rr.Hdr.len(off, compression)
-	l += 1 // IpVersion
-	l += 1 // Protocol
-	switch rr.IpVersion {
-	case 4:
-		l += 4 // SrcAddr
-		l += 4 // DestAddr
-
-	case 6:
-		l += 8 // SrcAddr
-		l += 8 // DestAddr
-	}
-	l += 2 // SrcPort
-	l += 2 // DestPort
-	//
-	return l
-}
-
 // ANY is a wildcard record. See RFC 1035, Section 3.2.3. ANY
 // is named "*" there.
 type ANY struct {

--- a/types_generate.go
+++ b/types_generate.go
@@ -24,6 +24,7 @@ var skipLen = map[string]struct{}{
 	"NSEC3": {},
 	"OPT":   {},
 	"CSYNC": {},
+	"XPF":   {},
 }
 
 var packageHdr = `

--- a/update_test.go
+++ b/update_test.go
@@ -10,7 +10,8 @@ func TestDynamicUpdateParsing(t *testing.T) {
 	for _, typ := range TypeToString {
 		if typ == "OPT" || typ == "AXFR" || typ == "IXFR" || typ == "ANY" || typ == "TKEY" ||
 			typ == "TSIG" || typ == "ISDN" || typ == "UNSPEC" || typ == "NULL" || typ == "ATMA" ||
-			typ == "Reserved" || typ == "None" || typ == "NXT" || typ == "MAILB" || typ == "MAILA" {
+			typ == "Reserved" || typ == "None" || typ == "NXT" || typ == "MAILB" || typ == "MAILA" ||
+			typ == "XPF" {
 			continue
 		}
 		if _, err := NewRR(prefix + typ); err != nil {

--- a/xpf.go
+++ b/xpf.go
@@ -1,0 +1,81 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+)
+
+// XPF RR. See https://tools.ietf.org/html/draft-bellis-dnsop-xpf-04
+type XPF struct {
+	Hdr  RR_Header
+	Data XPF_Data `dns:"xpf"` // This is seperated out to make this more compatible with the code generation
+}
+
+// XPF_Data encapsulates the xpf data for custom deserialization
+type XPF_Data struct {
+	IpVersion   uint8
+	Protocol    uint8
+	SrcAddress  net.IP
+	DestAddress net.IP
+	SrcPort     uint16
+	DestPort    uint16
+}
+
+// Equals does a deep equals for the XPF Data
+func (xpf_data *XPF_Data) Equals(xpf_data2 XPF_Data) bool {
+	if xpf_data.IpVersion != xpf_data2.IpVersion {
+		return false
+	}
+	if xpf_data.Protocol != xpf_data2.Protocol {
+		return false
+	}
+	if !xpf_data.SrcAddress.Equal(xpf_data2.SrcAddress) {
+		return false
+	}
+	if !xpf_data.DestAddress.Equal(xpf_data2.DestAddress) {
+		return false
+	}
+	if xpf_data.SrcPort != xpf_data2.SrcPort {
+		return false
+	}
+	if xpf_data.DestPort != xpf_data2.DestPort {
+		return false
+	}
+	fmt.Println("meow")
+	return true
+}
+
+func (rr *XPF) String() string {
+	return fmt.Sprintf("%v Source=%v:%v Destination=%v:%v", rr.Hdr.String(), rr.Data.SrcAddress, rr.Data.SrcPort, rr.Data.DestAddress, rr.Data.DestPort)
+}
+
+func (rr *XPF) parse(c *zlexer, origin, file string) *ParseError {
+	panic("dns: internal error: parse should never be called on XPF")
+}
+
+func (rr *XPF) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
+	l++ // IpVersion
+	l++ // Protocol
+	switch rr.Data.IpVersion {
+	case 4:
+		l += net.IPv4len // SrcAddr
+		l += net.IPv4len // DestAddr
+
+	case 6:
+		l += net.IPv6len // SrcAddr
+		l += net.IPv6len // DestAddr
+	}
+	l += 2 // SrcPort
+	l += 2 // DestPort
+	//
+	return l
+}
+
+func (r1 *XPF) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*XPF)
+	if !ok {
+		return false
+	}
+	return r1.Data.Equals(r2.Data)
+}

--- a/xpf.go
+++ b/xpf.go
@@ -41,7 +41,6 @@ func (xpf_data *XPF_Data) Equals(xpf_data2 XPF_Data) bool {
 	if xpf_data.DestPort != xpf_data2.DestPort {
 		return false
 	}
-	fmt.Println("meow")
 	return true
 }
 

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -1138,30 +1138,3 @@ func (r1 *X25) isDuplicate(_r2 RR) bool {
 	}
 	return true
 }
-
-func (r1 *XPF) isDuplicate(_r2 RR) bool {
-	r2, ok := _r2.(*XPF)
-	if !ok {
-		return false
-	}
-	_ = r2
-	if r1.IpVersion != r2.IpVersion {
-		return false
-	}
-	if r1.Protocol != r2.Protocol {
-		return false
-	}
-	if !r1.SrcAddress.Equal(r2.SrcAddress) {
-		return false
-	}
-	if !r1.DestAddress.Equal(r2.DestAddress) {
-		return false
-	}
-	if r1.SrcPort != r2.SrcPort {
-		return false
-	}
-	if r1.DestPort != r2.DestPort {
-		return false
-	}
-	return true
-}

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -1138,3 +1138,30 @@ func (r1 *X25) isDuplicate(_r2 RR) bool {
 	}
 	return true
 }
+
+func (r1 *XPF) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*XPF)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if r1.IpVersion != r2.IpVersion {
+		return false
+	}
+	if r1.Protocol != r2.Protocol {
+		return false
+	}
+	if r1.SrcAddress.String() != r2.SrcAddress.String() {
+		return false
+	}
+	if r1.DestAddress.String() != r2.DestAddress.String() {
+		return false
+	}
+	if r1.SrcPort != r2.SrcPort {
+		return false
+	}
+	if r1.DestPort != r2.DestPort {
+		return false
+	}
+	return true
+}

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -1151,10 +1151,10 @@ func (r1 *XPF) isDuplicate(_r2 RR) bool {
 	if r1.Protocol != r2.Protocol {
 		return false
 	}
-	if r1.SrcAddress.String() != r2.SrcAddress.String() {
+	if !r1.SrcAddress.Equal(r2.SrcAddress) {
 		return false
 	}
-	if r1.DestAddress.String() != r2.DestAddress.String() {
+	if !r1.DestAddress.Equal(r2.DestAddress) {
 		return false
 	}
 	if r1.SrcPort != r2.SrcPort {

--- a/zmsg.go
+++ b/zmsg.go
@@ -1078,6 +1078,34 @@ func (rr *X25) pack(msg []byte, off int, compression compressionMap, compress bo
 	return off, nil
 }
 
+func (rr *XPF) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packUint8(rr.IpVersion, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packUint8(rr.Protocol, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packDataA(rr.SrcAddress, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packDataA(rr.DestAddress, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packUint16(rr.SrcPort, msg, off)
+	if err != nil {
+		return off, err
+	}
+	off, err = packUint16(rr.DestPort, msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
 // unpack*() functions
 
 func (rr *A) unpack(msg []byte, off int) (off1 int, err error) {
@@ -2715,6 +2743,37 @@ func (rr *X25) unpack(msg []byte, off int) (off1 int, err error) {
 	_ = rdStart
 
 	rr.PSDNAddress, off, err = unpackString(msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
+func (rr *XPF) unpack(msg []byte, off int) (off1 int, err error) {
+	rdStart := off
+	_ = rdStart
+
+	rr.IpVersion, off, err = unpackUint8(msg, off)
+	if err != nil {
+		return off, err
+	}
+	rr.Protocol, off, err = unpackUint8(msg, off)
+	if err != nil {
+		return off, err
+	}
+	rr.SrcAddress, off, err = unpackDataA(msg, off)
+	if err != nil {
+		return off, err
+	}
+	rr.DestAddress, off, err = unpackDataA(msg, off)
+	if err != nil {
+		return off, err
+	}
+	rr.SrcPort, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return off, err
+	}
+	rr.DestPort, off, err = unpackUint16(msg, off)
 	if err != nil {
 		return off, err
 	}

--- a/zmsg.go
+++ b/zmsg.go
@@ -2757,21 +2757,36 @@ func (rr *XPF) unpack(msg []byte, off int) (off1 int, err error) {
 	if err != nil {
 		return off, err
 	}
+	if off == len(msg) {
+		return off, nil
+	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
 		return off, err
+	}
+	if off == len(msg) {
+		return off, nil
 	}
 	rr.SrcAddress, off, err = unpackDataA(msg, off)
 	if err != nil {
 		return off, err
 	}
+	if off == len(msg) {
+		return off, nil
+	}
 	rr.DestAddress, off, err = unpackDataA(msg, off)
 	if err != nil {
 		return off, err
 	}
+	if off == len(msg) {
+		return off, nil
+	}
 	rr.SrcPort, off, err = unpackUint16(msg, off)
 	if err != nil {
 		return off, err
+	}
+	if off == len(msg) {
+		return off, nil
 	}
 	rr.DestPort, off, err = unpackUint16(msg, off)
 	if err != nil {

--- a/zmsg.go
+++ b/zmsg.go
@@ -1079,27 +1079,7 @@ func (rr *X25) pack(msg []byte, off int, compression compressionMap, compress bo
 }
 
 func (rr *XPF) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
-	off, err = packUint8(rr.IpVersion, msg, off)
-	if err != nil {
-		return off, err
-	}
-	off, err = packUint8(rr.Protocol, msg, off)
-	if err != nil {
-		return off, err
-	}
-	off, err = packDataA(rr.SrcAddress, msg, off)
-	if err != nil {
-		return off, err
-	}
-	off, err = packDataA(rr.DestAddress, msg, off)
-	if err != nil {
-		return off, err
-	}
-	off, err = packUint16(rr.SrcPort, msg, off)
-	if err != nil {
-		return off, err
-	}
-	off, err = packUint16(rr.DestPort, msg, off)
+	off, err = packDataXpf(rr.Data, msg, off)
 	if err != nil {
 		return off, err
 	}
@@ -2753,42 +2733,7 @@ func (rr *XPF) unpack(msg []byte, off int) (off1 int, err error) {
 	rdStart := off
 	_ = rdStart
 
-	rr.IpVersion, off, err = unpackUint8(msg, off)
-	if err != nil {
-		return off, err
-	}
-	if off == len(msg) {
-		return off, nil
-	}
-	rr.Protocol, off, err = unpackUint8(msg, off)
-	if err != nil {
-		return off, err
-	}
-	if off == len(msg) {
-		return off, nil
-	}
-	rr.SrcAddress, off, err = unpackDataA(msg, off)
-	if err != nil {
-		return off, err
-	}
-	if off == len(msg) {
-		return off, nil
-	}
-	rr.DestAddress, off, err = unpackDataA(msg, off)
-	if err != nil {
-		return off, err
-	}
-	if off == len(msg) {
-		return off, nil
-	}
-	rr.SrcPort, off, err = unpackUint16(msg, off)
-	if err != nil {
-		return off, err
-	}
-	if off == len(msg) {
-		return off, nil
-	}
-	rr.DestPort, off, err = unpackUint16(msg, off)
+	rr.Data, off, err = unpackDataXpf(msg, off)
 	if err != nil {
 		return off, err
 	}

--- a/ztypes.go
+++ b/ztypes.go
@@ -163,8 +163,8 @@ var TypeToString = map[uint16]string{
 	TypeUNSPEC:     "UNSPEC",
 	TypeURI:        "URI",
 	TypeX25:        "X25",
-	TypeNSAPPTR:    "NSAP-PTR",
 	TypeXPF:        "XPF",
+	TypeNSAPPTR:    "NSAP-PTR",
 }
 
 func (rr *A) Header() *RR_Header          { return &rr.Hdr }
@@ -662,16 +662,6 @@ func (rr *X25) len(off int, compression map[string]struct{}) int {
 	l += len(rr.PSDNAddress) + 1
 	return l
 }
-func (rr *XPF) len(off int, compression map[string]struct{}) int {
-	l := rr.Hdr.len(off, compression)
-	l += 1 // IpAddress
-	l += 1 // Protocol
-	l += len(rr.DestAddress)
-	l += len(rr.SrcAddress)
-	l += 2 // DestPort
-	l += 2 // SrcPort
-	return l
-}
 
 // copy() functions
 func (rr *A) copy() RR {
@@ -893,5 +883,5 @@ func (rr *X25) copy() RR {
 	return &X25{rr.Hdr, rr.PSDNAddress}
 }
 func (rr *XPF) copy() RR {
-	return &XPF{rr.Hdr, rr.IpVersion, rr.Protocol, rr.DestAddress, rr.SrcAddress, rr.DestPort, rr.SrcPort}
+	return &XPF{rr.Hdr, rr.IpVersion, rr.Protocol, copyIP(rr.SrcAddress), copyIP(rr.DestAddress), rr.SrcPort, rr.DestPort}
 }

--- a/ztypes.go
+++ b/ztypes.go
@@ -79,6 +79,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeUINFO:      func() RR { return new(UINFO) },
 	TypeURI:        func() RR { return new(URI) },
 	TypeX25:        func() RR { return new(X25) },
+	TypeXPF:        func() RR { return new(XPF) },
 }
 
 // TypeToString is a map of strings for each RR type.
@@ -163,6 +164,7 @@ var TypeToString = map[uint16]string{
 	TypeURI:        "URI",
 	TypeX25:        "X25",
 	TypeNSAPPTR:    "NSAP-PTR",
+	TypeXPF:        "XPF",
 }
 
 func (rr *A) Header() *RR_Header          { return &rr.Hdr }
@@ -236,6 +238,7 @@ func (rr *UID) Header() *RR_Header        { return &rr.Hdr }
 func (rr *UINFO) Header() *RR_Header      { return &rr.Hdr }
 func (rr *URI) Header() *RR_Header        { return &rr.Hdr }
 func (rr *X25) Header() *RR_Header        { return &rr.Hdr }
+func (rr *XPF) Header() *RR_Header        { return &rr.Hdr }
 
 // len() functions
 func (rr *A) len(off int, compression map[string]struct{}) int {
@@ -659,6 +662,16 @@ func (rr *X25) len(off int, compression map[string]struct{}) int {
 	l += len(rr.PSDNAddress) + 1
 	return l
 }
+func (rr *XPF) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
+	l += 1 // IpAddress
+	l += 1 // Protocol
+	l += len(rr.DestAddress)
+	l += len(rr.SrcAddress)
+	l += 2 // DestPort
+	l += 2 // SrcPort
+	return l
+}
 
 // copy() functions
 func (rr *A) copy() RR {
@@ -878,4 +891,7 @@ func (rr *URI) copy() RR {
 }
 func (rr *X25) copy() RR {
 	return &X25{rr.Hdr, rr.PSDNAddress}
+}
+func (rr *XPF) copy() RR {
+	return &XPF{rr.Hdr, rr.IpVersion, rr.Protocol, rr.DestAddress, rr.SrcAddress, rr.DestPort, rr.SrcPort}
 }

--- a/ztypes.go
+++ b/ztypes.go
@@ -883,5 +883,5 @@ func (rr *X25) copy() RR {
 	return &X25{rr.Hdr, rr.PSDNAddress}
 }
 func (rr *XPF) copy() RR {
-	return &XPF{rr.Hdr, rr.IpVersion, rr.Protocol, copyIP(rr.SrcAddress), copyIP(rr.DestAddress), rr.SrcPort, rr.DestPort}
+	return &XPF{rr.Hdr, rr.Data}
 }


### PR DESCRIPTION
As described in this RFC draft [(IETF Draft)](https://tools.ietf.org/html/draft-bellis-dnsop-xpf-04), the DNS XPF RR implementation adds meta information about the original destination and source to the DNS request. Something that I made a decision on was the Record Type, I went with the option code that Wireshark is currently mapping the record to (65422). This would need updating if/when the RFC goes through. 

Another reference implementation that was used as inspiration was from the PowerDNS dnsdist feature that was added.

Adding this here as I'd like to get this feature supported in CoreDNS eventually.

Feedback appreciated!