### PR TITLE
Bump CI tested go versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
 
     - name: Check out code into the Go module directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: go
 sudo: false
 
 go:
-  - "1.12.x"
-  - "1.13.x"
+  - 1.14.x
+  - 1.15.x
   - tip
 
 env:


### PR DESCRIPTION
This bumps Travis CI to the last two supported golang releases, as documented in the readme: go1.14 and go1.15.

It also bumps the GitHub Code Action CI to go1.14 as it doesn't yet supported go1.15 (see actions/setup-go#74).

This is blocking #1155.