### PR TITLE
Speed up NextLabel and PrevLabel

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -127,18 +127,19 @@ func Split(s string) []int {
 // Also see PrevLabel.
 func NextLabel(s string, offset int) (i int, end bool) {
 	for i = offset; i < len(s)-1; i++ {
-		if s[i] == '.' {
-			j := i - 1
-			for j >= 0 && s[j] == '\\' {
-				j--
-			}
-
-			if (j-i)%2 == 0 {
-				continue
-			}
-
-			return i + 1, false
+		if s[i] != '.' {
+			continue
 		}
+		j := i - 1
+		for j >= 0 && s[j] == '\\' {
+			j--
+		}
+
+		if (j-i)%2 == 0 {
+			continue
+		}
+
+		return i + 1, false
 	}
 	return i + 1, true
 }
@@ -158,20 +159,21 @@ func PrevLabel(s string, n int) (i int, start bool) {
 	}
 
 	for ; l >= 0 && n > 0; l-- {
-		if s[l] == '.' {
-			j := l - 1
-			for j >= 0 && s[j] == '\\' {
-				j--
-			}
+		if s[l] != '.' {
+			continue
+		}
+		j := l - 1
+		for j >= 0 && s[j] == '\\' {
+			j--
+		}
 
-			if (j-l)%2 == 0 {
-				continue
-			}
+		if (j-l)%2 == 0 {
+			continue
+		}
 
-			n--
-			if n == 0 {
-				return l + 1, false
-			}
+		n--
+		if n == 0 {
+			return l + 1, false
 		}
 	}
 

--- a/labels.go
+++ b/labels.go
@@ -126,18 +126,8 @@ func Split(s string) []int {
 // The bool end is true when the end of the string has been reached.
 // Also see PrevLabel.
 func NextLabel(s string, offset int) (i int, end bool) {
-	quote := false
 	for i = offset; i < len(s)-1; i++ {
-		switch s[i] {
-		case '\\':
-			quote = !quote
-		default:
-			quote = false
-		case '.':
-			if quote {
-				quote = !quote
-				continue
-			}
+		if s[i] == '.' && (i == 0 || s[i-1] != '\\' || (i>1 && s[i-2]=='\\')) {
 			return i + 1, false
 		}
 	}
@@ -152,14 +142,22 @@ func PrevLabel(s string, n int) (i int, start bool) {
 	if n == 0 {
 		return len(s), false
 	}
-	lab := Split(s)
-	if lab == nil {
-		return 0, true
+
+	l := len(s) - 1
+	if s[l] == '.' {
+		l--
 	}
-	if n > len(lab) {
-		return 0, true
+
+	for ; l >= 0 && n > 0; l-- {
+		if s[l] == '.' && (l==0 || s[l-1] != '\\' || (l>1 && s[i-2]=='\\')) {
+			n--
+			if n == 0 {
+				return l + 1, false
+			}
+		}
 	}
-	return lab[len(lab)-n], false
+
+	return 0, n > 1
 }
 
 // equal compares a and b while ignoring case. It returns true when equal otherwise false.

--- a/labels.go
+++ b/labels.go
@@ -149,6 +149,9 @@ func NextLabel(s string, offset int) (i int, end bool) {
 // The bool start is true when the start of the string has been overshot.
 // Also see NextLabel.
 func PrevLabel(s string, n int) (i int, start bool) {
+	if s == "" {
+		return 0, true
+	}
 	if n == 0 {
 		return len(s), false
 	}

--- a/labels.go
+++ b/labels.go
@@ -128,12 +128,12 @@ func Split(s string) []int {
 func NextLabel(s string, offset int) (i int, end bool) {
 	for i = offset; i < len(s)-1; i++ {
 		if s[i] == '.' {
-			ii := i - 1
-			for ii >= 0 && s[ii] == '\\' {
-				ii--
+			j := i - 1
+			for j >= 0 && s[j] == '\\' {
+				j--
 			}
 
-			if (ii-i)%2 == 0 {
+			if (j-i)%2 == 0 {
 				continue
 			}
 
@@ -159,12 +159,12 @@ func PrevLabel(s string, n int) (i int, start bool) {
 
 	for ; l >= 0 && n > 0; l-- {
 		if s[l] == '.' {
-			ii := l - 1
-			for ii >= 0 && s[ii] == '\\' {
-				ii--
+			j := l - 1
+			for j >= 0 && s[j] == '\\' {
+				j--
 			}
 
-			if (ii-l)%2 == 0 {
+			if (j-l)%2 == 0 {
 				continue
 			}
 

--- a/labels.go
+++ b/labels.go
@@ -127,7 +127,16 @@ func Split(s string) []int {
 // Also see PrevLabel.
 func NextLabel(s string, offset int) (i int, end bool) {
 	for i = offset; i < len(s)-1; i++ {
-		if s[i] == '.' && (i == 0 || s[i-1] != '\\' || (i>1 && s[i-2]=='\\')) {
+		if s[i] == '.' {
+			ii := i - 1
+			for ii >= 0 && s[ii] == '\\' {
+				ii--
+			}
+
+			if (ii-i)%2 == 0 {
+				continue
+			}
+
 			return i + 1, false
 		}
 	}
@@ -149,7 +158,16 @@ func PrevLabel(s string, n int) (i int, start bool) {
 	}
 
 	for ; l >= 0 && n > 0; l-- {
-		if s[l] == '.' && (l==0 || s[l-1] != '\\' || (l>1 && s[i-2]=='\\')) {
+		if s[l] == '.' {
+			ii := l - 1
+			for ii >= 0 && s[ii] == '\\' {
+				ii--
+			}
+
+			if (ii-l)%2 == 0 {
+				continue
+			}
+
 			n--
 			if n == 0 {
 				return l + 1, false

--- a/labels.go
+++ b/labels.go
@@ -126,6 +126,9 @@ func Split(s string) []int {
 // The bool end is true when the end of the string has been reached.
 // Also see PrevLabel.
 func NextLabel(s string, offset int) (i int, end bool) {
+	if s == "" {
+		return 0, true
+	}
 	for i = offset; i < len(s)-1; i++ {
 		if s[i] != '.' {
 			continue

--- a/labels_test.go
+++ b/labels_test.go
@@ -238,3 +238,63 @@ func BenchmarkIsSubDomain(b *testing.B) {
 		IsSubDomain("miek.nl.", "aa.example.com.")
 	}
 }
+
+func BenchmarkNextLabelSimple(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		NextLabel("www.example.com", 0)
+		NextLabel("www.example.com", 5)
+		NextLabel("www.example.com", 12)
+	}
+}
+
+func BenchmarkPrevLabelSimple(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		PrevLabel("www.example.com", 0)
+		PrevLabel("www.example.com", 5)
+		PrevLabel("www.example.com", 12)
+	}
+}
+
+func BenchmarkNextLabelComplex(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		NextLabel(`www\.example.com`, 0)
+		NextLabel(`www\\.example.com`, 0)
+		NextLabel(`www\\\.example.com`, 0)
+	}
+}
+
+func BenchmarkPrevLabelComplex(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		PrevLabel(`www\.example.com`, 10)
+		PrevLabel(`www\\.example.com`, 10)
+		PrevLabel(`www\\\.example.com`, 10)
+	}
+}
+
+func BenchmarkNextLabelMixed(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		NextLabel("www.example.com", 0)
+		NextLabel(`www\.example.com`, 0)
+		NextLabel("www.example.com", 5)
+		NextLabel(`www\\.example.com`, 0)
+		NextLabel("www.example.com", 12)
+		NextLabel(`www\\\.example.com`, 0)
+	}
+}
+
+func BenchmarkPrevLabelMixed(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		PrevLabel("www.example.com", 0)
+		PrevLabel(`www\.example.com`, 10)
+		PrevLabel("www.example.com", 5)
+		PrevLabel(`www\\.example.com`, 10)
+		PrevLabel("www.example.com", 12)
+		PrevLabel(`www\\\.example.com`, 10)
+	}
+}

--- a/labels_test.go
+++ b/labels_test.go
@@ -80,6 +80,25 @@ func TestSplit2(t *testing.T) {
 	}
 }
 
+func TestNextLabel(t *testing.T) {
+	type next struct {
+		string
+		int
+	}
+	nexts := map[next]int{
+		{"", 1}:             0,
+		{"www.miek.nl.", 0}: 4,
+		{"www.miek.nl.", 4}: 9,
+		{"www.miek.nl.", 9}: 12,
+	}
+	for s, i := range nexts {
+		x, ok := NextLabel(s.string, s.int)
+		if i != x {
+			t.Errorf("label should be %d, got %d, %t: nexting %d, %s", i, x, ok, s.int, s.string)
+		}
+	}
+}
+
 func TestPrevLabel(t *testing.T) {
 	type prev struct {
 		string

--- a/labels_test.go
+++ b/labels_test.go
@@ -86,6 +86,7 @@ func TestPrevLabel(t *testing.T) {
 		int
 	}
 	prever := map[prev]int{
+		{"", 1}:             0,
 		{"www.miek.nl.", 0}: 12,
 		{"www.miek.nl.", 1}: 9,
 		{"www.miek.nl.", 2}: 4,

--- a/labels_test.go
+++ b/labels_test.go
@@ -40,16 +40,17 @@ func TestCompareDomainName(t *testing.T) {
 
 func TestSplit(t *testing.T) {
 	splitter := map[string]int{
-		"www.miek.nl.":   3,
-		"www.miek.nl":    3,
-		"www..miek.nl":   4,
-		`www\.miek.nl.`:  2,
-		`www\\.miek.nl.`: 3,
-		".":              0,
-		"nl.":            1,
-		"nl":             1,
-		"com.":           1,
-		".com.":          2,
+		"www.miek.nl.":    3,
+		"www.miek.nl":     3,
+		"www..miek.nl":    4,
+		`www\.miek.nl.`:   2,
+		`www\\.miek.nl.`:  3,
+		`www\\\.miek.nl.`: 2,
+		".":               0,
+		"nl.":             1,
+		"nl":              1,
+		"com.":            1,
+		".com.":           2,
 	}
 	for s, i := range splitter {
 		if x := len(Split(s)); x != i {


### PR DESCRIPTION
NextLabel and PrevLabel are heavily used in the "file" plugin in coredns. This change introduces benchmark tests and improves the performance (on my machine).

It eliminates all allocations and uses strings in a way that should make L1-Cache-Hits more likely.

The time for coredns "file"-plugin Requests is cut roughly in half.