### PR TITLE
Run a go fmt -w -s

### DIFF
--- a/msg_helpers_test.go
+++ b/msg_helpers_test.go
@@ -296,14 +296,14 @@ func TestPackDataAplPrefix_BufferBounds(t *testing.T) {
 
 func TestPackDataApl(t *testing.T) {
 	in := []APLPrefix{
-		APLPrefix{
+		{
 			Negation: true,
 			Network: net.IPNet{
 				IP:   net.ParseIP("198.51.0.0").To4(),
 				Mask: net.CIDRMask(16, 32),
 			},
 		},
-		APLPrefix{
+		{
 			Negation: false,
 			Network: net.IPNet{
 				IP:   net.ParseIP("2001:db8:beef::"),

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -161,7 +161,7 @@ func TestTsigGenerate(t *testing.T) {
 			testTSIG.OtherData = tc.otherData
 			req := &Msg{
 				MsgHdr:   MsgHdr{Opcode: OpcodeUpdate},
-				Question: []Question{Question{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
+				Question: []Question{{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
 				Extra:    []RR{&testTSIG},
 			}
 
@@ -220,7 +220,7 @@ func TestTSIGHMAC224And384(t *testing.T) {
 			}
 			req := &Msg{
 				MsgHdr:   MsgHdr{Opcode: OpcodeUpdate},
-				Question: []Question{Question{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
+				Question: []Question{{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
 				Extra:    []RR{&tsig},
 			}
 
@@ -294,7 +294,7 @@ func TestTsigGenerateProvider(t *testing.T) {
 			}
 			req := &Msg{
 				MsgHdr:   MsgHdr{Opcode: OpcodeUpdate},
-				Question: []Question{Question{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
+				Question: []Question{{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
 				Extra:    []RR{&tsig},
 			}
 
@@ -336,7 +336,7 @@ func TestTsigVerifyProvider(t *testing.T) {
 			}
 			req := &Msg{
 				MsgHdr:   MsgHdr{Opcode: OpcodeUpdate},
-				Question: []Question{Question{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
+				Question: []Question{{Name: "example.com.", Qtype: TypeSOA, Qclass: ClassINET}},
 				Extra:    []RR{&tsig},
 			}
 


### PR DESCRIPTION
Noticed a non-gofmted `;` earlier, run gofmt -w -s on all files.

(mechanical change)

Signed-off-by: Miek Gieben <miek@miek.nl>
