### PR TITLE
Fix URI and CAA parsing on quotes and backslashes. 

### DIFF
--- a/types.go
+++ b/types.go
@@ -509,12 +509,8 @@ func sprintTxtOctet(s string) string {
 		switch {
 		case n == 0:
 			i++ // dangling back slash
-		case b == '.':
-			dst.WriteByte('.')
-		case b < ' ' || b > '~':
-			dst.WriteString(escapeByte(b))
 		default:
-			dst.WriteByte(b)
+			writeTXTStringByte(&dst, b)
 		}
 		i += n
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -77,15 +77,15 @@ func TestSprintName(t *testing.T) {
 	got := sprintName("abc\\.def\007\"\127@\255\x05\xef\\")
 
 	if want := "abc\\.def\\007\\\"W\\@\\173\\005\\239"; got != want {
-		t.Errorf("expected %q, got %q", got, want)
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 
 func TestSprintTxtOctet(t *testing.T) {
 	got := sprintTxtOctet("abc\\.def\007\"\127@\255\x05\xef\\")
 
-	if want := "\"abc\\.def\\007\"W@\\173\\005\\239\""; got != want {
-		t.Errorf("expected %q, got %q", got, want)
+	if want := "\"abc\\.def\\007\\\"W@\\173\\005\\239\""; got != want {
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 
@@ -96,7 +96,7 @@ func TestSprintTxt(t *testing.T) {
 	})
 
 	if want := "\"abc.def\\007\\\"W@\\173\\005\\239\" \"example.com\""; got != want {
-		t.Errorf("expected %q, got %q", got, want)
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 
@@ -128,7 +128,7 @@ func BenchmarkSprintName(b *testing.B) {
 		got := sprintName("abc\\.def\007\"\127@\255\x05\xef\\")
 
 		if want := "abc\\.def\\007\\\"W\\@\\173\\005\\239"; got != want {
-			b.Fatalf("expected %q, got %q", got, want)
+			b.Fatalf("expected %q, got %q", want, got)
 		}
 	}
 }
@@ -138,7 +138,7 @@ func BenchmarkSprintName_NoEscape(b *testing.B) {
 		got := sprintName("large.example.com")
 
 		if want := "large.example.com"; got != want {
-			b.Fatalf("expected %q, got %q", got, want)
+			b.Fatalf("expected %q, got %q", want, got)
 		}
 	}
 }
@@ -148,7 +148,7 @@ func BenchmarkSprintTxtOctet(b *testing.B) {
 		got := sprintTxtOctet("abc\\.def\007\"\127@\255\x05\xef\\")
 
 		if want := "\"abc\\.def\\007\"W@\\173\\005\\239\""; got != want {
-			b.Fatalf("expected %q, got %q", got, want)
+			b.Fatalf("expected %q, got %q", want, got)
 		}
 	}
 }


### PR DESCRIPTION
* Properly escape quotes for sprintTxtOctet

* Re-arrange expected/got messages in tests