### PR TITLE
Efficient string concatenation

### DIFF
--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"bytes"
 	"encoding/base64"
 	"net"
 	"strconv"
@@ -10,15 +11,15 @@ import (
 // A remainder of the rdata with embedded spaces, return the parsed string (sans the spaces)
 // or an error
 func endingToString(c *zlexer, errstr string) (string, *ParseError) {
-	var s string
+	var buffer bytes.Buffer
 	l, _ := c.Next() // zString
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
-			return s, &ParseError{"", errstr, l}
+			return buffer.String(), &ParseError{"", errstr, l}
 		}
 		switch l.value {
 		case zString:
-			s += l.token
+			buffer.WriteString(l.token)
 		case zBlank: // Ok
 		default:
 			return "", &ParseError{"", errstr, l}
@@ -26,7 +27,7 @@ func endingToString(c *zlexer, errstr string) (string, *ParseError) {
 		l, _ = c.Next()
 	}
 
-	return s, nil
+	return buffer.String(), nil
 }
 
 // A remainder of the rdata with embedded spaces, split on unquoted whitespace


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21892

The optimization comes from 
https://hermanschaaf.com/efficient-string-concatenation-in-go/

My benchmark on the oss-fuzz test case is from 80 seconds to 0.1 second with this PR


Reproducer program is
```
package main

import (
	"fmt"
	"io/ioutil"
	"os"
	"runtime/pprof"

	"github.com/miekg/dns"
)

func main() {
	f, err := os.Create("cpu.prof")
	if err != nil {
		fmt.Printf("error %#+v\n", err)
		return
	}
	_ = pprof.StartCPUProfile(f)

	data, err := ioutil.ReadFile(os.Args[1])
	if err != nil {
		fmt.Printf("Failed to read corpus file", err)
	}
	fmt.Printf("Starting %s\n", os.Args[1])
	dns.NewRR(string(data))

	fmt.Printf("Finished\n")
	pprof.StopCPUProfile()
	f, err = os.Create("heap.prof")
	if err != nil {
		fmt.Printf("error %#+v\n", err)
		return
	}
	if err = pprof.WriteHeapProfile(f); err != nil {
		fmt.Printf("error %#+v\n", err)
		return
	}
	f.Close()
	fmt.Printf("end\n")
}
```