### PR TITLE
build: reduce testing output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 sudo: false
 
 go:
-  - 1.11.x
-  - 1.12.x
+  - "1.12.x"
+  - "1.13.x"
   - tip
 
 env:

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -147,12 +147,13 @@ func TestCrashNSEC3(t *testing.T) {
 // TestNewRRCommentLengthCrasherString test inputs to NewRR that generated crashes.
 func TestNewRRCommentLengthCrasherString(t *testing.T) {
 	tests := []struct {
-		in  string
-		err string
+		name string
+		in   string
+		err  string
 	}{
 
 		{
-			" HINFO ;;;;;;;;;;;;;" +
+			"HINFO1", " HINFO ;;;;;;;;;;;;;" +
 				";;;;;;;;\x00\x19;;;;;;;;;;" +
 				";\u007f;;;;;;;;;;;;;;;;;;" +
 				";;}mP_Qq_3sJ_1_84X_5" +
@@ -255,7 +256,7 @@ func TestNewRRCommentLengthCrasherString(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.in, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			_, err := NewRR(tc.in)
 			if err == nil {
 				t.Errorf("Expecting error for crasher line %s", tc.in)


### PR DESCRIPTION
Use a better name in the fuzzing test to not spam the travis output,
move to Go 1.13.x in travis.yaml