### PR TITLE
Ignore responses with unexpected IDs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -183,7 +183,7 @@ func TestClientSyncBadID(t *testing.T) {
 	m.SetQuestion("miek.nl.", TypeSOA)
 
 	c := &Client{
-		Timeout: 1 * time.Second,
+		Timeout: 50 * time.Millisecond,
 	}
 	if _, _, err := c.Exchange(m, addrstr); err == nil || !isNetworkTimeout(err) {
 		t.Errorf("query did not time out")

--- a/client_test.go
+++ b/client_test.go
@@ -175,6 +175,31 @@ func TestClientSyncBadID(t *testing.T) {
 	m := new(Msg)
 	m.SetQuestion("miek.nl.", TypeSOA)
 
+	c := &Client{
+		Timeout: 1 * time.Second,
+	}
+	if _, _, err := c.Exchange(m, addrstr); err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("query did not time out")
+	}
+	// And now with plain Exchange().
+	if _, err = Exchange(m, addrstr); err == nil || !strings.Contains(err.Error(), "timeout") {
+		t.Errorf("query did not time out")
+	}
+}
+
+func TestClientSyncBadThenGoodID(t *testing.T) {
+	HandleFunc("miek.nl.", HelloServerBadThenGoodID)
+	defer HandleRemove("miek.nl.")
+
+	s, addrstr, err := RunLocalUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeSOA)
+
 	c := new(Client)
 	r, _, err := c.Exchange(m, addrstr)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -225,6 +225,27 @@ func TestClientSyncBadThenGoodID(t *testing.T) {
 	}
 }
 
+func TestClientSyncTCPBadID(t *testing.T) {
+	HandleFunc("miek.nl.", HelloServerBadID)
+	defer HandleRemove("miek.nl.")
+
+	s, addrstr, err := RunLocalTCPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeSOA)
+
+	c := &Client{
+		Net: "tcp",
+	}
+	if _, _, err := c.Exchange(m, addrstr); err != ErrId {
+		t.Errorf("did not find a bad Id")
+	}
+}
+
 func TestClientEDNS0(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)
 	defer HandleRemove("miek.nl.")

--- a/client_test.go
+++ b/client_test.go
@@ -176,12 +176,20 @@ func TestClientSyncBadID(t *testing.T) {
 	m.SetQuestion("miek.nl.", TypeSOA)
 
 	c := new(Client)
-	if _, _, err := c.Exchange(m, addrstr); err != ErrId {
-		t.Errorf("did not find a bad Id")
+	r, _, err := c.Exchange(m, addrstr)
+	if err != nil {
+		t.Errorf("failed to exchange: %v", err)
+	}
+	if r.Id != m.Id {
+		t.Errorf("failed to get response with expected Id")
 	}
 	// And now with plain Exchange().
-	if _, err := Exchange(m, addrstr); err != ErrId {
-		t.Errorf("did not find a bad Id")
+	r, err = Exchange(m, addrstr)
+	if err != nil {
+		t.Errorf("failed to exchange: %v", err)
+	}
+	if r.Id != m.Id {
+		t.Errorf("failed to get response with expected Id")
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -33,6 +33,16 @@ func HelloServerBadID(w ResponseWriter, req *Msg) {
 	m.Extra = make([]RR, 1)
 	m.Extra[0] = &TXT{Hdr: RR_Header{Name: m.Question[0].Name, Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	w.WriteMsg(m)
+}
+
+func HelloServerBadThenGoodID(w ResponseWriter, req *Msg) {
+	m := new(Msg)
+	m.SetReply(req)
+	m.Id++
+
+	m.Extra = make([]RR, 1)
+	m.Extra[0] = &TXT{Hdr: RR_Header{Name: m.Question[0].Name, Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
+	w.WriteMsg(m)
 
 	m.Id--
 	w.WriteMsg(m)

--- a/server_test.go
+++ b/server_test.go
@@ -33,6 +33,9 @@ func HelloServerBadID(w ResponseWriter, req *Msg) {
 	m.Extra = make([]RR, 1)
 	m.Extra[0] = &TXT{Hdr: RR_Header{Name: m.Question[0].Name, Rrtype: TypeTXT, Class: ClassINET, Ttl: 0}, Txt: []string{"Hello world"}}
 	w.WriteMsg(m)
+
+	m.Id--
+	w.WriteMsg(m)
 }
 
 func HelloServerEchoAddrPort(w ResponseWriter, req *Msg) {


### PR DESCRIPTION
This fixes the following problem:

At time 0, we send a query with ID X from port P.

At time T, we time out the query due to lack of response, and then send a different query with ID Y.  By coincidence, the new query is sent from the same port number P (since port numbers are only 16 bits, this can happen with non-negligible probability when making queries at a high rate).

At time T+epsilon, we receive a response to the original query. Since the ID in this response is X, not Y, `exchange` returns `ErrId`, preventing the second query from succeeding.

Since UDP does not have connections, there's no guarantee that a response that we receive is actually associated with the query that we sent - the ID is needed to make the association. Therefore, it's more appropriate to ignore replies with unexpected IDs that to consider them an error.  Accordingly, this pull request changes `exchange` to ignore responses with mismatched IDs.  `exchange` continues waiting for a response with the expected ID and returns it when it arrives.  