### PR TITLE
Retain TC bit if original message was already marked truncated

### DIFF
--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -77,7 +77,7 @@ func (dns *Msg) Truncate(size int) {
 	}
 
 	// See the function documentation for when we set this.
-	dns.Truncated = len(dns.Answer) > numAnswer ||
+	dns.Truncated = dns.Truncated || len(dns.Answer) > numAnswer ||
 		len(dns.Ns) > numNS || len(dns.Extra) > numExtra
 
 	dns.Answer = dns.Answer[:numAnswer]


### PR DESCRIPTION
Retain TC bit if original message was already marked truncated.

Fixes coredns/coredns#4183

This could alternately be fixed in coredns/coredns, although I can't think how reverting the TC bit would be desirable in any scenario, hence suggesting the fix upstream here.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>