### PR TITLE
[fuzz] Fix crashes when parsing GENERATE

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -53,7 +53,14 @@ func (zp *ZoneParser) generate(l lex) (RR, bool) {
 		return zp.setParseError("bad range in $GENERATE range", l)
 	}
 
-	zp.c.Next() // _BLANK
+	// _BLANK
+	if l, ok := zp.c.Next(); ok {
+		if l.value != zBlank {
+			return zp.setParseError("Expect blank after $GENERATE range", l)
+		}
+	} else {
+		return zp.setParseError("Failed to parse token after $GENERATE range", l)
+	}
 
 	// Create a complete new string, which we then parse again.
 	var s string

--- a/generate.go
+++ b/generate.go
@@ -54,12 +54,9 @@ func (zp *ZoneParser) generate(l lex) (RR, bool) {
 	}
 
 	// _BLANK
-	if l, ok := zp.c.Next(); ok {
-		if l.value != zBlank {
-			return zp.setParseError("Expect blank after $GENERATE range", l)
-		}
-	} else {
-		return zp.setParseError("Failed to parse token after $GENERATE range", l)
+	l, ok := zp.c.Next()
+	if !ok || l.value != zBlank {
+			return zp.setParseError("garbage after $GENERATE range", l)
 	}
 
 	// Create a complete new string, which we then parse again.

--- a/generate_test.go
+++ b/generate_test.go
@@ -212,10 +212,10 @@ func TestCrasherString(t *testing.T) {
 	in  string
 	err string
 }{
-		{"$GENERATE 0-300103\"$$GENERATE 2-2", "dns: Expect blank after $GENERATE range: \"\\\"\" at line: 1:19"},
-		{"$GENERATE 0-5414137360", "dns: Expect blank after $GENERATE range: \"\\n\" at line: 1:22"},
-		{"$GENERATE       11522-3668518066406258", "dns: Expect blank after $GENERATE range: \"\\n\" at line: 1:38"},
-		{"$GENERATE 0-200\"(;00000000000000\n$$GENERATE 0-0", "dns: Expect blank after $GENERATE range: \"\\\"\" at line: 1:16"},
+		{"$GENERATE 0-300103\"$$GENERATE 2-2", "dns: garbage after $GENERATE range: \"\\\"\" at line: 1:19"},
+		{"$GENERATE 0-5414137360", "dns: garbage after $GENERATE range: \"\\n\" at line: 1:22"},
+		{"$GENERATE       11522-3668518066406258", "dns: garbage after $GENERATE range: \"\\n\" at line: 1:38"},
+		{"$GENERATE 0-200\"(;00000000000000\n$$GENERATE 0-0", "dns: garbage after $GENERATE range: \"\\\"\" at line: 1:16"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.in, func(t *testing.T) {

--- a/generate_test.go
+++ b/generate_test.go
@@ -204,3 +204,28 @@ $GENERATE 32-158 dhcp-${-32,4,d} A 10.0.0.$
 		}
 	}
 }
+
+
+
+func TestCrasherString(t *testing.T) {
+	tests := []struct{
+	in  string
+	err string
+}{
+		{"$GENERATE 0-300103\"$$GENERATE 2-2", "dns: Expect blank after $GENERATE range: \"\\\"\" at line: 1:19"},
+		{"$GENERATE 0-5414137360", "dns: Expect blank after $GENERATE range: \"\\n\" at line: 1:22"},
+		{"$GENERATE       11522-3668518066406258", "dns: Expect blank after $GENERATE range: \"\\n\" at line: 1:38"},
+		{"$GENERATE 0-200\"(;00000000000000\n$$GENERATE 0-0", "dns: Expect blank after $GENERATE range: \"\\\"\" at line: 1:16"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			_, err := NewRR(tc.in)
+			if err == nil {
+				t.Errorf("Expecting error for crasher line %s", tc.in)
+			}
+			if tc.err != err.Error() {
+				t.Errorf("Expecting error %s, got %s", tc.err, err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Running the fuzzer on NewRR, some crashes came up that could be
prevented by checking that the token after the range is a Blank.
This diff checks that and return an error when the blank is not found.