### PR TITLE
Fix for issue #788 on 64-bit machines

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"golang.org/x/crypto/ed25519"
 )
@@ -546,7 +546,7 @@ func (k *DNSKEY) publicKeyRSA() (*rsa.PublicKey, error) {
 	}
 
 	pubkey := new(rsa.PublicKey)
-	maxexplen := uint16(unsafe.Sizeof(pubkey.E))
+	maxexplen := uint16(strconv.IntSize / 8)
 
 	if explen > maxexplen || explen == 0 || keybuf[keyoff] == 0 {
 		// Exponent larger than supported by the crypto package,

--- a/dnssec.go
+++ b/dnssec.go
@@ -527,7 +527,7 @@ func (rr *RRSIG) sigBuf() []byte {
 func (k *DNSKEY) publicKeyRSA() (*rsa.PublicKey, error) {
 	keybuf, err := fromBase64([]byte(k.PublicKey))
 	if err != nil {
-		return nil, fmt.Errorf("base64 decode: %w", err)
+		return nil, err
 	}
 
 	if len(keybuf) < 1+1+64 {

--- a/dnssec.go
+++ b/dnssec.go
@@ -454,7 +454,7 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 		// TODO(mg): this can be done quicker, ie. cache the pubkey data somewhere??
 		pubkey, err := k.publicKeyRSA() // Get the key
 		if err != nil {
-			return err
+			return ErrKey
 		}
 
 		h := hash.New()

--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -56,7 +56,7 @@ func (k *DNSKEY) ReadPrivateKey(q io.Reader, file string) (crypto.PrivateKey, er
 		if err != nil {
 			return nil, err
 		}
-		pub := k.publicKeyRSA()
+		pub, _ := k.publicKeyRSA()
 		if pub == nil {
 			return nil, ErrKey
 		}

--- a/sig0.go
+++ b/sig0.go
@@ -192,7 +192,7 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 	case RSASHA1, RSASHA256, RSASHA512:
 		pk, err := k.publicKeyRSA()
 		if err != nil {
-			return err
+			return ErrSig
 		}
 		return rsa.VerifyPKCS1v15(pk, hash, hashed, sig)
 	case ECDSAP256SHA256, ECDSAP384SHA384:

--- a/sig0.go
+++ b/sig0.go
@@ -190,10 +190,11 @@ func (rr *SIG) Verify(k *KEY, buf []byte) error {
 			return ErrSig
 		}
 	case RSASHA1, RSASHA256, RSASHA512:
-		pk := k.publicKeyRSA()
-		if pk != nil {
-			return rsa.VerifyPKCS1v15(pk, hash, hashed, sig)
+		pk, err := k.publicKeyRSA()
+		if err != nil {
+			return err
 		}
+		return rsa.VerifyPKCS1v15(pk, hash, hashed, sig)
 	case ECDSAP256SHA256, ECDSAP384SHA384:
 		pk := k.publicKeyECDSA()
 		r := new(big.Int).SetBytes(sig[:len(sig)/2])


### PR DESCRIPTION
Hi, this fixes the issue #788 on 64-bit machines. The `crypto` package uses `int` for RSA exponents, which can hold larger numbers if compiled for 64-bit. 
On 32-bit a proper error message should be returned at least.