### PR TITLE
Add odohconfig parameter, defined in draft-pauly-dprive-oblivious-doh-02

### DIFF
--- a/svcb_test.go
+++ b/svcb_test.go
@@ -18,6 +18,7 @@ func TestSVCB(t *testing.T) {
 		{`no-default-alpn`, ``},
 		{`ipv6hint`, `1::4:4:4:4,1::3:3:3:3`},
 		{`echconfig`, `YUdWc2JHOD0=`},
+		{`odohconfig`, `MDZjZDNmNjBjZmY5ODNmZgo=`},
 		{`key65000`, `4\ 3`},
 		{`key65001`, `\"\ `},
 		{`key65002`, ``},


### PR DESCRIPTION
[draft-pauly-oblivious-doh-02](https://tools.ietf.org/html/draft-pauly-dprive-oblivious-doh-02) defines an "odohconfig" Service Binding parameter "odohconfig", which contains the public configuration information for Oblivious DoH. This structure is nearly identical to the "echconfig" parameter. The value of this parameter is a list of `ObliviousDoHConfig` structures.