### PR TITLE
catch error from tsigBuffer, mainly to detect other data overflow

### DIFF
--- a/tsig_test.go
+++ b/tsig_test.go
@@ -121,8 +121,7 @@ func TestTsigErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = tsigVerify(msgData, testSecret, "", false, timeSigned)
-	const expectedErrMsgPiece = "overflow"
-	if err == nil || !strings.Contains(err.Error(), expectedErrMsgPiece) {
-		t.Errorf("expected error to contain %q, but got %v", expectedErrMsgPiece, err)
+	if err == nil || !strings.Contains(err.Error(), "overflow") {
+		t.Errorf("expected error to contain %q, but got %v", "overflow", err)
 	}
 }


### PR DESCRIPTION
Currently, `tsigBuffer` ignores any error from `packXXX` functions, so `TsigGenerate` or `TsigVerify` can't notice that condition.  but since the buffer used for those `packXXX` only has `DefaultMsgSize` (4096) bytes, and "other data" can be up to 64KB, an arbitrary sender of TSIG message can cause this error in `TsigVerify`.  In practice it would just result in failing to verify the signature, but I think it's cleaner and safer to catch this kind (i.e., "overflow") of error conditions explicitly.

This PR does just that (also catching other minor errors).
