### PR TITLE
Bump go versions in .github/workflows/go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,5 @@ jobs:
 
     - name: Fuzz
       run: |
-        export GOPATH=$GOROOT
         make -f Makefile.fuzz get
         make -f Makefile.fuzz

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.14', '1.15' ]
+        go: [ 1.15.x, 1.16.x ]
     steps:
 
     - name: Set up Go
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: '1.14'
+        go-version: 1.16.x
 
     - name: Check out code
       uses: actions/checkout@v2


### PR DESCRIPTION
These are very out of date and it's causing persistent failures in the fuzz CI step. I hadn't paid much attention as I thought they were related to #1223, but I'm pretty sure it's because the go version is so out-of-date.

**Edit**: An example of the errors for posterity:

```
Error: /opt/hostedtoolcache/go/1.14.15/x64/pkg/mod/github.com/dvyukov/go-fuzz@v0.0.0-20210103155950-6a8e9d1f2415/go-fuzz-build/main.go:267:16: undefined: packages.NeedName
Error: /opt/hostedtoolcache/go/1.14.15/x64/pkg/mod/github.com/dvyukov/go-fuzz@v0.0.0-20210103155950-6a8e9d1f2415/go-fuzz-build/main.go:293:16: cannot use func literal (type func(*token.FileSet, string, []byte) (*ast.File, error)) as type func(*token.FileSet, string) (*ast.File, error) in assignment
Error: /opt/hostedtoolcache/go/1.14.15/x64/pkg/mod/github.com/dvyukov/go-fuzz@v0.0.0-20210103155950-6a8e9d1f2415/go-fuzz-build/main.go:419:13: undefined: packages.NeedName
```