### PR TITLE
When using TCP connections send only one packet

### DIFF
--- a/client.go
+++ b/client.go
@@ -330,11 +330,11 @@ func (co *Conn) Write(p []byte) (int, error) {
 		return co.Conn.Write(p)
 	}
 
-	l := make([]byte, 2)
-	binary.BigEndian.PutUint16(l, uint16(len(p)))
+	msg_with_length := make([]byte, 2+len(p))
+	binary.BigEndian.PutUint16(msg_with_length, uint16(len(p)))
+	copy(msg_with_length[2:], p[:])
 
-	n, err := (&net.Buffers{l, p}).WriteTo(co.Conn)
-	return int(n), err
+	return co.Conn.Write(msg_with_length)
 }
 
 // Return the appropriate timeout for a specific request

--- a/server.go
+++ b/server.go
@@ -752,11 +752,11 @@ func (w *response) Write(m []byte) (int, error) {
 			return 0, &Error{err: "message too large"}
 		}
 
-		l := make([]byte, 2)
-		binary.BigEndian.PutUint16(l, uint16(len(m)))
+		msg_with_length := make([]byte, 2+len(m))
+		binary.BigEndian.PutUint16(msg_with_length, uint16(len(m)))
+		copy(msg_with_length[2:], m[:])
 
-		n, err := (&net.Buffers{l, m}).WriteTo(w.tcp)
-		return int(n), err
+		return w.tcp.Write(msg_with_length)
 	default:
 		panic("dns: internal error: udp and tcp both nil")
 	}


### PR DESCRIPTION
net.Buffers relies on writeBuffer to send all the pieces in one go. The
tls library does not support this so the length and content get split
into 2 packets. This patch removes net.Buffers and replaces with a new
single memory allocation to ensure the length+content get sent in one
packet. This fixes #1199