### PR TITLE
Better performance for HINFO parsing

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -22,7 +22,10 @@ func FuzzNewRR(data []byte) int {
 	// Do not fuzz lines that include the $INCLUDE keyword and hint the fuzzer
 	// at avoiding them.
 	// See GH#1025 for context.
-	if strings.Contains(strings.ToUpper(str), "$INCLUDE") {
+	//Do not fuzz lines with $GENERATE keyword to avoid timeouts
+	// See GH#1127 for context
+	if strings.Contains(strings.ToUpper(str), "$INCLUDE") ||
+		strings.Contains(strings.ToUpper(str), "$GENERATE") {
 		return -1
 	}
 	if _, err := NewRR(str); err != nil {

--- a/generate.go
+++ b/generate.go
@@ -160,11 +160,9 @@ func (r *generateReader) ReadByte() (byte, error) {
 			return '$', nil
 		}
 
-		mod := "%d"
-
 		if si >= len(r.s)-1 {
 			// End of the string
-			fmt.Fprintf(&r.mod, mod, r.cur)
+			fmt.Fprintf(&r.mod, "%d", r.cur)
 			return r.mod.ReadByte()
 		}
 
@@ -173,10 +171,10 @@ func (r *generateReader) ReadByte() (byte, error) {
 			return '$', nil
 		}
 
-		var offset int
-
 		// Search for { and }
 		if r.s[si+1] == '{' {
+			var offset int
+			mod := "%d"
 			// Modifier block
 			sep := strings.Index(r.s[si+2:], "}")
 			if sep < 0 {
@@ -193,9 +191,11 @@ func (r *generateReader) ReadByte() (byte, error) {
 			}
 
 			r.si += 2 + sep // Jump to it
+			fmt.Fprintf(&r.mod, mod, r.cur+offset)
+		} else {
+			r.mod.WriteString(strconv.Itoa(r.cur))
 		}
 
-		fmt.Fprintf(&r.mod, mod, r.cur+offset)
 		return r.mod.ReadByte()
 	default:
 		if r.escape { // Pretty useless here


### PR DESCRIPTION
Found by oss-fuzz :
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=22846

This case uses several trick to time out :
- use `$GENERATE 1-40402` to duplicate many times the input
- use `HINFO` which creates many strings, appends them in a slice, before calling `strings.Join` taking much time with garbage collection (main cause for
- calling `fmt.Fprintf("%d"` which takes time in casting `int` to `uint64`

This PR tries not to change the behavior of the functions

Comments are welcome