### PR TITLE
correct default values fields in LOC record

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -364,6 +364,7 @@ func TestParseLOC(t *testing.T) {
 	lt := map[string]string{
 		"SW1A2AA.find.me.uk.	LOC	51 30 12.748 N 00 07 39.611 W 0.00m 0.00m 0.00m 0.00m": "SW1A2AA.find.me.uk.\t3600\tIN\tLOC\t51 30 12.748 N 00 07 39.611 W 0m 0.00m 0.00m 0.00m",
 		"SW1A2AA.find.me.uk.	LOC	51 0 0.0 N 00 07 39.611 W 0.00m 0.00m 0.00m 0.00m": "SW1A2AA.find.me.uk.\t3600\tIN\tLOC\t51 00 0.000 N 00 07 39.611 W 0m 0.00m 0.00m 0.00m",
+		"SW1A2AA.find.me.uk.	LOC	51 30 12.748 N 00 07 39.611 W 0.00m": "SW1A2AA.find.me.uk.\t3600\tIN\tLOC\t51 30 12.748 N 00 07 39.611 W 0m 1m 10000m 10m",
 	}
 	for i, o := range lt {
 		rr, err := NewRR(i)

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -581,9 +581,9 @@ func (rr *TALINK) parse(c *zlexer, o string) *ParseError {
 
 func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 	// Non zero defaults for LOC record, see RFC 1876, Section 3.
-	rr.HorizPre = 0x16 // 10000
-	rr.VertPre = 0x13  // 10
-	rr.Size = 0x12     // 1
+	rr.Size = 0x12     // 1e2 cm (1m)
+	rr.HorizPre = 0x16 // 1e6 cm (10000m)
+	rr.VertPre = 0x13  // 1e3 cm (10m)
 	ok := false
 
 	// North

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -581,9 +581,9 @@ func (rr *TALINK) parse(c *zlexer, o string) *ParseError {
 
 func (rr *LOC) parse(c *zlexer, o string) *ParseError {
 	// Non zero defaults for LOC record, see RFC 1876, Section 3.
-	rr.HorizPre = 165 // 10000
-	rr.VertPre = 162  // 10
-	rr.Size = 18      // 1
+	rr.HorizPre = 0x16 // 10000
+	rr.VertPre = 0x13  // 10
+	rr.Size = 0x12     // 1
 	ok := false
 
 	// North


### PR DESCRIPTION
https://github.com/miekg/dns/issues/1083

Fixing default values for HorizPre and VertPre fields at LOC record

According to RFC-1876 those fields should be:
"a pair of four-bit unsigned
integers, each ranging from zero to nine, with the most
significant four bits representing the base and the second
number representing the power of ten by which to multiply
the base.  This allows sizes from 0e0 (<1cm) to 9e9
(90,000km) to be expressed"

Current values for HorizPre and VertPre (165=0xA5 and 162=0xA2)
are incorrect because the first HEX digit is greater then 9

The default values should be:

HorizPre = 10000m = 10000 * 100 cm = 10^6 = 0x16
VertPre  = 10m    = 10 * 100 cm    = 10^3 = 0x13
Size     = 1m     = 1 * 100 cm     = 10^2 = 0x12

The value of Size was correct, but this PR changes it to HEX
representation to be more readable

