### PR TITLE
Allow custom Dialer implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -384,7 +384,7 @@ func (c *Client) getTimeoutForRequest(timeout time.Duration) time.Duration {
 	}
 	// net.Dialer.Timeout has priority if smaller than the timeouts computed so
 	// far
-	if netDialer, ok := c.Dialer.(*net.Dialer); ok {
+	if netDialer, ok := c.Dialer.(*net.Dialer); ok && netDialer.Timeout != 0 {
 		if netDialer.Timeout < requestTimeout {
 			requestTimeout = netDialer.Timeout
 		}


### PR DESCRIPTION
Currently only a `net.Dialer` can be passed to the client. This prevents the client from using a custom implementation, because `net.Dialer` is not a interface. E.g. it is not possible to use a proxy.

If the Dialer field type is replaced with an interface, we can still use `net.Dialer`, but also specify a custom Dialer. Because `tls.DialWithDialer` also uses `net.Dialer` this function must be replaced with the call to the provided dialer, settings the `ServerName` in the `TlsConfig` and the handshaking.

I have tested the changes with the existing tests and the following script, that uses a running Tor instance as a proxy and connect to the Cloudflare onion address.

<details>
<summary>test.go</summary>

```go
package main

import (
	"crypto/tls"
	"fmt"
	"github.com/miekg/dns"
	"golang.org/x/net/proxy"
	"log"
	"net"
	"net/url"
)

func main() {
	var server = "dns4torpnlfs2ifuz2s2yf3fc7rdmsbhm6rw75euj35pac6ap25zgqad.onion:853"
	var proxyDialer dns.Dialer
	proxyUrl, err := url.Parse("socks5h://localhost:9050")
	if err != nil {
		log.Fatalf("invalid proxy url: %s\n", err)
	}
	proxyDialer, err = proxy.FromURL(proxyUrl, &net.Dialer{})
	if err != nil {
		log.Fatalf("invalid proxy: %s\n", err)
	}
	client := new(dns.Client)
	client.Dialer = proxyDialer
	client.TLSConfig = &tls.Config{
		ServerName: "one.one.one.one", // because we use the .onion address
	}
	client.Net = "tcp-tls"
	m := new(dns.Msg)
	m.SetQuestion(dns.Fqdn("example.com"), dns.TypeA)
	m.RecursionDesired = true
	r, _, err := client.Exchange(m, server)
	if err != nil {
		log.Fatalf("*** error: %s\n", err.Error())
	}
	if r.Rcode != dns.RcodeSuccess {
		log.Fatalf(" *** invalid answer: %s$n", dns.RcodeToString[r.Rcode])
	}
	// Stuff must be in the answer section
	for _, a := range r.Answer {
		fmt.Printf("%v\n", a)
	}
}
```

</details>

