### PR TITLE
Fix comment about SVCB values in AliasMode

### DIFF
--- a/svcb.go
+++ b/svcb.go
@@ -204,7 +204,7 @@ type SVCB struct {
 	Hdr      RR_Header
 	Priority uint16
 	Target   string         `dns:"domain-name"`
-	Value    []SVCBKeyValue `dns:"pairs"` // Value must be empty if Priority is non-zero.
+	Value    []SVCBKeyValue `dns:"pairs"` // Value must be empty if Priority is zero.
 }
 
 // HTTPS RR. Everything valid for SVCB applies to HTTPS as well.


### PR DESCRIPTION
When the priority is zero, the record is in AliasMode and so the value must be empty. This changes the comment accordingly.