### PR TITLE
Send DNS query in one packet when using TCP/TLS

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -340,8 +341,8 @@ func (co *Conn) Write(p []byte) (int, error) {
 		return co.Conn.Write(p)
 	}
 
-	if _, ok := co.Conn.(*net.TCPConn); ok {
-		// Limit usage of net.Buffers to net.TCPConn only
+	if _, ok := co.Conn.(*net.TCPConn); ok && runtime.GOOS == "linux" {
+		// Limit usage of net.Buffers to net.TCPConn on Linux only
 		// In the case of TLS using it results in splitting it
 		// into two packets
 
@@ -354,7 +355,7 @@ func (co *Conn) Write(p []byte) (int, error) {
 
 	msg := make([]byte, 2+len(p))
 	binary.BigEndian.PutUint16(msg, uint16(len(p)))
-	copy(msg[2:], p[:])
+	copy(msg[2:], p)
 	return co.Conn.Write(msg)
 }
 

--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -339,18 +338,6 @@ func (co *Conn) Write(p []byte) (int, error) {
 
 	if _, ok := co.Conn.(net.PacketConn); ok {
 		return co.Conn.Write(p)
-	}
-
-	if _, ok := co.Conn.(*net.TCPConn); ok && runtime.GOOS == "linux" {
-		// Limit usage of net.Buffers to net.TCPConn on Linux only
-		// In the case of TLS using it results in splitting it
-		// into two packets
-
-		l := make([]byte, 2)
-		binary.BigEndian.PutUint16(l, uint16(len(p)))
-
-		n, err := (&net.Buffers{l, p}).WriteTo(co.Conn)
-		return int(n), err
 	}
 
 	msg := make([]byte, 2+len(p))

--- a/client_test.go
+++ b/client_test.go
@@ -396,6 +396,24 @@ func TestClientConn(t *testing.T) {
 	}
 }
 
+func TestClientConnWriteSinglePacket(t *testing.T) {
+	c := &countingConn{}
+	conn := Conn{
+		Conn: c,
+	}
+	m := new(Msg)
+	m.SetQuestion("miek.nl.", TypeTXT)
+	err := conn.WriteMsg(m)
+
+	if err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	if c.writes != 1 {
+		t.Fatalf("incorrect number of Write calls")
+	}
+}
+
 func TestTruncatedMsg(t *testing.T) {
 	m := new(Msg)
 	m.SetQuestion("miek.nl.", TypeSRV)

--- a/server.go
+++ b/server.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"io"
 	"net"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -751,18 +750,6 @@ func (w *response) Write(m []byte) (int, error) {
 	case w.tcp != nil:
 		if len(m) > MaxMsgSize {
 			return 0, &Error{err: "message too large"}
-		}
-
-		if _, ok := w.tcp.(*net.TCPConn); ok && runtime.GOOS == "linux" {
-			// Limit usage of net.Buffers to net.TCPConn on Linux only
-			// In the case of TLS using it results in splitting it
-			// into two packets
-
-			l := make([]byte, 2)
-			binary.BigEndian.PutUint16(l, uint16(len(m)))
-
-			n, err := (&net.Buffers{l, m}).WriteTo(w.tcp)
-			return int(n), err
 		}
 
 		msg := make([]byte, 2+len(m))


### PR DESCRIPTION
Attempt to improve #1200.
This fixes #1199 and this is also crucial for #1218.

This way we'll continue to use `net.Buffers` for TCP connections and only switch to allocating a new buffer for TLS.
Regarding additional unit-tests, it seems that both code branches are already covered by existing unit-tests.