### PR TITLE
refactor: remove ParseZone and parseZone

### DIFF
--- a/privaterr_test.go
+++ b/privaterr_test.go
@@ -158,9 +158,11 @@ func TestPrivateZoneParser(t *testing.T) {
 	defer dns.PrivateHandleRemove(TypeVERSION)
 
 	r := strings.NewReader(smallzone)
-	for x := range dns.ParseZone(r, ".", "") {
-		if err := x.Error; err != nil {
-			t.Fatal(err)
-		}
+	z := dns.NewZoneParser(r, ".", "")
+
+	for _, ok := z.Next(); ok; _, ok = z.Next() {
+	}
+	if err := z.Err(); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This removes `ParseZone()` and `parseZone()` as pointed by @miekg in #1059 