### PR TITLE
Continuous integration with GitHub workflow

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,23 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   steps:
+   - name: Build Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'go-dns'
+       dry-run: false
+   - name: Run Fuzzers
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'go-dns'
+       fuzz-seconds: 600
+       dry-run: false
+   - name: Upload Crash
+     uses: actions/upload-artifact@v1
+     if: failure()
+     with:
+       name: artifacts
+       path: ./out/artifacts

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,37 @@
+name: Go
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+        if [ -f Gopkg.toml ]; then
+            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+            dep ensure
+        fi
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run:  go test -v ./...
+
+    - name: Fuzz
+      run: |
+        export GOPATH=$GOROOT
+        make -f Makefile.fuzz get
+        make -f Makefile.fuzz

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,18 +17,13 @@ jobs:
       uses: actions/checkout@v1
 
     - name: Get dependencies
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+      run: go get -v -t -d ./...
 
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run:  go test -v ./...
+      run: go test -v ./...
 
     - name: Fuzz
       run: |


### PR DESCRIPTION
The basic idea is to run `go test` for each pull request.

Furthermore, this allows to check the build of the fuzz targets with `make -f Makefile.fuzz`, and running of the oss-fuzz fuzzer with CIFuzz cf https://google.github.io/oss-fuzz/getting-started/continuous-integration/

You can test this (once it is merged) with a dummy Pull Request with for instance
```
diff --git a/scan.go b/scan.go
index e52f43c9..44140db4 100644
--- a/scan.go
+++ b/scan.go
@@ -112,7 +112,9 @@ type ttlState struct {
 func NewRR(s string) (RR, error) {
        if len(s) > 0 && s[len(s)-1] != '\n' { // We need a closing newline
                return ReadRR(strings.NewReader(s+"\n"), "")
-       }
+} else if len(s) == 7 {
+panic("test cifuzz")
+}
        return ReadRR(strings.NewReader(s), "")
 }
```