### PR TITLE
Add ReverseAddrIP function

### DIFF
--- a/dns_bench_test.go
+++ b/dns_bench_test.go
@@ -343,7 +343,7 @@ func BenchmarkIdGeneration(b *testing.B) {
 	}
 }
 
-func BenchmarkReverseAddr(b *testing.B) {
+func BenchmarkReverseAddrString(b *testing.B) {
 	b.Run("IP4", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			addr, err := ReverseAddr("192.0.2.1")
@@ -359,6 +359,64 @@ func BenchmarkReverseAddr(b *testing.B) {
 	b.Run("IP6", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			addr, err := ReverseAddr("2001:db8::68")
+			if err != nil {
+				b.Fatal(err)
+			}
+			if expect := "8.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."; addr != expect {
+				b.Fatalf("invalid reverse address, expected %q, got %q", expect, addr)
+			}
+		}
+	})
+}
+
+func BenchmarkReverseAddrIP(b *testing.B) {
+	b.Run("IP4", func(b *testing.B) {
+		ip := net.ParseIP("192.0.2.1")
+		for n := 0; n < b.N; n++ {
+			addr, err := ReverseAddr(ip)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if expect := "1.2.0.192.in-addr.arpa."; addr != expect {
+				b.Fatalf("invalid reverse address, expected %q, got %q", expect, addr)
+			}
+		}
+	})
+
+	b.Run("IP6", func(b *testing.B) {
+		ip := net.ParseIP("2001:db8::68")
+		for n := 0; n < b.N; n++ {
+			addr, err := ReverseAddr(ip)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if expect := "8.6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."; addr != expect {
+				b.Fatalf("invalid reverse address, expected %q, got %q", expect, addr)
+			}
+		}
+	})
+}
+
+func BenchmarkReverseAddrStringFromIP(b *testing.B) {
+	b.Run("IP4", func(b *testing.B) {
+		ip := net.ParseIP("192.0.2.1")
+		for n := 0; n < b.N; n++ {
+			str := ip.String()
+			addr, err := ReverseAddr(str)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if expect := "1.2.0.192.in-addr.arpa."; addr != expect {
+				b.Fatalf("invalid reverse address, expected %q, got %q", expect, addr)
+			}
+		}
+	})
+
+	b.Run("IP6", func(b *testing.B) {
+		ip := net.ParseIP("2001:db8::68")
+		for n := 0; n < b.N; n++ {
+			str := ip.String()
+			addr, err := ReverseAddr(str)
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
Hello Meik, thank you for a great project.

To avoid unnecessary conversions from `dns.A -> string -> dns.ReverseAddr(string)` I've implemented ReverseAddrIP function.

Here you can see the benchmark results:

```
go test -bench BenchmarkReverse -benchmem . -benchtime 10000000x
goos: linux
goarch: amd64
pkg: github.com/miekg/dns
cpu: AMD Ryzen 7 4800H with Radeon Graphics         
BenchmarkReverseAddr/IP4-16      	10000000	      180.3 ns/op	     40 B/op	      2 allocs/op
BenchmarkReverseAddr/IP6-16      	10000000	      234.4 ns/op	     96 B/op	      2 allocs/op
BenchmarkReverseAddrIP/IP4-16    	10000000	       96.96 ns/op	     24 B/op	      1 allocs/op
BenchmarkReverseAddrIP/IP6-16    	10000000	      142.1 ns/op	     80 B/op	      1 allocs/op
BenchmarkReverseAddrFromIP/IP4-16         	10000000	      222.3 ns/op	     56 B/op	      3 allocs/op
BenchmarkReverseAddrFromIP/IP6-16         	10000000	      342.1 ns/op	    112 B/op	      3 allocs/op
PASS
ok  	github.com/miekg/dns	15.107s
```