### PR TITLE
msg_helpers: improve perf of unpackString by 20% and halve allocs

### DIFF
--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -261,28 +261,42 @@ func packUint64(i uint64, msg []byte, off int) (off1 int, err error) {
 }
 
 func unpackString(msg []byte, off int) (string, int, error) {
-	if off+1 > len(msg) {
+	start := off + 1
+	if start > len(msg) {
 		return "", off, &Error{err: "overflow unpacking txt"}
 	}
 	l := int(msg[off])
-	if off+l+1 > len(msg) {
+	end := start + l
+	if end > len(msg) {
 		return "", off, &Error{err: "overflow unpacking txt"}
 	}
 	var s strings.Builder
-	s.Grow(l)
-	for _, b := range msg[off+1 : off+1+l] {
+	p := msg[start:end]
+	for i, b := range p {
 		switch {
 		case b == '"' || b == '\\':
+			if s.Len() == 0 {
+				s.Grow(l * 2)
+				s.Write(p[:i])
+			}
 			s.WriteByte('\\')
 			s.WriteByte(b)
 		case b < ' ' || b > '~': // unprintable
+			if s.Len() == 0 {
+				s.Grow(l * 2)
+				s.Write(p[:i])
+			}
 			s.WriteString(escapeByte(b))
 		default:
-			s.WriteByte(b)
+			if s.Len() != 0 {
+				s.WriteByte(b)
+			}
 		}
 	}
-	off += 1 + l
-	return s.String(), off, nil
+	if s.Len() == 0 {
+		return string(p), end, nil
+	}
+	return s.String(), end, nil
 }
 
 func packString(s string, msg []byte, off int) (int, error) {

--- a/msg_helpers_test.go
+++ b/msg_helpers_test.go
@@ -136,3 +136,19 @@ func BenchmarkUnpackString(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkUnpackString_NoEscape(b *testing.B) {
+	msg := []byte("\x00large.example.com")
+	msg[0] = byte(len(msg) - 1)
+
+	for n := 0; n < b.N; n++ {
+		got, _, err := unpackString(msg, 0)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if want := `large.example.com`; want != got {
+			b.Errorf("expected %q, got %q", want, got)
+		}
+	}
+}


### PR DESCRIPTION
**Edit:** forgot to include results from: `BenchmarkUnpackString_NoEscape`
```
benchmark                             old ns/op     new ns/op     delta
BenchmarkUnpackString-12              79.7          64.5          -19.07%
BenchmarkUnpackString_NoEscape-12     51.3          51.8          +0.97%

benchmark                             old allocs     new allocs     delta
BenchmarkUnpackString-12              2              1              -50.00%
BenchmarkUnpackString_NoEscape-12     1              1              +0.00%

benchmark                             old bytes     new bytes     delta
BenchmarkUnpackString-12              48            32            -33.33%
BenchmarkUnpackString_NoEscape-12     32            32            +0.00%
```