### PR TITLE
Adds function ExchangeWithConn

### DIFF
--- a/client.go
+++ b/client.go
@@ -124,15 +124,38 @@ func (c *Client) Dial(address string) (conn *Conn, err error) {
 // of 512 bytes
 // To specify a local address or a timeout, the caller has to set the `Client.Dialer`
 // attribute appropriately
+
 func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, err error) {
+	co, err := c.Dial(address)
+
+	if err != nil {
+		return nil, 0, err
+	}
+	defer co.Close()
+	return c.ExchangeWithConn(m, co)
+}
+
+// ExchangeWithConn has the same behavior as Exchange, just with a predetermined connection
+// that will be used instead of creating a new one.
+// Usage pattern with a *dns.Client:
+//	c := new(dns.Client)
+//  // connection management logic goes here
+//
+//  conn := c.Dial(address)
+//	in, rtt, err := c.ExchangeWithConn(message, conn)
+//
+//  This allows users of the library to implement their own connection management,
+//  as opposed to Exchange, which will always use new connections and incur the added overhead
+//  that entails when using "tcp" and especially "tcp-tls" clients.
+func (c *Client) ExchangeWithConn(m *Msg, conn *Conn) (r *Msg, rtt time.Duration, err error) {
 	if !c.SingleInflight {
-		return c.exchange(m, address)
+		return c.exchange(m, conn)
 	}
 
 	q := m.Question[0]
 	key := fmt.Sprintf("%s:%d:%d", q.Name, q.Qtype, q.Qclass)
 	r, rtt, err, shared := c.group.Do(key, func() (*Msg, time.Duration, error) {
-		return c.exchange(m, address)
+		return c.exchange(m, conn)
 	})
 	if r != nil && shared {
 		r = r.Copy()
@@ -141,15 +164,7 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 	return r, rtt, err
 }
 
-func (c *Client) exchange(m *Msg, a string) (r *Msg, rtt time.Duration, err error) {
-	var co *Conn
-
-	co, err = c.Dial(a)
-
-	if err != nil {
-		return nil, 0, err
-	}
-	defer co.Close()
+func (c *Client) exchange(m *Msg, co *Conn) (r *Msg, rtt time.Duration, err error) {
 
 	opt := m.IsEdns0()
 	// If EDNS0 is used use that for size.

--- a/client.go
+++ b/client.go
@@ -139,7 +139,7 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 // that will be used instead of creating a new one.
 // Usage pattern with a *dns.Client:
 //	c := new(dns.Client)
-//  // connection management logic goes here
+//	// connection management logic goes here
 //
 //  conn := c.Dial(address)
 //	in, rtt, err := c.ExchangeWithConn(message, conn)

--- a/client.go
+++ b/client.go
@@ -141,7 +141,7 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 //	c := new(dns.Client)
 //	// connection management logic goes here
 //
-//  conn := c.Dial(address)
+//	conn := c.Dial(address)
 //	in, rtt, err := c.ExchangeWithConn(message, conn)
 //
 //  This allows users of the library to implement their own connection management,

--- a/client_test.go
+++ b/client_test.go
@@ -565,3 +565,34 @@ func TestConcurrentExchanges(t *testing.T) {
 		}
 	}
 }
+
+func TestExchangeWithConn(t *testing.T) {
+	HandleFunc("miek.nl.", HelloServer)
+	defer HandleRemove("miek.nl.")
+
+	s, addrstr, err := RunLocalUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeSOA)
+
+	c := new(Client)
+	conn, err := c.Dial(addrstr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	r, _, err := c.ExchangeWithConn(m, conn)
+	if err != nil {
+		t.Fatalf("failed to exchange: %v", err)
+	}
+	if r == nil {
+		t.Fatal("response is nil")
+	}
+	if r.Rcode != RcodeSuccess {
+		t.Errorf("failed to get an valid answer\n%v", r)
+	}
+}


### PR DESCRIPTION
#614 requested that connection reuse be implemented in this library to help improve performance when using TCP/TCP-TLS connections.  This was rejected, fairly, because of the complexity in handling that logic within the library.  This PR would solve the problem without introducing connection management code into the library at all.  Instead it does some minor refactoring in order to expose the ability for the *caller* to manage connections and pass them in to the library via the ExchangeWithConn function.  The existing Exchange behavior is preserved, so backwards compatibility shouldn't be an issue.