### PR TITLE
unused local variable assignment 

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -661,7 +661,6 @@ func unpackRRslice(l int, msg []byte, off int) (dst1 []RR, off1 int, err error) 
 		}
 		// If offset does not increase anymore, l is a lie
 		if off1 == off {
-			l = i
 			break
 		}
 		dst = append(dst, r)

--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -73,7 +73,7 @@ func (dns *Msg) Truncate(size int) {
 
 	var numExtra int
 	if l < size {
-		l, numExtra = truncateLoop(dns.Extra, size, l, compression)
+		_, numExtra = truncateLoop(dns.Extra, size, l, compression)
 	}
 
 	// See the function documentation for when we set this.


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This is a tiny code clean up. In both cases, a value is assigned to the local variable `l` but never used afterwards.