### PR TITLE
Generate copy() for derived types

### DIFF
--- a/types_generate.go
+++ b/types_generate.go
@@ -241,11 +241,15 @@ func main() {
 	for _, name := range namedTypes {
 		o := scope.Lookup(name)
 		st, isEmbedded := getTypeStruct(o.Type(), scope)
-		if isEmbedded {
-			continue
-		}
 		fmt.Fprintf(b, "func (rr *%s) copy() RR {\n", name)
-		fields := []string{"rr.Hdr"}
+		fields := make([]string, 0, st.NumFields())
+		if isEmbedded {
+			a, _ := o.Type().Underlying().(*types.Struct)
+			parent := a.Field(0).Name()
+			fields = append(fields, "*rr."+parent+".copy().(*"+parent+")")
+			goto WriteCopy
+		}
+		fields = append(fields, "rr.Hdr")
 		for i := 1; i < st.NumFields(); i++ {
 			f := st.Field(i).Name()
 			if sl, ok := st.Field(i).Type().(*types.Slice); ok {
@@ -263,8 +267,8 @@ func main() {
 					continue
 				}
 				if t == "APLPrefix" {
-					fmt.Fprintf(b, "%s := make([]%s, len(rr.%s));\nfor i := range rr.%s {\n %s[i] = rr.%s[i].copy()\n}\n",
-						f, t, f, f, f, f)
+					fmt.Fprintf(b, "%s := make([]%s, len(rr.%s));\nfor i,e := range rr.%s {\n %s[i] = e.copy()\n}\n",
+						f, t, f, f, f)
 					fields = append(fields, f)
 					continue
 				}
@@ -279,6 +283,7 @@ func main() {
 			}
 			fields = append(fields, "rr."+f)
 		}
+	WriteCopy:
 		fmt.Fprintf(b, "return &%s{%s}\n", name, strings.Join(fields, ","))
 		fmt.Fprintf(b, "}\n")
 	}

--- a/ztypes.go
+++ b/ztypes.go
@@ -685,8 +685,8 @@ func (rr *ANY) copy() RR {
 }
 func (rr *APL) copy() RR {
 	Prefixes := make([]APLPrefix, len(rr.Prefixes))
-	for i := range rr.Prefixes {
-		Prefixes[i] = rr.Prefixes[i].copy()
+	for i, e := range rr.Prefixes {
+		Prefixes[i] = e.copy()
 	}
 	return &APL{rr.Hdr, Prefixes}
 }
@@ -697,6 +697,12 @@ func (rr *AVC) copy() RR {
 }
 func (rr *CAA) copy() RR {
 	return &CAA{rr.Hdr, rr.Flag, rr.Tag, rr.Value}
+}
+func (rr *CDNSKEY) copy() RR {
+	return &CDNSKEY{*rr.DNSKEY.copy().(*DNSKEY)}
+}
+func (rr *CDS) copy() RR {
+	return &CDS{*rr.DS.copy().(*DS)}
 }
 func (rr *CERT) copy() RR {
 	return &CERT{rr.Hdr, rr.Type, rr.KeyTag, rr.Algorithm, rr.Certificate}
@@ -711,6 +717,9 @@ func (rr *CSYNC) copy() RR {
 }
 func (rr *DHCID) copy() RR {
 	return &DHCID{rr.Hdr, rr.Digest}
+}
+func (rr *DLV) copy() RR {
+	return &DLV{*rr.DS.copy().(*DS)}
 }
 func (rr *DNAME) copy() RR {
 	return &DNAME{rr.Hdr, rr.Target}
@@ -743,6 +752,9 @@ func (rr *HIP) copy() RR {
 	RendezvousServers := make([]string, len(rr.RendezvousServers))
 	copy(RendezvousServers, rr.RendezvousServers)
 	return &HIP{rr.Hdr, rr.HitLength, rr.PublicKeyAlgorithm, rr.PublicKeyLength, rr.Hit, rr.PublicKey, RendezvousServers}
+}
+func (rr *KEY) copy() RR {
+	return &KEY{*rr.DNSKEY.copy().(*DNSKEY)}
 }
 func (rr *KX) copy() RR {
 	return &KX{rr.Hdr, rr.Preference, rr.Exchanger}
@@ -846,6 +858,9 @@ func (rr *RRSIG) copy() RR {
 }
 func (rr *RT) copy() RR {
 	return &RT{rr.Hdr, rr.Preference, rr.Host}
+}
+func (rr *SIG) copy() RR {
+	return &SIG{*rr.RRSIG.copy().(*RRSIG)}
 }
 func (rr *SMIMEA) copy() RR {
 	return &SMIMEA{rr.Hdr, rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}


### PR DESCRIPTION
Fixes:
```go
e := new(DNSKEY)
f := new(CDNSKEY)
fmt.Println(e.isDuplicate(e))        // true (correct)
fmt.Println(e.isDuplicate(e.copy())) // true (correct)
fmt.Println(f.isDuplicate(f))        // true (correct)
fmt.Println(f.isDuplicate(f.copy())) // false
```

**Edited** to address tmthrgd's comment

`isDuplicate` is actually working, `copy` is broken. Here's why `copy` is broken:

When I do

```go
f := new(CDNSKEY)
g := f.copy()
```

since `CDNSKEY` is a derived type, it doesn't (didn't) have its own `copy` method. So DNSKEY's copy method was called:

```go
func (rr *DNSKEY) copy() RR {
	return &DNSKEY{rr.Hdr, rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
}
```

which clones CDNSKEY's internal DNSKEY and returns it as a DNSKEY. How I solved it was a wrapper that casts the result of the copy:

```go
func (rr *CDNSKEY) copy() RR {
	return &CDNSKEY{*rr.DNSKEY.copy().(*DNSKEY)}
}
```

---
Moreover, there's a slightly irrelevant change in the same file `types_generate.go`:

For consistency, making this:
```go
func (rr *APL) copy() RR {
	Prefixes := make([]APLPrefix, len(rr.Prefixes))
	for i := range rr.Prefixes {
		Prefixes[i] = rr.Prefixes[i].copy() // rr.Prefixes[i] can be `e`
	}
	return &APL{rr.Hdr, Prefixes}
}
```
similar to this
```go
func (rr *OPT) copy() RR {
	Option := make([]EDNS0, len(rr.Option))
	for i, e := range rr.Option {
		Option[i] = e.copy()
	}
	return &OPT{rr.Hdr, Option}
}
```