### PR TITLE
sorts NSEC params to fix packing

### DIFF
--- a/scan_rr.go
+++ b/scan_rr.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -843,6 +844,7 @@ func (rr *CSYNC) parse(c *zlexer, o string) *ParseError {
 		}
 		l, _ = c.Next()
 	}
+	sort.Slice(rr.TypeBitMap, func(i, j int) bool { return rr.TypeBitMap[i] < rr.TypeBitMap[j] })
 	return nil
 }
 
@@ -972,6 +974,7 @@ func (rr *NSEC) parse(c *zlexer, o string) *ParseError {
 		}
 		l, _ = c.Next()
 	}
+	sort.Slice(rr.TypeBitMap, func(i, j int) bool { return rr.TypeBitMap[i] < rr.TypeBitMap[j] })
 	return nil
 }
 
@@ -1037,6 +1040,7 @@ func (rr *NSEC3) parse(c *zlexer, o string) *ParseError {
 		}
 		l, _ = c.Next()
 	}
+	sort.Slice(rr.TypeBitMap, func(i, j int) bool { return rr.TypeBitMap[i] < rr.TypeBitMap[j] })
 	return nil
 }
 


### PR DESCRIPTION
Sorts parsed NSEC TypeBitMap so that packing is always successful and string representation of identical records are always equal.

Fixes https://github.com/miekg/dns/issues/1106