### PR TITLE
Fix copy() in SVCBIPv4Hint and SVCBIPv6Hint

### DIFF
--- a/svcb.go
+++ b/svcb.go
@@ -511,9 +511,9 @@ func (s *SVCBIPv4Hint) parse(b string) error {
 }
 
 func (s *SVCBIPv4Hint) copy() SVCBKeyValue {
-	hint := []net.IP(nil)
-	for _, ip := range s.Hint {
-		hint = append(hint, copyIP(ip))
+	hint := make([]net.IP, len(s.Hint))
+	for i, ip := range s.Hint {
+		hint[i] = copyIP(ip)
 	}
 
 	return &SVCBIPv4Hint{
@@ -634,9 +634,9 @@ func (s *SVCBIPv6Hint) parse(b string) error {
 }
 
 func (s *SVCBIPv6Hint) copy() SVCBKeyValue {
-	hint := []net.IP(nil)
-	for _, ip := range s.Hint {
-		hint = append(hint, copyIP(ip))
+	hint := make([]net.IP, len(s.Hint))
+	for i, ip := range s.Hint {
+		hint[i] = copyIP(ip)
 	}
 
 	return &SVCBIPv6Hint{

--- a/svcb.go
+++ b/svcb.go
@@ -511,8 +511,13 @@ func (s *SVCBIPv4Hint) parse(b string) error {
 }
 
 func (s *SVCBIPv4Hint) copy() SVCBKeyValue {
+	hint := []net.IP(nil)
+	for _, ip := range s.Hint {
+		hint = append(hint, copyIP(ip))
+	}
+
 	return &SVCBIPv4Hint{
-		append([]net.IP(nil), s.Hint...),
+		Hint: hint,
 	}
 }
 
@@ -629,8 +634,13 @@ func (s *SVCBIPv6Hint) parse(b string) error {
 }
 
 func (s *SVCBIPv6Hint) copy() SVCBKeyValue {
+	hint := []net.IP(nil)
+	for _, ip := range s.Hint {
+		hint = append(hint, copyIP(ip))
+	}
+
 	return &SVCBIPv6Hint{
-		append([]net.IP(nil), s.Hint...),
+		Hint: hint,
 	}
 }
 


### PR DESCRIPTION
The problem with the current implementation is that it is not a real deep copy,
it points to the same base arrays behind the slices. This was causing some
issues in real-life application.