### PR TITLE
Set the TC bit more aggressively in Truncate

### DIFF
--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -8,8 +8,13 @@ package dns
 // record adding as many records as possible without exceeding the
 // requested buffer size.
 //
-// The TC bit will be set if any answer records were excluded from the
-// message. This indicates to that the client should retry over TCP.
+// The TC bit will be set if any records were excluded from the message.
+// This indicates to that the client should retry over TCP.
+//
+// According to RFC 2181, the TC bit should only be set if not all of the
+// "required" RRs can be included in the response. Unfortunately, we have
+// no way of knowing which RRs are required so we set the TC bit if any RR
+// had to be omitted from the response.
 //
 // The appropriate buffer size can be retrieved from the requests OPT
 // record, if present, and is transport specific otherwise. dns.MinMsgSize
@@ -71,10 +76,7 @@ func (dns *Msg) Truncate(size int) {
 		l, numExtra = truncateLoop(dns.Extra, size, l, compression)
 	}
 
-	// According to RFC 2181, the TC bit should only be set if not all of
-	// the "required" RRs can be included in the response. Unfortunately,
-	// we have no way of knowing which RRs are required so we set the TC
-	// bit if any RR had to be omitted from the response.
+	// See the function documentation for when we set this.
 	dns.Truncated = len(dns.Answer) > numAnswer ||
 		len(dns.Ns) > numNS || len(dns.Extra) > numExtra
 

--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -71,9 +71,12 @@ func (dns *Msg) Truncate(size int) {
 		l, numExtra = truncateLoop(dns.Extra, size, l, compression)
 	}
 
-	// According to RFC 2181, the TC bit should only be set if not all
-	// of the answer RRs can be included in the response.
-	dns.Truncated = len(dns.Answer) > numAnswer
+	// According to RFC 2181, the TC bit should only be set if not all of
+	// the "required" RRs can be included in the response. Unfortunately,
+	// we have no way of knowing which RRs are required so we set the TC
+	// bit if any RR had to be omitted from the response.
+	dns.Truncated = len(dns.Answer) > numAnswer ||
+		len(dns.Ns) > numNS || len(dns.Extra) > numExtra
 
 	dns.Answer = dns.Answer[:numAnswer]
 	dns.Ns = dns.Ns[:numNS]

--- a/msg_truncate_test.go
+++ b/msg_truncate_test.go
@@ -40,8 +40,8 @@ func TestRequestTruncateExtra(t *testing.T) {
 	if want, got := MinMsgSize, reply.Len(); want < got {
 		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
 	}
-	if reply.Truncated {
-		t.Errorf("truncated bit should not be set")
+	if !reply.Truncated {
+		t.Errorf("truncated bit should be set")
 	}
 }
 
@@ -64,8 +64,8 @@ func TestRequestTruncateExtraEdns0(t *testing.T) {
 	if want, got := size, reply.Len(); want < got {
 		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
 	}
-	if reply.Truncated {
-		t.Errorf("truncated bit should not be set")
+	if !reply.Truncated {
+		t.Errorf("truncated bit should be set")
 	}
 	opt := reply.Extra[len(reply.Extra)-1]
 	if opt.Header().Rrtype != TypeOPT {
@@ -96,8 +96,8 @@ func TestRequestTruncateExtraRegression(t *testing.T) {
 	if want, got := size, reply.Len(); want < got {
 		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
 	}
-	if reply.Truncated {
-		t.Errorf("truncated bit should not be set")
+	if !reply.Truncated {
+		t.Errorf("truncated bit should be set")
 	}
 	opt := reply.Extra[len(reply.Extra)-1]
 	if opt.Header().Rrtype != TypeOPT {


### PR DESCRIPTION
This changes the `(*Msg).Truncate` implementation to set the `TC` header flag whenever any RR is omitted from the response. Previously the `TC` flag was only set when an answer RR had to be omitted.

Fixes #987 (see this issue for a discussion on this approach).

/cc @markdingo