### PR TITLE
Fix URI and CAA parsing on quotes and backslashes. (#1101)

### DIFF
--- a/types.go
+++ b/types.go
@@ -506,15 +506,10 @@ func sprintTxtOctet(s string) string {
 		}
 
 		b, n := nextByte(s, i)
-		switch {
-		case n == 0:
+		if n == 0 {
 			i++ // dangling back slash
-		case b == '.':
-			dst.WriteByte('.')
-		case b < ' ' || b > '~':
-			dst.WriteString(escapeByte(b))
-		default:
-			dst.WriteByte(b)
+		} else {
+			writeTXTStringByte(&dst, b)
 		}
 		i += n
 	}
@@ -1121,6 +1116,7 @@ type URI struct {
 	Target   string `dns:"octet"`
 }
 
+// rr.Target to be parsed as a sequence of character encoded octets according to RFC 3986
 func (rr *URI) String() string {
 	return rr.Hdr.String() + strconv.Itoa(int(rr.Priority)) +
 		" " + strconv.Itoa(int(rr.Weight)) + " " + sprintTxtOctet(rr.Target)
@@ -1282,6 +1278,7 @@ type CAA struct {
 	Value string `dns:"octet"`
 }
 
+// rr.Value Is the character-string encoding of the value field as specified in RFC 1035, Section 5.1.
 func (rr *CAA) String() string {
 	return rr.Hdr.String() + strconv.Itoa(int(rr.Flag)) + " " + rr.Tag + " " + sprintTxtOctet(rr.Value)
 }

--- a/types_test.go
+++ b/types_test.go
@@ -77,15 +77,15 @@ func TestSprintName(t *testing.T) {
 	got := sprintName("abc\\.def\007\"\127@\255\x05\xef\\")
 
 	if want := "abc\\.def\\007\\\"W\\@\\173\\005\\239"; got != want {
-		t.Errorf("expected %q, got %q", got, want)
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 
 func TestSprintTxtOctet(t *testing.T) {
 	got := sprintTxtOctet("abc\\.def\007\"\127@\255\x05\xef\\")
 
-	if want := "\"abc\\.def\\007\"W@\\173\\005\\239\""; got != want {
-		t.Errorf("expected %q, got %q", got, want)
+	if want := "\"abc\\.def\\007\\\"W@\\173\\005\\239\""; got != want {
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 
@@ -96,7 +96,7 @@ func TestSprintTxt(t *testing.T) {
 	})
 
 	if want := "\"abc.def\\007\\\"W@\\173\\005\\239\" \"example.com\""; got != want {
-		t.Errorf("expected %q, got %q", got, want)
+		t.Errorf("expected %q, got %q", want, got)
 	}
 }
 
@@ -128,7 +128,7 @@ func BenchmarkSprintName(b *testing.B) {
 		got := sprintName("abc\\.def\007\"\127@\255\x05\xef\\")
 
 		if want := "abc\\.def\\007\\\"W\\@\\173\\005\\239"; got != want {
-			b.Fatalf("expected %q, got %q", got, want)
+			b.Fatalf("expected %q, got %q", want, got)
 		}
 	}
 }
@@ -138,7 +138,7 @@ func BenchmarkSprintName_NoEscape(b *testing.B) {
 		got := sprintName("large.example.com")
 
 		if want := "large.example.com"; got != want {
-			b.Fatalf("expected %q, got %q", got, want)
+			b.Fatalf("expected %q, got %q", want, got)
 		}
 	}
 }
@@ -147,8 +147,8 @@ func BenchmarkSprintTxtOctet(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		got := sprintTxtOctet("abc\\.def\007\"\127@\255\x05\xef\\")
 
-		if want := "\"abc\\.def\\007\"W@\\173\\005\\239\""; got != want {
-			b.Fatalf("expected %q, got %q", got, want)
+		if want := "\"abc\\.def\\007\\\"W@\\173\\005\\239\""; got != want {
+			b.Fatalf("expected %q, got %q", want, got)
 		}
 	}
 }


### PR DESCRIPTION
* Properly escape quotes and backslashes for sprintTxtOctet

* Re-arrange expected/got messages in tests

Sorry for the PR spam earlier, i rebased on my master and got confused by issue referencing. It should be referencing #1101 