### PR TITLE
Set UDPSize in connections created with client.Dial()

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,7 +106,7 @@ func (c *Client) Dial(address string) (conn *Conn, err error) {
 	if err != nil {
 		return nil, err
 	}
-
+	conn.UDPSize = c.UDPSize
 	return conn, nil
 }
 


### PR DESCRIPTION
While Client.UDPSize is honored when using Client.Exchange(), the value is currently not passed on to any Conn that is created with Client.Dial(). For consistency, I believe the Conn should inherit the value from the Client.