### PR TITLE
Remove HMAC-MD5 support from TSIG

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -1004,7 +1004,7 @@ func TestServerRoundtripTsig(t *testing.T) {
 			status := w.TsigStatus()
 			if status == nil {
 				// *Msg r has an TSIG record and it was validated
-				m.SetTsig("test.", HmacMD5, 300, time.Now().Unix())
+				m.SetTsig("test.", HmacSHA256, 300, time.Now().Unix())
 			} else {
 				// *Msg r has an TSIG records and it was not valided
 				t.Errorf("invalid TSIG: %v", status)
@@ -1031,7 +1031,7 @@ func TestServerRoundtripTsig(t *testing.T) {
 		Target: "bar.example.com.",
 	}}
 	c.TsigSecret = secret
-	m.SetTsig("test.", HmacMD5, 300, time.Now().Unix())
+	m.SetTsig("test.", HmacSHA256, 300, time.Now().Unix())
 	_, _, err = c.Exchange(m, addrstr)
 	if err != nil {
 		t.Fatal("failed to exchange", err)

--- a/tsig.go
+++ b/tsig.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"crypto/hmac"
-	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
@@ -16,12 +15,13 @@ import (
 
 // HMAC hashing codes. These are transmitted as domain names.
 const (
-	HmacMD5    = "hmac-md5.sig-alg.reg.int."
 	HmacSHA1   = "hmac-sha1."
 	HmacSHA224 = "hmac-sha224."
 	HmacSHA256 = "hmac-sha256."
 	HmacSHA384 = "hmac-sha384."
 	HmacSHA512 = "hmac-sha512."
+
+	HmacMD5 = "hmac-md5.sig-alg.reg.int." // Deprecated: HmacMD5 is no longer supported.
 )
 
 // TSIG is the RR the holds the transaction signature of a message.
@@ -121,8 +121,6 @@ func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, s
 	t := new(TSIG)
 	var h hash.Hash
 	switch CanonicalName(rr.Algorithm) {
-	case HmacMD5:
-		h = hmac.New(md5.New, rawsecret)
 	case HmacSHA1:
 		h = hmac.New(sha1.New, rawsecret)
 	case HmacSHA224:
@@ -185,8 +183,6 @@ func tsigVerify(msg []byte, secret, requestMAC string, timersOnly bool, now uint
 
 	var h hash.Hash
 	switch CanonicalName(tsig.Algorithm) {
-	case HmacMD5:
-		h = hmac.New(md5.New, rawsecret)
 	case HmacSHA1:
 		h = hmac.New(sha1.New, rawsecret)
 	case HmacSHA224:

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -17,7 +17,7 @@ func newTsig(algo string) *Msg {
 }
 
 func TestTsig(t *testing.T) {
-	m := newTsig(HmacMD5)
+	m := newTsig(HmacSHA256)
 	buf, _, err := TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
 	if err != nil {
 		t.Fatal(err)
@@ -29,7 +29,7 @@ func TestTsig(t *testing.T) {
 
 	// TSIG accounts for ID substitution. This means if the message ID is
 	// changed by a forwarder, we should still be able to verify the TSIG.
-	m = newTsig(HmacMD5)
+	m = newTsig(HmacSHA256)
 	buf, _, err = TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
 	if err != nil {
 		t.Fatal(err)
@@ -43,7 +43,7 @@ func TestTsig(t *testing.T) {
 }
 
 func TestTsigCase(t *testing.T) {
-	m := newTsig("HmAc-mD5.sig-ALg.rEg.int.") // HmacMD5
+	m := newTsig(strings.ToUpper(HmacSHA256))
 	buf, _, err := TsigGenerate(m, "pRZgBrBvI4NAHZYhxmhs/Q==", "", false)
 	if err != nil {
 		t.Fatal(err)
@@ -62,7 +62,7 @@ const (
 		"%012x" + // placeholder for the "time signed" field
 		"012c00208cf23e0081d915478a182edcea7ff48ad102948e6c7ef8e887536957d1fa5616c60000000000"
 	// A secret (in base64 format) with which the TSIG in wireMsg will be validated
-	testSecret        = "NoTCJU+DMqFWywaPyxSijrDEA/eC3nK0xi3AMEZuPVk="
+	testSecret = "NoTCJU+DMqFWywaPyxSijrDEA/eC3nK0xi3AMEZuPVk="
 	// the 'time signed' field value that would make the TSIG RR valid with testSecret
 	timeSigned uint64 = 1594855491
 )


### PR DESCRIPTION
The [Wikipedia article for TSIG](https://en.wikipedia.org/wiki/TSIG#Alternatives_to_TSIG) claims that HMAC-MD5 is "still in common usage", but doesn't provide any source for this. If there's no one who desperately needs this, I'd like to remove it entirely.

MD5 is a severely broken algorithm so it would be great to get it out of this library, even removing legacy support.

Considering that the TSIG algorithm is set by the TSIG record and not by the secret key (!! see [the JWT token mess](https://auth0.com/blog/critical-vulnerabilities-in-json-web-token-libraries/)), an exploitable weakness in HMAC-MD5 could allow easy forging of TSIG records even on systems that do not otherwise use MD5.