### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @miekg @tmthrgd


### PR DESCRIPTION
git shows:

 git shortlog -sne | head
  3311	Miek Gieben <miek@miek.nl>
   157	Tom Thorogood <me+github@tomthorogood.co.uk>
    39	Alex Sergeyev <asergeyev@dyn.com>
    37	Andrew Tunnell-Jones <andrew@tj.id.au>
    34	Filippo Valsorda <filippo@cloudflare.com>
    21	Rafael Dantas Justo <rafael@registro.br>
    19	Michael Haro <mharo@google.com>
    14	Alex Sergeyev <abc@alexsergeyev.com>
    13	chantra <chantra@users.noreply.github.com>
    11	Alex Ciuba <alexciuba@gmail.com>

I took the top 2, but happy to extend this obvs.