### PR TITLE
Update Truncate doc with compress behaviour

### DIFF
--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -8,6 +8,11 @@ package dns
 // record adding as many records as possible without exceeding the
 // requested buffer size.
 //
+// Note that if the message fits within the requested size without compression,
+// Truncate will reset the message's `Compress` attribute to `false`. It is
+// the caller responsibility to set it back to `true` if they wish to compress
+// the payload regardless.
+//
 // The TC bit will be set if any records were excluded from the message.
 // If the TC bit is already set on the message it will be retained.
 // TC indicates that the client should retry over TCP.

--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -8,10 +8,10 @@ package dns
 // record adding as many records as possible without exceeding the
 // requested buffer size.
 //
-// Note that if the message fits within the requested size without compression,
-// Truncate will reset the message's `Compress` attribute to `false`. It is
-// the caller responsibility to set it back to `true` if they wish to compress
-// the payload regardless.
+// If the message fits within the requested size without compression,
+// Truncate will set the message's Compress attribute to false. It is
+// the caller's responsibility to set it back to true if they wish to
+// compress the payload regardless.
 //
 // The TC bit will be set if any records were excluded from the message.
 // If the TC bit is already set on the message it will be retained.

--- a/msg_truncate.go
+++ b/msg_truncate.go
@@ -11,7 +11,7 @@ package dns
 // If the message fits within the requested size without compression,
 // Truncate will set the message's Compress attribute to false. It is
 // the caller's responsibility to set it back to true if they wish to
-// compress the payload regardless.
+// compress the payload regardless of size.
 //
 // The TC bit will be set if any records were excluded from the message.
 // If the TC bit is already set on the message it will be retained.


### PR DESCRIPTION
This is a documentation update to highlight the behaviour of Truncate, which will reset dns.Compress to false when the message fits in the requested size without truncation, and make it the caller responsibility to set it back to true if they wish to compress, regardless of fitting, uncompressed, in the requested message size in the first place or not.
Fixes #1216