### PR TITLE
types: improve the performance of sprintName by ~30% and halve allocs

### DIFF
--- a/types_test.go
+++ b/types_test.go
@@ -133,6 +133,16 @@ func BenchmarkSprintName(b *testing.B) {
 	}
 }
 
+func BenchmarkSprintName_NoEscape(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		got := sprintName("large.example.com")
+
+		if want := "large.example.com"; got != want {
+			b.Fatalf("expected %q, got %q", got, want)
+		}
+	}
+}
+
 func BenchmarkSprintTxtOctet(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		got := sprintTxtOctet("abc\\.def\007\"\127@\255\x05\xef\\")
@@ -149,6 +159,7 @@ func BenchmarkSprintTxt(b *testing.B) {
 		"example.com",
 	}
 
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		got := sprintTxt(txt)
 


### PR DESCRIPTION
This PR improves performance and memory usage by lazily allocating the `strings.Builder` and by inlining the `writeDomainNameByte()` logic.

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkSprintName-12              180           120           -33.33%
BenchmarkSprintName_NoEscape-12     198           82.4          -58.38%

benchmark                           old allocs     new allocs     delta
BenchmarkSprintName-12              2              1              -50.00%
BenchmarkSprintName_NoEscape-12     1              0              -100.00%

benchmark                           old bytes     new bytes     delta
BenchmarkSprintName-12              48            32            -33.33%
BenchmarkSprintName_NoEscape-12     32            0             -100.00%
```

**Edit:** forgot to include the results of `BenchmarkSprintName_NoEscape`.