### PR TITLE
fix and enhance stringToCm to parse LOC RR optional fields

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -389,6 +389,67 @@ func TestParseLOC(t *testing.T) {
 	}
 }
 
+// this tests a subroutine for the LOC RR parser.  It's complicated enough to test separately.
+func TestStringToCm(t *testing.T) {
+	tests := []struct {
+		// Test description: the input token and the expected return values from stringToCm.
+		token string
+		e     uint8
+		m     uint8
+		ok    bool
+	}{
+		{"100", 4, 1, true},
+		{"0100", 4, 1, true}, // leading 0 (allowed)
+		{"100.99", 4, 1, true},
+		{"90000000", 9, 9, true},
+		{"90000000.00", 9, 9, true},
+		{"0", 0, 0, true},
+		{"0.00", 0, 0, true},
+		{"0.01", 0, 1, true},
+		{".01", 0, 1, true}, // empty 'meter' part (allowed)
+		{"0.1", 1, 1, true},
+
+		// out of range (too large)
+		{"90000001", 0, 0, false},
+		{"90000000.01", 0, 0, false},
+
+		// more than 2 digits in 'cmeter' part
+		{"0.000", 0, 0, false},
+		{"0.001", 0, 0, false},
+		{"0.999", 0, 0, false},
+		// with plus or minus sign (disallowed)
+		{"-100", 0, 0, false},
+		{"+100", 0, 0, false},
+		{"0.-10", 0, 0, false},
+		{"0.+10", 0, 0, false},
+		{"0a.00", 0, 0, false}, // invalid string for 'meter' part
+		{".1x", 0, 0, false},   // invalid string for 'cmeter' part
+		{".", 0, 0, false},     // empty 'cmeter' part (disallowed)
+		{"1.", 0, 0, false},    // ditto
+		{"m", 0, 0, false},     // only the "m" suffix
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.token, func(t *testing.T) {
+			// In all cases the expected result is the same with or without the 'm' suffix.
+			// So we test both cases using the same test code.
+			for _, sfx := range []string{"", "m"} {
+				token := tc.token + sfx
+				e, m, ok := stringToCm(token)
+				if ok != tc.ok {
+					t.Fatal("unexpected validation result")
+				}
+				if m != tc.m {
+					t.Fatalf("Expected %d, got %d", tc.m, m)
+				}
+				if e != tc.e {
+					t.Fatalf("Expected %d, got %d", tc.e, e)
+				}
+			}
+		})
+	}
+}
+
 func TestParseDS(t *testing.T) {
 	dt := map[string]string{
 		"example.net. 3600 IN DS 40692 12 3 22261A8B0E0D799183E35E24E2AD6BB58533CBA7E3B14D659E9CA09B 2071398F": "example.net.\t3600\tIN\tDS\t40692 12 3 22261A8B0E0D799183E35E24E2AD6BB58533CBA7E3B14D659E9CA09B2071398F",


### PR DESCRIPTION
`stringToCm`, a subroutine for `LOC.parse`, has a couple of issues that violate RFC1876:
- there's an off-by-one error in calculating the base and exponent values: a value of 100 should be encoded as 0x12 (1e2) but this implementation encodes it as 0xa1 (10e1).  (btw #1084 fixed the same problem but only for the default value)
- the current implementation treats "0.1m" as "1cm" (0x01 in the encoded form) as it simply extracts the number and passes it to `Atoi`.  But the actual value is 10cm and should be encoded as 0x11.
- the current implementation accepts a negative value

This PR fixes these issues.

It also introduces some other enhancements that are not necessarily for standard conformance:
- It enforces the max value (90000000.00m) described in the RFC more strictly.
- It allows omitting the 'meter' part if it follows by a dot and 'cmeter' part (e.g. ".01" to me 1cm)
- in addition to rejecting negative values, it also rejects somewhat awkward representation like "10.+10" (and also "+10.10", which may not necessarily be considered invalid, but probably not expected by the RFC)

I wouldn't necessarily insist on these enhancements (they are derived from the BIND's implementation of LOC).  If you don't like them please feel free to ignore them.