### PR TITLE
answer queries with no matching handler with RcodeRefused

### DIFF
--- a/serve_mux.go
+++ b/serve_mux.go
@@ -102,7 +102,9 @@ func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
 	if h != nil {
 		h.ServeDNS(w, req)
 	} else {
-		HandleFailed(w, req)
+		m := new(Msg)
+		m.SetRcode(req, RcodeRefused)
+		w.WriteMsg(m)
 	}
 }
 

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -91,7 +91,7 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 // are redirected to the parent zone (if that is also registered),
 // otherwise the child gets the query.
 //
-// If no handler is found, or there is no question, a standard SERVFAIL
+// If no handler is found, or there is no question, a standard REFUSED
 // message is returned
 func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
 	var h Handler

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -102,9 +102,7 @@ func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
 	if h != nil {
 		h.ServeDNS(w, req)
 	} else {
-		m := new(Msg)
-		m.SetRcode(req, RcodeRefused)
-		w.WriteMsg(m)
+		handleRefused(w, req)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -88,7 +88,6 @@ func handleRefused(w ResponseWriter, r *Msg) {
 // HandleFailed returns a HandlerFunc that returns SERVFAIL for every request it gets.
 // Deprecated: This function is going away.
 func HandleFailed(w ResponseWriter, r *Msg) {
-	println("dns: HandleFailed: this function is deprecated")
 	m := new(Msg)
 	m.SetRcode(r, RcodeServerFailure)
 	// does not matter if this write fails

--- a/server.go
+++ b/server.go
@@ -78,6 +78,13 @@ type response struct {
 	writer         Writer            // writer to output the raw DNS bits
 }
 
+// handleRefused returns a HandlerFunc that returns REFUSED for every request it gets.
+func handleRefused(w ResponseWriter, r *Msg) {
+	m := new(Msg)
+	m.SetRcode(r, RcodeRefused)
+	w.WriteMsg(m)
+}
+
 // HandleFailed returns a HandlerFunc that returns SERVFAIL for every request it gets.
 // Deprecated: This function is going away.
 func HandleFailed(w ResponseWriter, r *Msg) {

--- a/server.go
+++ b/server.go
@@ -79,7 +79,9 @@ type response struct {
 }
 
 // HandleFailed returns a HandlerFunc that returns SERVFAIL for every request it gets.
+// Deprecated: This function is going away.
 func HandleFailed(w ResponseWriter, r *Msg) {
+	println("dns: HandleFailed: this function is deprecated")
 	m := new(Msg)
 	m.SetRcode(r, RcodeServerFailure)
 	// does not matter if this write fails


### PR DESCRIPTION
... instead of RcodeServerFailure.