### PR TITLE
Fixed msg.Question.Name string panic

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -1053,8 +1053,9 @@ func (dns *Msg) CopyTo(r1 *Msg) *Msg {
 	r1.Compress = dns.Compress
 
 	if len(dns.Question) > 0 {
-		r1.Question = make([]Question, len(dns.Question))
-		copy(r1.Question, dns.Question) // TODO(miek): Question is an immutable value, ok to do a shallow-copy
+		qs := make([]Question, len(dns.Question))
+		copy(qs, dns.Question) // TODO(miek): Question is an immutable value, ok to do a shallow-copy
+		r1.Question = qs
 	}
 
 	rrArr := make([]RR, len(dns.Answer)+len(dns.Ns)+len(dns.Extra))


### PR DESCRIPTION
Concurrent reading msg.Question.Name while copying msg.Question may cause panic. Panic issue: https://github.com/Dreamacro/clash/issues/527

Panic is caused by the following code:

msg.go line 1056:
```
r1.Question = make([]Question, len(dns.Question))
copy(r1.Question, dns.Question)
```

When copy dns.Question to r1.Querstion is processing, some other goroutines is accesccing msg.Question.Name value, but at this time, .Name has only length and data pointer with addr 0x0.

So, copy to a temporary variable and then assign to r1.Question maybe more safer.

```
qs := make([]Question, len(dns.Question))
copy(qs, dns.Question) // TODO(miek): Question is an immutable value, ok to do a shallow-copy
r1.Question = qs
```