### PR TITLE
Tsig secret provider

### DIFF
--- a/client.go
+++ b/client.go
@@ -36,12 +36,18 @@ type Client struct {
 	// WriteTimeout when non-zero. Can be overridden with net.Dialer.Timeout (see Client.ExchangeWithDialer and
 	// Client.Dialer) or context.Context.Deadline (see the deprecated ExchangeContext)
 	Timeout        time.Duration
-	DialTimeout    time.Duration      // net.DialTimeout, defaults to 2 seconds, or net.Dialer.Timeout if expiring earlier - overridden by Timeout when that value is non-zero
-	ReadTimeout    time.Duration      // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
-	WriteTimeout   time.Duration      // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
-	TsigSecrets    TsigSecretResolver // TsigSecrets will be used to resolve the given secret name in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2) into the corresponding secret bytes.
-	SingleInflight bool               // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
+	DialTimeout    time.Duration // net.DialTimeout, defaults to 2 seconds, or net.Dialer.Timeout if expiring earlier - overridden by Timeout when that value is non-zero
+	ReadTimeout    time.Duration // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
+	WriteTimeout   time.Duration // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
+	SingleInflight bool          // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
+
+	// secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	//
+	// Deprecated: Please use TsigSecrets field and the TsigSecretMap container.
+	TsigSecret map[string]string
+	// TsigSecrets will be used to resolve the given secret name in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2) into the corresponding secret bytes.
+	TsigSecrets TsigSecretResolver
 }
 
 // Exchange performs a synchronous UDP query. It sends the message m to the address
@@ -162,6 +168,11 @@ func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err erro
 	}
 
 	co.TsigSecrets = c.TsigSecrets
+	if co.TsigSecrets == nil && c.TsigSecret != nil {
+		co.TsigSecrets = TsigSecretResolverFunc(func(name string) (secret []byte) {
+			return extractTsigSecret(c.TsigSecret, name)
+		})
+	}
 	t := time.Now()
 	// write with the appropriate write timeout
 	co.SetWriteDeadline(t.Add(c.getTimeoutForRequest(c.writeTimeout())))

--- a/tsig.go
+++ b/tsig.go
@@ -37,6 +37,31 @@ func (m TsigSecretMap) SetBase64Secret(name, secret string) error {
 	return nil
 }
 
+// The TsigSecretResolverFunc type is an adapter similar
+// to http.HandlerFunc that allows the use of ordinary
+// functions as TSIG secret resolvers. If f is a function
+// with the appropriate signature, TsigSecretResolverFunc(f)
+// is a TSIG secret resolver that calls f.
+type TsigSecretResolverFunc func(name string) (secret []byte)
+
+// Resolve calls f(name)
+func (f TsigSecretResolverFunc) Resolve(name string) (secret []byte) {
+	return f(name)
+}
+
+func extractTsigSecret(secrets map[string]string, name string) (secret []byte) {
+	s, ok := secrets[name]
+	if !ok {
+		return nil
+	}
+
+	secret, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return nil
+	}
+	return secret
+}
+
 // HMAC hashing codes. These are transmitted as domain names.
 const (
 	HmacMD5    = "hmac-md5.sig-alg.reg.int."

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -1,10 +1,19 @@
 package dns
 
 import (
+	"encoding/base64"
 	"encoding/binary"
 	"testing"
 	"time"
 )
+
+func newSecret(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
 
 func newTsig(algo string) *Msg {
 	m := new(Msg)
@@ -14,12 +23,14 @@ func newTsig(algo string) *Msg {
 }
 
 func TestTsig(t *testing.T) {
+	secret := newSecret("pRZgBrBvI4NAHZYhxmhs/Q==")
+
 	m := newTsig(HmacMD5)
-	buf, _, err := TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	buf, _, err := TsigGenerate(m, secret, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = TsigVerify(buf, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	err = TsigVerify(buf, secret, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -27,25 +38,27 @@ func TestTsig(t *testing.T) {
 	// TSIG accounts for ID substitution. This means if the message ID is
 	// changed by a forwarder, we should still be able to verify the TSIG.
 	m = newTsig(HmacMD5)
-	buf, _, err = TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	buf, _, err = TsigGenerate(m, secret, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	binary.BigEndian.PutUint16(buf[0:2], 42)
-	err = TsigVerify(buf, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	err = TsigVerify(buf, secret, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestTsigCase(t *testing.T) {
+	secret := newSecret("pRZgBrBvI4NAHZYhxmhs/Q==")
+
 	m := newTsig("HmAc-mD5.sig-ALg.rEg.int.") // HmacMD5
-	buf, _, err := TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	buf, _, err := TsigGenerate(m, secret, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = TsigVerify(buf, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
+	err = TsigVerify(buf, secret, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/xfr.go
+++ b/xfr.go
@@ -14,10 +14,10 @@ type Envelope struct {
 // A Transfer defines parameters that are used during a zone transfer.
 type Transfer struct {
 	*Conn
-	DialTimeout    time.Duration     // net.DialTimeout, defaults to 2 seconds
-	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds
-	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds
-	TsigSecret     map[string]string // Secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	DialTimeout    time.Duration      // net.DialTimeout, defaults to 2 seconds
+	ReadTimeout    time.Duration      // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds
+	WriteTimeout   time.Duration      // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds
+	TsigSecrets    TsigSecretResolver // TsigSecrets will be used to resolve the given secret name in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2) into the corresponding secret bytes.
 	tsigTimersOnly bool
 }
 
@@ -224,12 +224,13 @@ func (t *Transfer) ReadMsg() (*Msg, error) {
 	if err := m.Unpack(p); err != nil {
 		return nil, err
 	}
-	if ts := m.IsTsig(); ts != nil && t.TsigSecret != nil {
-		if _, ok := t.TsigSecret[ts.Hdr.Name]; !ok {
+	if ts := m.IsTsig(); ts != nil && t.TsigSecrets != nil {
+		secret := t.TsigSecrets.Resolve(ts.Hdr.Name)
+		if secret == nil {
 			return m, ErrSecret
 		}
 		// Need to work on the original message p, as that was used to calculate the tsig.
-		err = TsigVerify(p, t.TsigSecret[ts.Hdr.Name], t.tsigRequestMAC, t.tsigTimersOnly)
+		err = TsigVerify(p, secret, t.tsigRequestMAC, t.tsigTimersOnly)
 		t.tsigRequestMAC = ts.MAC
 	}
 	return m, err
@@ -238,11 +239,12 @@ func (t *Transfer) ReadMsg() (*Msg, error) {
 // WriteMsg writes a message through the transfer connection t.
 func (t *Transfer) WriteMsg(m *Msg) (err error) {
 	var out []byte
-	if ts := m.IsTsig(); ts != nil && t.TsigSecret != nil {
-		if _, ok := t.TsigSecret[ts.Hdr.Name]; !ok {
+	if ts := m.IsTsig(); ts != nil && t.TsigSecrets != nil {
+		secret := t.TsigSecrets.Resolve(ts.Hdr.Name)
+		if secret == nil {
 			return ErrSecret
 		}
-		out, t.tsigRequestMAC, err = TsigGenerate(m, t.TsigSecret[ts.Hdr.Name], t.tsigRequestMAC, t.tsigTimersOnly)
+		out, t.tsigRequestMAC, err = TsigGenerate(m, secret, t.tsigRequestMAC, t.tsigTimersOnly)
 	} else {
 		out, err = m.Pack()
 	}

--- a/xfr_test.go
+++ b/xfr_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	tsigSecret  = map[string]string{"axfr.": "so6ZGir4GPAqINNh9U5c3A=="}
+	tsigSecret  = TsigSecretMap{"axfr.": newSecret("so6ZGir4GPAqINNh9U5c3A==")}
 	xfrSoa      = testRR(`miek.nl.	0	IN	SOA	linode.atoom.net. miek.miek.nl. 2009032802 21600 7200 604800 3600`)
 	xfrA        = testRR(`x.miek.nl.	1792	IN	A	10.0.0.1`)
 	xfrMX       = testRR(`miek.nl.	1800	IN	MX	1	x.miek.nl.`)
@@ -100,19 +100,24 @@ func TestMultiEnvelopeXfr(t *testing.T) {
 	axfrTestingSuite(addrstr)
 }
 
-func RunLocalTCPServerWithTsig(laddr string, tsig map[string]string) (*Server, string, error) {
+func RunLocalTCPServerWithTsig(laddr string, tsig TsigSecretMap) (*Server, string, error) {
 	server, l, _, err := RunLocalTCPServerWithFinChanWithTsig(laddr, tsig)
 
 	return server, l, err
 }
 
-func RunLocalTCPServerWithFinChanWithTsig(laddr string, tsig map[string]string) (*Server, string, chan error, error) {
+func RunLocalTCPServerWithFinChanWithTsig(laddr string, tsig TsigSecretMap) (*Server, string, chan error, error) {
 	l, err := net.Listen("tcp", laddr)
 	if err != nil {
 		return nil, "", nil, err
 	}
 
-	server := &Server{Listener: l, ReadTimeout: time.Hour, WriteTimeout: time.Hour, TsigSecret: tsig}
+	server := &Server{
+		Listener:     l,
+		ReadTimeout:  time.Hour,
+		WriteTimeout: time.Hour,
+		TsigSecrets:  tsig,
+	}
 
 	waitLock := sync.Mutex{}
 	waitLock.Lock()


### PR DESCRIPTION
These changes replace the secrets map present in both the server and the client with a new resolver interface that will be inquired to resolve a secret by its canonical name into the corresponding secret bytes. The new approach is more flexible and allows server implementations to be free in their secrets managing strategy.

So far these changes are just a draft and haven't been battle tested yet.