### PR TITLE
Start the server with any net.PacketConn implementation

### DIFF
--- a/udp_windows.go
+++ b/udp_windows.go
@@ -6,7 +6,7 @@ import "net"
 
 // SessionUDP holds the remote address
 type SessionUDP struct {
-	raddr *net.UDPAddr
+	raddr net.Addr
 }
 
 // RemoteAddr returns the remote network address.
@@ -15,17 +15,17 @@ func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
 // TODO(fastest963): Once go1.10 is released, use ReadMsgUDP.
-func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
+func ReadFromSessionUDP(conn net.PacketConn, b []byte) (int, *SessionUDP, error) {
 	n, raddr, err := conn.ReadFrom(b)
 	if err != nil {
 		return n, nil, err
 	}
-	return n, &SessionUDP{raddr.(*net.UDPAddr)}, err
+	return n, &SessionUDP{raddr}, err
 }
 
 // WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
 // TODO(fastest963): Once go1.10 is released, use WriteMsgUDP.
-func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
+func WriteToSessionUDP(conn net.PacketConn, b []byte, session *SessionUDP) (int, error) {
 	return conn.WriteTo(b, session.raddr)
 }
 


### PR DESCRIPTION
This removes the check for *net.UDPConn. If it is possible to cast the
connection to *net.UDPConn, it will do it and use more precise
functions.

Fixes https://github.com/miekg/dns/issues/1168