### PR TITLE
DNSSEC: remove deprecated algorithm RSAMD5 (RFC 6944)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 6844 - CAA record
 * 6891 - EDNS0 update
 * 6895 - DNS IANA considerations
+* 6944 - DNSSEC DNSKEY Algorithm Status
 * 6975 - Algorithm Understanding in DNSSEC
 * 7043 - EUI48/EUI64 records
 * 7314 - DNS (EDNS) EXPIRE Option

--- a/dnssec.go
+++ b/dnssec.go
@@ -318,6 +318,9 @@ func (rr *RRSIG) Sign(k crypto.Signer, rrset []RR) error {
 		}
 
 		rr.Signature = toBase64(signature)
+	case RSAMD5:
+		// See RFC 6944.
+		return ErrAlg
 	default:
 		h := hash.New()
 		h.Write(signdata)

--- a/dnssec_keygen.go
+++ b/dnssec_keygen.go
@@ -20,11 +20,13 @@ import (
 // bits should be set to the size of the algorithm.
 func (k *DNSKEY) Generate(bits int) (crypto.PrivateKey, error) {
 	switch k.Algorithm {
+	case RSAMD5:
+		return nil, ErrAlg
 	case DSA, DSANSEC3SHA1:
 		if bits != 1024 {
 			return nil, ErrKeySize
 		}
-	case RSAMD5, RSASHA1, RSASHA256, RSASHA1NSEC3SHA1:
+	case RSASHA1, RSASHA256, RSASHA1NSEC3SHA1:
 		if bits < 512 || bits > 4096 {
 			return nil, ErrKeySize
 		}
@@ -60,7 +62,7 @@ func (k *DNSKEY) Generate(bits int) (crypto.PrivateKey, error) {
 		}
 		k.setPublicKeyDSA(params.Q, params.P, params.G, priv.PublicKey.Y)
 		return priv, nil
-	case RSAMD5, RSASHA1, RSASHA256, RSASHA512, RSASHA1NSEC3SHA1:
+	case RSASHA1, RSASHA256, RSASHA512, RSASHA1NSEC3SHA1:
 		priv, err := rsa.GenerateKey(rand.Reader, bits)
 		if err != nil {
 			return nil, err

--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -44,6 +44,8 @@ func (k *DNSKEY) ReadPrivateKey(q io.Reader, file string) (crypto.PrivateKey, er
 		return nil, ErrPrivKey
 	}
 	switch uint8(algo) {
+	case RSAMD5:
+		return nil, ErrAlg
 	case DSA:
 		priv, err := readPrivateKeyDSA(m)
 		if err != nil {
@@ -55,8 +57,6 @@ func (k *DNSKEY) ReadPrivateKey(q io.Reader, file string) (crypto.PrivateKey, er
 		}
 		priv.PublicKey = *pub
 		return priv, nil
-	case RSAMD5:
-		fallthrough
 	case RSASHA1:
 		fallthrough
 	case RSASHA1NSEC3SHA1:


### PR DESCRIPTION
This removes RSAMD5 as an algorithm you can use. BIND also has
deprecated *all* DSA algos which is more involved can removes more
helper codes as well, so that should be done in a new PR.

This adds a ErrDeprecated signalling the DNSSEC algorithm is removed and
can't be used.

See #968