### PR TITLE
Export MakeSVCBKeyValue

### DIFF
--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -627,7 +627,7 @@ func unpackDataSVCB(msg []byte, off int) ([]SVCBKeyValue, int, error) {
 		if err != nil || off+int(length) > len(msg) {
 			return nil, len(msg), &Error{err: "overflow unpacking SVCB"}
 		}
-		e := makeSVCBKeyValue(SVCBKey(code))
+		e := MakeSVCBKeyValue(SVCBKey(code))
 		if e == nil {
 			return nil, len(msg), &Error{err: "bad SVCB key"}
 		}

--- a/svcb.go
+++ b/svcb.go
@@ -149,7 +149,7 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 					}
 				}
 			}
-			kv := makeSVCBKeyValue(svcbStringToKey(key))
+			kv := MakeSVCBKeyValue(svcbStringToKey(key))
 			if kv == nil {
 				return &ParseError{l.token, "bad SVCB key", l}
 			}
@@ -173,8 +173,8 @@ func (rr *SVCB) parse(c *zlexer, o string) *ParseError {
 	return nil
 }
 
-// makeSVCBKeyValue returns an SVCBKeyValue struct with the key or nil for reserved keys.
-func makeSVCBKeyValue(key SVCBKey) SVCBKeyValue {
+// MakeSVCBKeyValue returns an SVCBKeyValue struct with the key or nil for reserved keys.
+func MakeSVCBKeyValue(key SVCBKey) SVCBKeyValue {
 	switch key {
 	case SVCB_MANDATORY:
 		return new(SVCBMandatory)

--- a/svcb_test.go
+++ b/svcb_test.go
@@ -27,7 +27,7 @@ func TestSVCB(t *testing.T) {
 
 	for _, o := range svcbs {
 		keyCode := svcbStringToKey(o.key)
-		kv := makeSVCBKeyValue(keyCode)
+		kv := MakeSVCBKeyValue(keyCode)
 		if kv == nil {
 			t.Error("failed to parse svc key: ", o.key)
 			continue
@@ -87,7 +87,7 @@ func TestDecodeBadSVCB(t *testing.T) {
 		},
 	}
 	for _, o := range svcbs {
-		err := makeSVCBKeyValue(SVCBKey(o.key)).unpack(o.data)
+		err := MakeSVCBKeyValue(SVCBKey(o.key)).unpack(o.data)
 		if err == nil {
 			t.Error("accepted invalid svc value with key ", SVCBKey(o.key).String())
 		}


### PR DESCRIPTION
This would be very helpful for deserializing `SVCBKeyValue`.

Because `SVCBKeyValue` is an interface, it's currently not possible to deserialize structs like `SVCBAlpn` if we don't already know their concrete type. This change would allow us to serialize the `SVCBKey` and use it to instantiate the appropriate type when deserializing.

Currently, `Key()` is exported which allows us to get the `SVCBKey` from an `SVCBKeyValue`, but it's not possible to create a new `SVCBKeyValue` from a `SVCBKey`.

Thank you!