### PR TITLE
Add a link to https://github.com/bodgit/tsig

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://router7.org/
 * https://github.com/fortio/dnsping
 * https://github.com/Luzilla/dnsbl_exporter
+* https://github.com/bodgit/tsig
 
 Send pull request if you want to be listed here.
 


### PR DESCRIPTION
With #1201 merged, I've finalised my GSS-TSIG library. This PR is a link to my library.

By using the `TsigProvider` interface, it disables the original support for the HMAC TSIG methods so I wrote a version of that implementing the same interface. Rather than try and create a "super-provider" that supports every algorithm possible directly I borrowed an idea from the `io.Multi*` functions and wrote a `MultiProvider` that chains multiple providers together. If one provider returns `ErrKeyAlg`, the next provider in the list is tried.

So you can create a client that supports both sets of TSIG algorithms with something like this:
```golang
dnsClient := new(dns.Client)
dnsClient.Net = "tcp"

hmac := tsig.HMAC{"axfr.": "so6ZGir4GPAqINNh9U5c3A=="}

gssClient, err := gss.NewClient(dnsClient)
if err != nil {
        panic(err)
}
defer gssClient.Close()

dnsClient.TsigProvider = tsig.MultiProvider(hmac, gssClient)
```
Thanks again for merging!