### PR TITLE
Improve unpackString performance

### DIFF
--- a/msg_helpers_test.go
+++ b/msg_helpers_test.go
@@ -122,17 +122,34 @@ func TestUnpackString(t *testing.T) {
 }
 
 func BenchmarkUnpackString(b *testing.B) {
-	msg := []byte("\x00abcdef\x0f\\\"ghi\x04mmm")
-	msg[0] = byte(len(msg) - 1)
+	b.Run("Escaped", func(b *testing.B) {
+		msg := []byte("\x00abcdef\x0f\\\"ghi\x04mmm")
+		msg[0] = byte(len(msg) - 1)
 
-	for n := 0; n < b.N; n++ {
-		got, _, err := unpackString(msg, 0)
-		if err != nil {
-			b.Fatal(err)
-		}
+		for n := 0; n < b.N; n++ {
+			got, _, err := unpackString(msg, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
 
-		if want := `abcdef\015\\\"ghi\004mmm`; want != got {
-			b.Errorf("expected %q, got %q", want, got)
+			if want := `abcdef\015\\\"ghi\004mmm`; want != got {
+				b.Errorf("expected %q, got %q", want, got)
+			}
 		}
-	}
+	})
+	b.Run("Unescaped", func(b *testing.B) {
+		msg := []byte("\x00large.example.com")
+		msg[0] = byte(len(msg) - 1)
+
+		for n := 0; n < b.N; n++ {
+			got, _, err := unpackString(msg, 0)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if want := "large.example.com"; want != got {
+				b.Errorf("expected %q, got %q", want, got)
+			}
+		}
+	})
 }


### PR DESCRIPTION
This is an alternative approach to #1009.

I'm not convinced this is really worth doing, because it does add a decent amount of complexity no matter how you approach it. That being said, it does show a performance improvement and reduces the allocations when there is escaping.

```
name                       old time/op    new time/op    delta
UnpackString/Escaped-12      83.7ns ± 7%    78.2ns ± 3%   -6.50%  (p=0.000 n=10+9)
UnpackString/Unescaped-12    57.8ns ± 9%    50.4ns ±13%  -12.74%  (p=0.000 n=10+10)

name                       old alloc/op   new alloc/op   delta
UnpackString/Escaped-12       48.0B ± 0%     32.0B ± 0%  -33.33%  (p=0.000 n=10+10)
UnpackString/Unescaped-12     32.0B ± 0%     32.0B ± 0%     ~     (all equal)

name                       old allocs/op  new allocs/op  delta
UnpackString/Escaped-12        2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
UnpackString/Unescaped-12      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```

/cc @charlievieth