### PR TITLE
Add GSS-TSIG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 340{1,2,3} - NAPTR record
 * 3445 - Limiting the scope of (DNS)KEY
 * 3597 - Unknown RRs
-* 3645 - GSS-TSIG
 * 403{3,4,5} - DNSSEC + validation functions
 * 4255 - SSHFP record
 * 4343 - Case insensitivity

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 340{1,2,3} - NAPTR record
 * 3445 - Limiting the scope of (DNS)KEY
 * 3597 - Unknown RRs
+* 3645 - GSS-TSIG
 * 403{3,4,5} - DNSSEC + validation functions
 * 4255 - SSHFP record
 * 4343 - Case insensitivity

--- a/client.go
+++ b/client.go
@@ -23,7 +23,7 @@ type Conn struct {
 	net.Conn                         // a net.Conn holding the connection
 	UDPSize        uint16            // minimum receive buffer for UDP messages
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
-	GSSAPI         GSSAPI            // an implementation of the GSSAPI interface
+	TsigGSS                          // An implementation of the TsigGSS interface.
 	tsigRequestMAC string
 }
 
@@ -41,7 +41,7 @@ type Client struct {
 	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
-	GSSAPI         GSSAPI            // an implementation of the GSSAPI interface
+	TsigGSS                          // An implementation of the TsigGSS interface.
 	SingleInflight bool              // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
 }
@@ -177,7 +177,7 @@ func (c *Client) exchange(m *Msg, co *Conn) (r *Msg, rtt time.Duration, err erro
 		co.UDPSize = c.UDPSize
 	}
 
-	co.TsigSecret, co.GSSAPI = c.TsigSecret, c.GSSAPI
+	co.TsigSecret, co.TsigGSS = c.TsigSecret, c.TsigGSS
 	t := time.Now()
 	// write with the appropriate write timeout
 	co.SetWriteDeadline(t.Add(c.getTimeoutForRequest(c.writeTimeout())))
@@ -228,7 +228,7 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 			return m, ErrSecret
 		}
 		// Need to work on the original message p, as that was used to calculate the tsig.
-		err = tsigVerifyGSSAPI(p, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false, co.GSSAPI)
+		err = tsigVerifyGSS(p, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false, co.TsigGSS)
 	}
 	return m, err
 }
@@ -309,7 +309,7 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 			return ErrSecret
 		}
-		out, mac, err = tsigGenerateGSSAPI(m, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false, co.GSSAPI)
+		out, mac, err = tsigGenerateGSS(m, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false, co.TsigGSS)
 		// Set for the next read, although only used in zone transfers
 		co.tsigRequestMAC = mac
 	} else {

--- a/client.go
+++ b/client.go
@@ -225,7 +225,7 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 	}
 	if t := m.IsTsig(); t != nil {
 		if co.TsigProvider != nil {
-			err = tsigVerifyProvider(p, co.tsigRequestMAC, false, co.TsigProvider)
+			err = tsigVerifyProvider(p, co.TsigProvider, co.tsigRequestMAC, false)
 		} else {
 			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 				return m, ErrSecret
@@ -311,7 +311,7 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 	if t := m.IsTsig(); t != nil {
 		mac := ""
 		if co.TsigProvider != nil {
-			out, mac, err = tsigGenerateProvider(m, co.tsigRequestMAC, false, co.TsigProvider)
+			out, mac, err = tsigGenerateProvider(m, co.TsigProvider, co.tsigRequestMAC, false)
 		} else {
 			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 				return ErrSecret

--- a/client.go
+++ b/client.go
@@ -23,6 +23,7 @@ type Conn struct {
 	net.Conn                         // a net.Conn holding the connection
 	UDPSize        uint16            // minimum receive buffer for UDP messages
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	GSSAPI         GSSAPI            // an implementation of the GSSAPI interface
 	tsigRequestMAC string
 }
 
@@ -40,6 +41,7 @@ type Client struct {
 	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
+	GSSAPI         GSSAPI            // an implementation of the GSSAPI interface
 	SingleInflight bool              // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
 }
@@ -175,7 +177,7 @@ func (c *Client) exchange(m *Msg, co *Conn) (r *Msg, rtt time.Duration, err erro
 		co.UDPSize = c.UDPSize
 	}
 
-	co.TsigSecret = c.TsigSecret
+	co.TsigSecret, co.GSSAPI = c.TsigSecret, c.GSSAPI
 	t := time.Now()
 	// write with the appropriate write timeout
 	co.SetWriteDeadline(t.Add(c.getTimeoutForRequest(c.writeTimeout())))
@@ -226,7 +228,7 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 			return m, ErrSecret
 		}
 		// Need to work on the original message p, as that was used to calculate the tsig.
-		err = TsigVerify(p, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
+		err = tsigVerifyGSSAPI(p, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false, co.GSSAPI)
 	}
 	return m, err
 }
@@ -307,7 +309,7 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 		if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 			return ErrSecret
 		}
-		out, mac, err = TsigGenerate(m, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false)
+		out, mac, err = tsigGenerateGSSAPI(m, co.TsigSecret[t.Hdr.Name], co.tsigRequestMAC, false, co.GSSAPI)
 		// Set for the next read, although only used in zone transfers
 		co.tsigRequestMAC = mac
 	} else {

--- a/client.go
+++ b/client.go
@@ -23,7 +23,7 @@ type Conn struct {
 	net.Conn                         // a net.Conn holding the connection
 	UDPSize        uint16            // minimum receive buffer for UDP messages
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
-	TsigProvider                     // An implementation of the TsigProvider interface.
+	TsigProvider   TsigProvider      // An implementation of the TsigProvider interface. If defined it replaces TsigSecret and is used for all TSIG operations.
 	tsigRequestMAC string
 }
 
@@ -41,7 +41,7 @@ type Client struct {
 	ReadTimeout    time.Duration     // net.Conn.SetReadTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	WriteTimeout   time.Duration     // net.Conn.SetWriteTimeout value for connections, defaults to 2 seconds - overridden by Timeout when that value is non-zero
 	TsigSecret     map[string]string // secret(s) for Tsig map[<zonename>]<base64 secret>, zonename must be in canonical form (lowercase, fqdn, see RFC 4034 Section 6.2)
-	TsigProvider                     // An implementation of the TsigProvider interface.
+	TsigProvider   TsigProvider      // An implementation of the TsigProvider interface. If defined it replaces TsigSecret and is used for all TSIG operations.
 	SingleInflight bool              // if true suppress multiple outstanding queries for the same Qname, Qtype and Qclass
 	group          singleflight
 }

--- a/doc.go
+++ b/doc.go
@@ -214,7 +214,7 @@ client must be configured with an implementation of the TsigProvider interface:
 	c.TsigProvider = new(Provider)
 	m := new(dns.Msg)
 	m.SetQuestion("miek.nl.", dns.TypeMX)
-	m.SetTsig(keyname, dns.GSS, 300, time.Now().Unix())
+	m.SetTsig(keyname, dns.HmacSHA1, 300, time.Now().Unix())
 	...
 	// TSIG RR is calculated by calling your Generate method
 

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -80,23 +80,23 @@ func TestTsigErrors(t *testing.T) {
 	}
 
 	// the signature is valid but 'time signed' is too far from the "current time".
-	if err := tsigVerify(buildMsgData(timeSigned), "", false, timeSigned+301, tsigHMACProvider(testSecret)); err != ErrTime {
+	if err := tsigVerify(buildMsgData(timeSigned), tsigHMACProvider(testSecret), "", false, timeSigned+301); err != ErrTime {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrTime, err)
 	}
-	if err := tsigVerify(buildMsgData(timeSigned), "", false, timeSigned-301, tsigHMACProvider(testSecret)); err != ErrTime {
+	if err := tsigVerify(buildMsgData(timeSigned), tsigHMACProvider(testSecret), "", false, timeSigned-301); err != ErrTime {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrTime, err)
 	}
 
 	// the signature is invalid and 'time signed' is too far.
 	// the signature should be checked first, so we should see ErrSig.
-	if err := tsigVerify(buildMsgData(timeSigned+301), "", false, timeSigned, tsigHMACProvider(testSecret)); err != ErrSig {
+	if err := tsigVerify(buildMsgData(timeSigned+301), tsigHMACProvider(testSecret), "", false, timeSigned); err != ErrSig {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrSig, err)
 	}
 
 	// tweak the algorithm name in the wire data, resulting in the "unknown algorithm" error.
 	msgData := buildMsgData(timeSigned)
 	copy(msgData[67:], "bogus")
-	if err := tsigVerify(msgData, "", false, timeSigned, tsigHMACProvider(testSecret)); err != ErrKeyAlg {
+	if err := tsigVerify(msgData, tsigHMACProvider(testSecret), "", false, timeSigned); err != ErrKeyAlg {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrKeyAlg, err)
 	}
 
@@ -105,7 +105,7 @@ func TestTsigErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tsigVerify(msgData, "", false, timeSigned, tsigHMACProvider(testSecret)); err != ErrNoSig {
+	if err := tsigVerify(msgData, tsigHMACProvider(testSecret), "", false, timeSigned); err != ErrNoSig {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrNoSig, err)
 	}
 
@@ -121,7 +121,7 @@ func TestTsigErrors(t *testing.T) {
 	if msgData, err = msg.Pack(); err != nil {
 		t.Fatal(err)
 	}
-	err = tsigVerify(msgData, "", false, timeSigned, tsigHMACProvider(testSecret))
+	err = tsigVerify(msgData, tsigHMACProvider(testSecret), "", false, timeSigned)
 	if err == nil || !strings.Contains(err.Error(), "overflow") {
 		t.Errorf("expected error to contain %q, but got %v", "overflow", err)
 	}
@@ -232,16 +232,14 @@ func TestTSIGHMAC224And384(t *testing.T) {
 			if mac != tc.expectedMAC {
 				t.Fatalf("MAC doesn't match: expected '%s' but got '%s'", tc.expectedMAC, mac)
 			}
-			if err = tsigVerify(msgData, "", false, timeSigned, tsigHMACProvider(tc.secret)); err != nil {
+			if err = tsigVerify(msgData, tsigHMACProvider(tc.secret), "", false, timeSigned); err != nil {
 				t.Error(err)
 			}
 		})
 	}
 }
 
-const (
-	testGoodKeyName = "goodkey."
-)
+const testGoodKeyName = "goodkey."
 
 var (
 	testErrBadKey = errors.New("this is an intentional error")
@@ -254,43 +252,39 @@ type testProvider struct {
 }
 
 func (provider *testProvider) Generate(_ []byte, t *TSIG) ([]byte, error) {
-	switch {
-	case t.Hdr.Name == testGoodKeyName || provider.GenerateAllKeys:
+	if t.Hdr.Name == testGoodKeyName || provider.GenerateAllKeys {
 		return testGoodMAC, nil
-	default:
-		return nil, testErrBadKey
 	}
+	return nil, testErrBadKey
 }
 
 func (*testProvider) Verify(_ []byte, t *TSIG) error {
-	switch t.Hdr.Name {
-	case testGoodKeyName:
+	if t.Hdr.Name == testGoodKeyName {
 		return nil
-	default:
-		return testErrBadKey
 	}
+	return testErrBadKey
 }
 
 func TestTsigGenerateProvider(t *testing.T) {
-	tables := map[string]struct {
+	tables := []struct {
 		keyname string
 		mac     []byte
 		err     error
 	}{
-		"ok": {
+		{
 			testGoodKeyName,
 			testGoodMAC,
 			nil,
 		},
-		"bad": {
+		{
 			"badkey.",
 			nil,
 			testErrBadKey,
 		},
 	}
 
-	for name, table := range tables {
-		t.Run(name, func(t *testing.T) {
+	for _, table := range tables {
+		t.Run(table.keyname, func(t *testing.T) {
 			tsig := TSIG{
 				Hdr:        RR_Header{Name: table.keyname, Rrtype: TypeTSIG, Class: ClassANY, Ttl: 0},
 				Algorithm:  HmacSHA1,
@@ -304,7 +298,7 @@ func TestTsigGenerateProvider(t *testing.T) {
 				Extra:    []RR{&tsig},
 			}
 
-			_, mac, err := tsigGenerateProvider(req, "", false, new(testProvider))
+			_, mac, err := tsigGenerateProvider(req, new(testProvider), "", false)
 			if err != table.err {
 				t.Fatalf("error doesn't match: expected '%s' but got '%s'", table.err, err)
 			}
@@ -317,22 +311,22 @@ func TestTsigGenerateProvider(t *testing.T) {
 }
 
 func TestTsigVerifyProvider(t *testing.T) {
-	tables := map[string]struct {
+	tables := []struct {
 		keyname string
 		err     error
 	}{
-		"ok": {
+		{
 			testGoodKeyName,
 			nil,
 		},
-		"bad": {
+		{
 			"badkey.",
 			testErrBadKey,
 		},
 	}
 
-	for name, table := range tables {
-		t.Run(name, func(t *testing.T) {
+	for _, table := range tables {
+		t.Run(table.keyname, func(t *testing.T) {
 			tsig := TSIG{
 				Hdr:        RR_Header{Name: table.keyname, Rrtype: TypeTSIG, Class: ClassANY, Ttl: 0},
 				Algorithm:  HmacSHA1,
@@ -347,11 +341,11 @@ func TestTsigVerifyProvider(t *testing.T) {
 			}
 
 			provider := &testProvider{true}
-			msgData, _, err := tsigGenerateProvider(req, "", false, provider)
+			msgData, _, err := tsigGenerateProvider(req, provider, "", false)
 			if err != nil {
 				t.Error(err)
 			}
-			if err = tsigVerify(msgData, "", false, timeSigned, provider); err != table.err {
+			if err = tsigVerify(msgData, provider, "", false, timeSigned); err != table.err {
 				t.Fatalf("error doesn't match: expected '%s' but got '%s'", table.err, err)
 			}
 		})

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -79,23 +79,23 @@ func TestTsigErrors(t *testing.T) {
 	}
 
 	// the signature is valid but 'time signed' is too far from the "current time".
-	if err := tsigVerify(buildMsgData(timeSigned), testSecret, "", false, timeSigned+301); err != ErrTime {
+	if err := tsigVerify(buildMsgData(timeSigned), testSecret, "", false, timeSigned+301, nil); err != ErrTime {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrTime, err)
 	}
-	if err := tsigVerify(buildMsgData(timeSigned), testSecret, "", false, timeSigned-301); err != ErrTime {
+	if err := tsigVerify(buildMsgData(timeSigned), testSecret, "", false, timeSigned-301, nil); err != ErrTime {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrTime, err)
 	}
 
 	// the signature is invalid and 'time signed' is too far.
 	// the signature should be checked first, so we should see ErrSig.
-	if err := tsigVerify(buildMsgData(timeSigned+301), testSecret, "", false, timeSigned); err != ErrSig {
+	if err := tsigVerify(buildMsgData(timeSigned+301), testSecret, "", false, timeSigned, nil); err != ErrSig {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrSig, err)
 	}
 
 	// tweak the algorithm name in the wire data, resulting in the "unknown algorithm" error.
 	msgData := buildMsgData(timeSigned)
 	copy(msgData[67:], "bogus")
-	if err := tsigVerify(msgData, testSecret, "", false, timeSigned); err != ErrKeyAlg {
+	if err := tsigVerify(msgData, testSecret, "", false, timeSigned, nil); err != ErrKeyAlg {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrKeyAlg, err)
 	}
 
@@ -104,7 +104,7 @@ func TestTsigErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tsigVerify(msgData, testSecret, "", false, timeSigned); err != ErrNoSig {
+	if err := tsigVerify(msgData, testSecret, "", false, timeSigned, nil); err != ErrNoSig {
 		t.Fatalf("expected an error '%v' but got '%v'", ErrNoSig, err)
 	}
 
@@ -120,7 +120,7 @@ func TestTsigErrors(t *testing.T) {
 	if msgData, err = msg.Pack(); err != nil {
 		t.Fatal(err)
 	}
-	err = tsigVerify(msgData, testSecret, "", false, timeSigned)
+	err = tsigVerify(msgData, testSecret, "", false, timeSigned, nil)
 	if err == nil || !strings.Contains(err.Error(), "overflow") {
 		t.Errorf("expected error to contain %q, but got %v", "overflow", err)
 	}
@@ -231,7 +231,7 @@ func TestTSIGHMAC224And384(t *testing.T) {
 			if mac != tc.expectedMAC {
 				t.Fatalf("MAC doesn't match: expected '%s' but got '%s'", tc.expectedMAC, mac)
 			}
-			if err = tsigVerify(msgData, tc.secret, "", false, timeSigned); err != nil {
+			if err = tsigVerify(msgData, tc.secret, "", false, timeSigned, nil); err != nil {
 				t.Error(err)
 			}
 		})


### PR DESCRIPTION
Here's another go at adding GSS-TSIG support.

Inspired by how crypto/ssh handles this I've defined a simple interface for an external GSSAPI implementation and added this to the `Client` and `Conn` structs. I've added two new internal `tsigGenerateGSSAPI()` and `tsigVerifyGSSAPI()` functions that are passed this interface and then refactored the original exported `TsigGenerate()` and `TsigVerify()` functions to use these, passing `nil` for the GSSAPI interface, so existing code using those will behave the same as before.

I've left the new functions unexported and I haven't touched the `Server` or `Transfer` structs yet. I've not added any tests either but that should be easy enough if you approve.