### PR TITLE
Use strings.ToLower in ServeMux.match

### DIFF
--- a/serve_mux.go
+++ b/serve_mux.go
@@ -36,33 +36,9 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 		return nil
 	}
 
+	q = strings.ToLower(q)
+
 	var handler Handler
-
-	// TODO(tmthrgd): Once https://go-review.googlesource.com/c/go/+/137575
-	// lands in a go release, replace the following with strings.ToLower.
-	var sb strings.Builder
-	for i := 0; i < len(q); i++ {
-		c := q[i]
-		if !(c >= 'A' && c <= 'Z') {
-			continue
-		}
-
-		sb.Grow(len(q))
-		sb.WriteString(q[:i])
-
-		for ; i < len(q); i++ {
-			c := q[i]
-			if c >= 'A' && c <= 'Z' {
-				c += 'a' - 'A'
-			}
-
-			sb.WriteByte(c)
-		}
-
-		q = sb.String()
-		break
-	}
-
 	for off, end := 0, false; !end; off, end = NextLabel(q, off) {
 		if h, ok := mux.z[q[off:]]; ok {
 			if t != TypeDS {


### PR DESCRIPTION
This has been a long standing TODO. [golang.org/cl/137575](https://golang.org/cl/137575) was included in go1.12 which is the oldest officially supported release.