### PR TITLE
Remove fuzz from .github/workflows/go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,21 +23,3 @@ jobs:
 
     - name: Test
       run: go test -v ./...
-
-  fuzz:
-    name: Fuzz
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16.x
-
-    - name: Check out code
-      uses: actions/checkout@v2
-
-    - name: Fuzz
-      run: |
-        make -f Makefile.fuzz get
-        make -f Makefile.fuzz


### PR DESCRIPTION
The Fuzz step is still failing even after #1237. See these two runs on the master branch: https://github.com/miekg/dns/runs/2031876704 & https://github.com/miekg/dns/runs/2031876289. They failed even though the run for the #1237 PR succeeded: https://github.com/miekg/dns/pull/1237/checks?check_run_id=2027941443.

The problem is caused by github.com/dvyukov/go-fuzz/go-fuzz (and it's dependencies as it lacks a go.mod file) not being included in our go.mod file. For some reason the go command seems to be non-deterministically picking a version of golang.org/x/tools to download, sometimes picking one that's too old. I'm not sure why that is, and it feels like a bug in the go command or go module proxy.

We can either add it to our go.mod and go.sum files or remove the step. I think removing it (this PR) is the best option as it doesn't actually run the fuzzer, it merely checks it builds. go1.17/go1.18 is set to have a native fuzzer support (see golang.org/issue/44551) so I don't think wrangling this makes a ton of sense.

Also oss-fuzz is actually running the fuzzers so they'd break loudly if we broke the fuzz targets anyway.

This should finally fix the failing CI runs.

Updates #1237