### PR TITLE
Provide zp.ClearError()

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -8,3 +8,4 @@ Peter van Dijk
 Omri Bahumi
 Alex Sergeyev
 James Hartig
+Luis Muñoz

--- a/scan.go
+++ b/scan.go
@@ -275,6 +275,14 @@ func NewZoneParser(r io.Reader, origin, file string) *ZoneParser {
 	}
 }
 
+// ClearError resets the error state of the parser. This is useful to forcibly
+// parse widely distributed but malformed zones such as .us, which include TSIG
+// pseudo-RRs. By clearing the error state from the parsing loop, the user is
+// able to skip the errors.
+func (zp *ZoneParser) ClearError() {
+	zp.parseErr = nil
+}
+
 // SetDefaultTTL sets the parsers default TTL to ttl.
 func (zp *ZoneParser) SetDefaultTTL(ttl uint32) {
 	zp.defttl = &ttlState{ttl, false}


### PR DESCRIPTION
Various zone files distributed by ICANN via the CZDS as well as via direct interfaces provided by the respective registry operator, contain malformed or bogus records.

Examples at the time of this writing include .us as distributed by Neustar and .tel as available through the CZDS.

High-performance processing pipelines can benefit from filtering those bogus records on the fly.

The ClearError() method allows these classes of applications to simply have the parser state machine to step through these errors without changing the parser or otherwise affecting its correctness.