### PR TITLE
Reply with NOTIMPL when Opcode is not supported

### DIFF
--- a/acceptfunc.go
+++ b/acceptfunc.go
@@ -19,9 +19,10 @@ var DefaultMsgAcceptFunc MsgAcceptFunc = defaultMsgAcceptFunc
 type MsgAcceptAction int
 
 const (
-	MsgAccept MsgAcceptAction = iota // Accept the message
-	MsgReject                        // Reject the message with a RcodeFormatError
-	MsgIgnore                        // Ignore the error and send nothing back.
+	MsgAccept         MsgAcceptAction = iota // Accept the message
+	MsgReject                                // Reject the message with a RcodeFormatError
+	MsgIgnore                                // Ignore the error and send nothing back.
+	MsgRejectNotImplemented                        // Reject the message with a RcodeNotImplemented
 )
 
 func defaultMsgAcceptFunc(dh Header) MsgAcceptAction {
@@ -32,7 +33,7 @@ func defaultMsgAcceptFunc(dh Header) MsgAcceptAction {
 	// Don't allow dynamic updates, because then the sections can contain a whole bunch of RRs.
 	opcode := int(dh.Bits>>11) & 0xF
 	if opcode != OpcodeQuery && opcode != OpcodeNotify {
-		return MsgReject
+		return MsgRejectNotImplemented
 	}
 
 	if dh.Qdcount != 1 {

--- a/server.go
+++ b/server.go
@@ -560,18 +560,24 @@ func (srv *Server) serveDNS(m []byte, w *response) {
 	req := new(Msg)
 	req.setHdr(dh)
 
-	switch srv.MsgAcceptFunc(dh) {
+	switch action := srv.MsgAcceptFunc(dh); action {
 	case MsgAccept:
 		if req.unpack(dh, m, off) == nil {
 			break
 		}
 
 		fallthrough
-	case MsgReject:
+	case MsgReject, MsgRejectNotImplemented:
+		opcode := req.Opcode
 		req.SetRcodeFormatError(req)
+		req.Zero = false
+		if action == MsgRejectNotImplemented {
+			req.Opcode = opcode
+			req.Rcode = RcodeNotImplemented
+		}
+
 		// Are we allowed to delete any OPT records here?
 		req.Ns, req.Answer, req.Extra = nil, nil, nil
-		req.Zero = false
 
 		w.WriteMsg(req)
 		fallthrough


### PR DESCRIPTION
One of the test from DNS Compliance testing validates that if the opcode
is not supported, a NOTIMPL rcode is returned.

https://gitlab.isc.org/isc-projects/DNS-Compliance-Testing/blob/e0884144dde6704128e22acc14e2b65ba41a92b2/genreport.c#L293

This diff makes the default acceptfunc support this case and reply with
NOTIMPL instead of FORMERR.