### PR TITLE
fix TsigGenerate for non-0 TSIG error or non-empty other data

### DIFF
--- a/tsig.go
+++ b/tsig.go
@@ -131,7 +131,7 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 		return nil, "", ErrKeyAlg
 	}
 	h.Write(buf)
-	// Copy all TSIG fields expect MAC and its size, which are filled using the computed digest.
+	// Copy all TSIG fields except MAC and its size, which are filled using the computed digest.
 	*t = *rr
 	t.MAC = hex.EncodeToString(h.Sum(nil))
 	t.MACSize = uint16(len(t.MAC) / 2) // Size is half!

--- a/tsig.go
+++ b/tsig.go
@@ -131,14 +131,10 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 		return nil, "", ErrKeyAlg
 	}
 	h.Write(buf)
+	// Copy all TSIG fields expect MAC and its size, which are filled using the computed digest.
+	*t = *rr
 	t.MAC = hex.EncodeToString(h.Sum(nil))
 	t.MACSize = uint16(len(t.MAC) / 2) // Size is half!
-
-	t.Hdr = RR_Header{Name: rr.Hdr.Name, Rrtype: TypeTSIG, Class: ClassANY, Ttl: 0}
-	t.Fudge = rr.Fudge
-	t.TimeSigned = rr.TimeSigned
-	t.Algorithm = rr.Algorithm
-	t.OrigId = m.Id
 
 	tbuf := make([]byte, Len(t))
 	off, err := PackRR(t, tbuf, 0, nil, false)


### PR DESCRIPTION
The current implementation of `TsigGenerate` ignores the TSIG error and other data fields of the TSIG RR in the passed DNS message for generating the signed binary-format message (it uses these fields correctly for computing the MAC).  So the resulting message would fail to be verified at the recipient.  This PR is a straightforward fix to this problem.