### PR TITLE
Add MDNS class helper functions to RR_Header and Question

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -75,6 +75,24 @@ type RR_Header struct {
 // Header returns itself. This is here to make RR_Header implements the RR interface.
 func (h *RR_Header) Header() *RR_Header { return h }
 
+// MDNSClass will return an unpacked record class as defined in RFC6762. The
+// lower 15 bits of the Class field is returned along with if the cache-flush
+// bit has been set or not.
+func (h *RR_Header) MDNSClass() (uint16, bool) {
+	return h.Class ^ 1<<15, (h.Class & 1 << 15) != 0
+}
+
+// SetMDNSClass will pack a query class and a cache-flush bit into the
+// Class field as defined in RFC6762.  The lower 15 bits of the class are
+// used to represent the class with the cache-flush bit packed into the
+// top bit.
+func (h *RR_Header) SetMDNSClass(class uint16, unicastResponse bool) {
+	if unicastResponse {
+		h.Class = class | 1<<15
+	}
+	h.Class = class ^ 1<<15
+}
+
 // Just to implement the RR interface.
 func (h *RR_Header) copy() RR { return nil }
 

--- a/types.go
+++ b/types.go
@@ -237,6 +237,24 @@ func (q *Question) len(off int, compression map[string]struct{}) int {
 	return l
 }
 
+// MDNSClass will return an unpacked query class as defined in RFC6762. The
+// lower 15 bits of the Qclass field is returned along with if the
+// unicast-response bit has been set or not.
+func (q *Question) MDNSClass() (uint16, bool) {
+	return q.Qclass ^ 1<<15, (q.Qclass & 1 << 15) != 0
+}
+
+// SetMDNSClass will pack a query class and a unicast-response bit into the
+// Qclass field as defined in RFC6762.  The lower 15 bits of the class are
+// used to represent the class with the unicast-reponse bit packed into the
+// top bit.
+func (q *Question) SetMDNSClass(class uint16, unicastResponse bool) {
+	if unicastResponse {
+		q.Qclass = class | 1<<15
+	}
+	q.Qclass = class ^ 1<<15
+}
+
 func (q *Question) String() (s string) {
 	// prefix with ; (as in dig)
 	s = ";" + sprintName(q.Name) + "\t"


### PR DESCRIPTION
Add two methods to be used with MDNS (RFC6762) messages for dealing
with extra data encoded in to the class field of queries and resource
record headers.

For queries the top bit of the class field is the unicast-response bit
indicating the querier can accept a unicast response to the queuery (in
addition or in lieu of a multicast response)

For resource records the top bit of the class field is for the
cache-flush bit that indicates the record is unique and should replace
any entries vs appending to the cache.

Fixes some of the discussed parts of #436 and #423