### PR TITLE
code generation compatible with go modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - GO111MODULE=on
 
 script:
+  - go generate ./... && test `git ls-files --modified | wc -l` = 0
   - go test -race -v -bench=. -coverprofile=coverage.txt -covermode=atomic ./...
 
 after_success:

--- a/duplicate_generate.go
+++ b/duplicate_generate.go
@@ -11,10 +11,11 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"go/importer"
 	"go/types"
 	"log"
 	"os"
+
+	"golang.org/x/tools/go/packages"
 )
 
 var packageHdr = `
@@ -39,9 +40,19 @@ func getTypeStruct(t types.Type, scope *types.Scope) (*types.Struct, bool) {
 	return nil, false
 }
 
+// loadModule retrieves package description for a given module.
+func loadModule(name string) (*types.Package, error) {
+	conf := packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo}
+	pkgs, err := packages.Load(&conf, name)
+	if err != nil {
+		return nil, err
+	}
+	return pkgs[0].Types, nil
+}
+
 func main() {
 	// Import and type-check the package
-	pkg, err := importer.Default().Import("github.com/miekg/dns")
+	pkg, err := loadModule("github.com/miekg/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,9 @@ module github.com/miekg/dns
 go 1.12
 
 require (
-	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550
 	golang.org/x/net v0.0.0-20190923162816-aa69164e4478
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe
-	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20190907020128-2ca718005c18 // indirect
+	golang.org/x/tools v0.0.0-20191216052735-49a3e744a425 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,9 @@ golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472 h1:Gv7RPwsi3eZ2Fgewe3CBsu
 golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3 h1:dgd4x4kJt7G4k4m93AYLzM8Ni6h2qLTfh9n9vXJT3/0=
 golang.org/x/net v0.0.0-20180926154720-4dfa2610cdf3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -30,4 +33,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190907020128-2ca718005c18/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191216052735-49a3e744a425 h1:VvQyQJN0tSuecqgcIxMWnnfG5kSmgy9KZR9sW3W5QeA=
+golang.org/x/tools v0.0.0-20191216052735-49a3e744a425/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -10,11 +10,12 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"go/importer"
 	"go/types"
 	"log"
 	"os"
 	"strings"
+
+	"golang.org/x/tools/go/packages"
 )
 
 var packageHdr = `
@@ -44,9 +45,19 @@ func getTypeStruct(t types.Type, scope *types.Scope) (*types.Struct, bool) {
 	return nil, false
 }
 
+// loadModule retrieves package description for a given module.
+func loadModule(name string) (*types.Package, error) {
+	conf := packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo}
+	pkgs, err := packages.Load(&conf, name)
+	if err != nil {
+		return nil, err
+	}
+	return pkgs[0].Types, nil
+}
+
 func main() {
 	// Import and type-check the package
-	pkg, err := importer.Default().Import("github.com/miekg/dns")
+	pkg, err := loadModule("github.com/miekg/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 

--- a/types_generate.go
+++ b/types_generate.go
@@ -11,12 +11,13 @@ import (
 	"bytes"
 	"fmt"
 	"go/format"
-	"go/importer"
 	"go/types"
 	"log"
 	"os"
 	"strings"
 	"text/template"
+
+	"golang.org/x/tools/go/packages"
 )
 
 var skipLen = map[string]struct{}{
@@ -81,9 +82,19 @@ func getTypeStruct(t types.Type, scope *types.Scope) (*types.Struct, bool) {
 	return nil, false
 }
 
+// loadModule retrieves package description for a given module.
+func loadModule(name string) (*types.Package, error) {
+	conf := packages.Config{Mode: packages.NeedTypes | packages.NeedTypesInfo}
+	pkgs, err := packages.Load(&conf, name)
+	if err != nil {
+		return nil, err
+	}
+	return pkgs[0].Types, nil
+}
+
 func main() {
 	// Import and type-check the package
-	pkg, err := importer.Default().Import("github.com/miekg/dns")
+	pkg, err := loadModule("github.com/miekg/dns")
 	fatalIfErr(err)
 	scope := pkg.Scope()
 


### PR DESCRIPTION
The programs to generate type definitions use `go/importer` which is not compatible with go modules and require `miekg/dns` to be installed globally. This PR replaces `go/importer` with the new `golang.org/x/tools/go/packages` which is module aware.