### PR TITLE
Remove RSAMD5 support from (*RRSIG).Verify

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -6,7 +6,6 @@ import (
 	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	_ "crypto/md5"
 	"crypto/rand"
 	"crypto/rsa"
 	_ "crypto/sha1"
@@ -448,7 +447,7 @@ func (rr *RRSIG) Verify(k *DNSKEY, rrset []RR) error {
 	}
 
 	switch rr.Algorithm {
-	case RSASHA1, RSASHA1NSEC3SHA1, RSASHA256, RSASHA512, RSAMD5:
+	case RSASHA1, RSASHA1NSEC3SHA1, RSASHA256, RSASHA512:
 		// TODO(mg): this can be done quicker, ie. cache the pubkey data somewhere??
 		pubkey := k.publicKeyRSA() // Get the key
 		if pubkey == nil {


### PR DESCRIPTION
AFAIK, the only way to get an RSAMD5 DNSKEY was to manually construct one. This is ancient, just get rid of it.

The only remaining usage of md5 is in tsig.go. Hopefully that might be removable as well.