### PR TITLE
update noRdata to limit acceptable empty RDATA cases

### DIFF
--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -171,8 +171,10 @@ func fromBase64(s []byte) (buf []byte, err error) {
 
 func toBase64(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
 
-// dynamicUpdate returns true if the Rdlength is zero.
-func noRdata(h RR_Header) bool { return h.Rdlength == 0 }
+// noRdata returns true if the Rdlength can be and is indeed zero.
+// It's allowed for dynamic update delete records.
+// This function also returns true for types that lacks a presentation format.
+func noRdata(h RR_Header) bool { return h.Rdlength == 0 && (h.Class == ClassANY || h.Class == ClassNONE || !canParseAsRR(h.Rrtype))}
 
 func unpackUint8(msg []byte, off int) (i uint8, off1 int, err error) {
 	if off+1 > len(msg) {

--- a/update_test.go
+++ b/update_test.go
@@ -34,7 +34,7 @@ func TestDynamicUpdateUnpack(t *testing.T) {
 
 func TestDynamicUpdateZeroRdataUnpack(t *testing.T) {
 	m := new(Msg)
-	rr := &RR_Header{Name: ".", Rrtype: 0, Class: 1, Ttl: ^uint32(0), Rdlength: 0}
+	rr := &RR_Header{Name: ".", Rrtype: 0, Class: ClassNONE, Ttl: ^uint32(0), Rdlength: 0}
 	m.Answer = []RR{rr, rr, rr, rr, rr}
 	m.Ns = m.Answer
 	for n, s := range TypeToString {


### PR DESCRIPTION
The current implementation of `noRdata` in msg_helpers.go just checks whether the RDLENGTH is 0, and its callers skip any further validation.  But it allows invalid empty RDATA for most types of RRs (A, AAAA...) in wire format to be successfully "unpacked".  According to the code comment, the intent seems to allow empty RDATA in a dynamic update request.  If so, we can limit the case to some specific RR classes since it's only possible for "delete" variants of update requests.

So I propose including this check in `noRdata`.  The actual diff also covers some special types, mainly for allowing empty OPT RR (which is indeed valid, but its `unpack` rejects).

I personally think it would be even better if `UnpackRR` is more aware of the unpack context and also checks OPCODE so it won't accidentally accept broken wire form data from the net, but that will be a much bigger change, so I chose to suggest this small adjustment first.

I'd also note that the `unpack` implementation of some RR types will have to be updated to reject empty RDATA when it's not allowed.  Just from a quick look, at least TXT.unpack should be updated (empty TXT RDATA isn't possible per RFC1035).  There are probably some more.  See the comment in revised `TestNoRdataPack`.