### PR TITLE
fix Msg.Used TTL must be zero

### DIFF
--- a/update.go
+++ b/update.go
@@ -32,8 +32,9 @@ func (u *Msg) Used(rr []RR) {
 		u.Answer = make([]RR, 0, len(rr))
 	}
 	for _, r := range rr {
-		r.Header().Class = u.Question[0].Qclass
-		r.Header().Ttl = 0
+		hdr := r.Header()
+		hdr.Class = u.Question[0].Qclass
+		hdr.Ttl = 0
 		u.Answer = append(u.Answer, r)
 	}
 }

--- a/update.go
+++ b/update.go
@@ -33,6 +33,7 @@ func (u *Msg) Used(rr []RR) {
 	}
 	for _, r := range rr {
 		r.Header().Class = u.Question[0].Qclass
+		r.Header().Ttl = 0
 		u.Answer = append(u.Answer, r)
 	}
 }

--- a/update_test.go
+++ b/update_test.go
@@ -122,7 +122,7 @@ func TestPreReqAndRemovals(t *testing.T) {
 name_used.	0	CLASS255	ANY	
 name_not_used.	0	NONE	ANY	
 rrset_used1.	0	CLASS255	A	
-rrset_used2.	3600	IN	A	127.0.0.1
+rrset_used2.	0	IN	A	127.0.0.1
 rrset_not_used.	0	NONE	A	
 
 ;; AUTHORITY SECTION:


### PR DESCRIPTION
Prerequisite Section RRset Exist Value Dependent TTL must be zero.

```
   2.4.2 - RRset Exists (Value Dependent)

   A set of RRs with a specified NAME and TYPE exists and has the same
   members with the same RDATAs as the RRset specified here in this
   section.  While RRset ordering is undefined and therefore not
   significant to this comparison, the sets be identical in their
   extent.

   For this prerequisite, a requestor adds to the section an entire
   RRset whose preexistence is required.  NAME and TYPE are that of the
   RRset being denoted.  CLASS is that of the zone.  TTL must be
   specified as zero (0) and is ignored when comparing RRsets for
   identity.
``