### PR TITLE
pool the transient maps used for Msg Pack, Truncate and Len

### DIFF
--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -54,7 +54,7 @@ func (dns *Msg) Truncate(size int) {
 		size -= Len(edns0)
 	}
 
-	compression := make(map[string]struct{})
+	compression := compressionPool.Get().(map[string]struct{})
 
 	l = headerSize
 	for _, r := range dns.Question {
@@ -88,6 +88,11 @@ func (dns *Msg) Truncate(size int) {
 		// Add the OPT record back onto the additional section.
 		dns.Extra = append(dns.Extra, edns0)
 	}
+
+	for k := range compression {
+		delete(compression, k)
+	}
+	compressionPool.Put(compression)
 }
 
 func truncateLoop(rrs []RR, size, l int, compression map[string]struct{}) (int, int) {


### PR DESCRIPTION
This improves runtime by 20-40% and more importantly significantly reduces memory usage and allocations.  The goal here is to reduce allocations.

Benchmarks:
```
benchmark                                          old ns/op     new ns/op     delta
BenchmarkMsgLength-12                              337           263           -21.96%
BenchmarkMsgLengthNoCompression-12                 48.0          49.6          +3.33%
BenchmarkMsgLengthPack-12                          1010          963           -4.65%
BenchmarkMsgLengthMassive-12                       25409         14551         -42.73%
BenchmarkMsgLengthOnlyQuestion-12                  13.3          13.6          +2.26%
BenchmarkMsgLengthEscapedName-12                   108           112           +3.70%
BenchmarkPackDomainName-12                         140           143           +2.14%
BenchmarkUnpackDomainName-12                       118           119           +0.85%
BenchmarkUnpackDomainNameUnprintable-12            97.0          97.5          +0.52%
BenchmarkUnpackDomainNameLongest-12                510           507           -0.59%
BenchmarkUnpackDomainNameLongestUnprintable-12     1270          1276          +0.47%
BenchmarkCopy-12                                   222           228           +2.70%
BenchmarkPackA-12                                  48.7          48.7          +0.00%
BenchmarkUnpackA-12                                122           123           +0.82%
BenchmarkPackMX-12                                 88.1          88.4          +0.34%
BenchmarkUnpackMX-12                               146           145           -0.68%
BenchmarkPackAAAAA-12                              41.3          41.0          -0.73%
BenchmarkUnpackAAAA-12                             132           131           -0.76%
BenchmarkPackMsg-12                                965           935           -3.11%
BenchmarkPackMsgMassive-12                         42512         31269         -26.45%
BenchmarkPackMsgOnlyQuestion-12                    191           200           +4.71%
BenchmarkUnpackMsg-12                              1038          1037          -0.10%
BenchmarkIdGeneration-12                           13.5          13.5          +0.00%
BenchmarkReverseAddr/IP4-12                        103           104           +0.97%
BenchmarkReverseAddr/IP6-12                        110           112           +1.82%
BenchmarkGenerate-12                               156365        155104        -0.81%
BenchmarkSplitLabels-12                            40.7          40.2          -1.23%
BenchmarkLenLabels-12                              26.2          26.4          +0.76%
BenchmarkCompareDomainName-12                      108           108           +0.00%
BenchmarkIsSubDomain-12                            350           351           +0.29%
BenchmarkUnpackString-12                           78.0          78.5          +0.64%
BenchmarkMsgTruncate-12                            8926          5953          -33.31%
BenchmarkHashName/150-12                           20891         21504         +2.93%
BenchmarkHashName/2500-12                          338180        339422        +0.37%
BenchmarkHashName/5000-12                          659772        670657        +1.65%
BenchmarkHashName/10000-12                         1330291       1348682       +1.38%
BenchmarkHashName/65535-12                         8839862       8698766       -1.60%
BenchmarkDedup-12                                  1553          1568          +0.97%
BenchmarkNewRR-12                                  2090          2089          -0.05%
BenchmarkReadRR-12                                 2358          2339          -0.81%
BenchmarkParseZone-12                              37784         37818         +0.09%
BenchmarkZoneParser-12                             10718         11111         +3.67%
BenchmarkMuxMatch/lowercase-12                     61.6          58.9          -4.38%
BenchmarkMuxMatch/uppercase-12                     100           105           +5.00%
BenchmarkServe-12                                  130004        141492        +8.84%
BenchmarkServe6-12                                 143604        137140        -4.50%
BenchmarkServeCompress-12                          134134        139924        +4.32%
BenchmarkSprintName-12                             171           174           +1.75%
BenchmarkSprintTxtOctet-12                         116           120           +3.45%
BenchmarkSprintTxt-12                              206           203           -1.46%

benchmark                                          old allocs     new allocs     delta
BenchmarkMsgLength-12                              2              0              -100.00%
BenchmarkMsgLengthNoCompression-12                 0              0              +0.00%
BenchmarkMsgLengthPack-12                          3              1              -66.67%
BenchmarkMsgLengthMassive-12                       11             0              -100.00%
BenchmarkMsgLengthOnlyQuestion-12                  0              0              +0.00%
BenchmarkMsgLengthEscapedName-12                   0              0              +0.00%
BenchmarkPackDomainName-12                         0              0              +0.00%
BenchmarkUnpackDomainName-12                       1              1              +0.00%
BenchmarkUnpackDomainNameUnprintable-12            1              1              +0.00%
BenchmarkUnpackDomainNameLongest-12                1              1              +0.00%
BenchmarkUnpackDomainNameLongestUnprintable-12     1              1              +0.00%
BenchmarkCopy-12                                   7              7              +0.00%
BenchmarkPackA-12                                  0              0              +0.00%
BenchmarkUnpackA-12                                3              3              +0.00%
BenchmarkPackMX-12                                 0              0              +0.00%
BenchmarkUnpackMX-12                               4              4              +0.00%
BenchmarkPackAAAAA-12                              0              0              +0.00%
BenchmarkUnpackAAAA-12                             3              3              +0.00%
BenchmarkPackMsg-12                                2              0              -100.00%
BenchmarkPackMsgMassive-12                         12             1              -91.67%
BenchmarkPackMsgOnlyQuestion-12                    0              0              +0.00%
BenchmarkUnpackMsg-12                              12             12             +0.00%
BenchmarkIdGeneration-12                           0              0              +0.00%
BenchmarkReverseAddr/IP4-12                        2              2              +0.00%
BenchmarkReverseAddr/IP6-12                        2              2              +0.00%
BenchmarkGenerate-12                               1429           1429           +0.00%
BenchmarkSplitLabels-12                            1              1              +0.00%
BenchmarkLenLabels-12                              0              0              +0.00%
BenchmarkCompareDomainName-12                      2              2              +0.00%
BenchmarkIsSubDomain-12                            6              6              +0.00%
BenchmarkUnpackString-12                           2              2              +0.00%
BenchmarkMsgTruncate-12                            6              0              -100.00%
BenchmarkHashName/150-12                           6              6              +0.00%
BenchmarkHashName/2500-12                          6              6              +0.00%
BenchmarkHashName/5000-12                          6              6              +0.00%
BenchmarkHashName/10000-12                         6              6              +0.00%
BenchmarkHashName/65535-12                         6              6              +0.00%
BenchmarkDedup-12                                  31             31             +0.00%
BenchmarkNewRR-12                                  14             14             +0.00%
BenchmarkReadRR-12                                 16             16             +0.00%
BenchmarkParseZone-12                              92             92             +0.00%
BenchmarkZoneParser-12                             81             81             +0.00%
BenchmarkMuxMatch/lowercase-12                     0              0              +0.00%
BenchmarkMuxMatch/uppercase-12                     1              1              +0.00%
BenchmarkServe-12                                  53             53             +0.00%
BenchmarkServe6-12                                 50             50             +0.00%
BenchmarkServeCompress-12                          55             53             -3.64%
BenchmarkSprintName-12                             2              2              +0.00%
BenchmarkSprintTxtOctet-12                         2              2              +0.00%
BenchmarkSprintTxt-12                              2              2              +0.00%

benchmark                                          old bytes     new bytes     delta
BenchmarkMsgLength-12                              192           0             -100.00%
BenchmarkMsgLengthNoCompression-12                 0             0             +0.00%
BenchmarkMsgLengthPack-12                          528           320           -39.39%
BenchmarkMsgLengthMassive-12                       10865         0             -100.00%
BenchmarkMsgLengthOnlyQuestion-12                  0             0             +0.00%
BenchmarkMsgLengthEscapedName-12                   0             0             +0.00%
BenchmarkPackDomainName-12                         0             0             +0.00%
BenchmarkUnpackDomainName-12                       64            64            +0.00%
BenchmarkUnpackDomainNameUnprintable-12            48            48            +0.00%
BenchmarkUnpackDomainNameLongest-12                256           256           +0.00%
BenchmarkUnpackDomainNameLongestUnprintable-12     1024          1024          +0.00%
BenchmarkCopy-12                                   288           288           +0.00%
BenchmarkPackA-12                                  0             0             +0.00%
BenchmarkUnpackA-12                                100           100           +0.00%
BenchmarkPackMX-12                                 0             0             +0.00%
BenchmarkUnpackMX-12                               116           116           +0.00%
BenchmarkPackAAAAA-12                              0             0             +0.00%
BenchmarkUnpackAAAA-12                             112           112           +0.00%
BenchmarkPackMsg-12                                208           0             -100.00%
BenchmarkPackMsgMassive-12                         18981         6787          -64.24%
BenchmarkPackMsgOnlyQuestion-12                    0             0             +0.00%
BenchmarkUnpackMsg-12                              592           592           +0.00%
BenchmarkIdGeneration-12                           0             0             +0.00%
BenchmarkReverseAddr/IP4-12                        48            48            +0.00%
BenchmarkReverseAddr/IP6-12                        96            96            +0.00%
BenchmarkGenerate-12                               33887         33887         +0.00%
BenchmarkSplitLabels-12                            32            32            +0.00%
BenchmarkLenLabels-12                              0             0             +0.00%
BenchmarkCompareDomainName-12                      64            64            +0.00%
BenchmarkIsSubDomain-12                            192           192           +0.00%
BenchmarkUnpackString-12                           48            48            +0.00%
BenchmarkMsgTruncate-12                            2398          52            -97.83%
BenchmarkHashName/150-12                           468           468           +0.00%
BenchmarkHashName/2500-12                          468           468           +0.00%
BenchmarkHashName/5000-12                          468           468           +0.00%
BenchmarkHashName/10000-12                         468           468           +0.00%
BenchmarkHashName/65535-12                         468           468           +0.00%
BenchmarkDedup-12                                  624           624           +0.00%
BenchmarkNewRR-12                                  688           688           +0.00%
BenchmarkReadRR-12                                 1696          1696          +0.00%
BenchmarkParseZone-12                              84417         84417         +0.00%
BenchmarkZoneParser-12                             1968          1968          +0.00%
BenchmarkMuxMatch/lowercase-12                     0             0             +0.00%
BenchmarkMuxMatch/uppercase-12                     32            32            +0.00%
BenchmarkServe-12                                  3265          3265          +0.00%
BenchmarkServe6-12                                 3106          3105          -0.03%
BenchmarkServeCompress-12                          3473          3266          -5.96%
BenchmarkSprintName-12                             48            48            +0.00%
BenchmarkSprintTxtOctet-12                         80            80            +0.00%
BenchmarkSprintTxt-12                              80            80            +0.00%
```