### PR TITLE
Export TsigProvider functions (Resolves #1296)

### DIFF
--- a/client.go
+++ b/client.go
@@ -260,7 +260,7 @@ func (co *Conn) ReadMsg() (*Msg, error) {
 	}
 	if t := m.IsTsig(); t != nil {
 		if co.TsigProvider != nil {
-			err = tsigVerifyProvider(p, co.TsigProvider, co.tsigRequestMAC, false)
+			err = TsigVerifyProvider(p, co.TsigProvider, co.tsigRequestMAC, false)
 		} else {
 			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 				return m, ErrSecret
@@ -346,7 +346,7 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 	if t := m.IsTsig(); t != nil {
 		mac := ""
 		if co.TsigProvider != nil {
-			out, mac, err = tsigGenerateProvider(m, co.TsigProvider, co.tsigRequestMAC, false)
+			out, mac, err = TsigGenerateProvider(m, co.TsigProvider, co.tsigRequestMAC, false)
 		} else {
 			if _, ok := co.TsigSecret[t.Hdr.Name]; !ok {
 				return ErrSecret

--- a/tsig.go
+++ b/tsig.go
@@ -139,19 +139,20 @@ type timerWireFmt struct {
 	Fudge      uint16
 }
 
-// TsigGenerate fills out the TSIG record attached to the message.
+// TsigGenerate calls TsigGenerateProvider with the default TsigProvider tsigHMACProvider.
+func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, string, error) {
+	return TsigGenerateProvider(m, tsigHMACProvider(secret), requestMAC, timersOnly)
+}
+
+// TsigGenerateProvider fills out the TSIG record attached to the message using the provided TsigProvider.
 // The message should contain
 // a "stub" TSIG RR with the algorithm, key name (owner name of the RR),
 // time fudge (defaults to 300 seconds) and the current time
 // The TSIG MAC is saved in that Tsig RR.
-// When TsigGenerate is called for the first time requestMAC is set to the empty string and
+// When TsigGenerateProvider is called for the first time requestMAC is set to the empty string and
 // timersOnly is false.
 // If something goes wrong an error is returned, otherwise it is nil.
-func TsigGenerate(m *Msg, secret, requestMAC string, timersOnly bool) ([]byte, string, error) {
-	return tsigGenerateProvider(m, tsigHMACProvider(secret), requestMAC, timersOnly)
-}
-
-func tsigGenerateProvider(m *Msg, provider TsigProvider, requestMAC string, timersOnly bool) ([]byte, string, error) {
+func TsigGenerateProvider(m *Msg, provider TsigProvider, requestMAC string, timersOnly bool) ([]byte, string, error) {
 	if m.IsTsig() == nil {
 		panic("dns: TSIG not last RR in additional")
 	}
@@ -189,14 +190,15 @@ func tsigGenerateProvider(m *Msg, provider TsigProvider, requestMAC string, time
 	return mbuf, t.MAC, nil
 }
 
-// TsigVerify verifies the TSIG on a message.
-// If the signature does not validate err contains the
-// error, otherwise it is nil.
+// TsigVerify calls TsigVerifyProvider with the default TsigProvider tsigHMACProvider.
 func TsigVerify(msg []byte, secret, requestMAC string, timersOnly bool) error {
 	return tsigVerify(msg, tsigHMACProvider(secret), requestMAC, timersOnly, uint64(time.Now().Unix()))
 }
 
-func tsigVerifyProvider(msg []byte, provider TsigProvider, requestMAC string, timersOnly bool) error {
+// TsigVerifyProvider verifies the TSIG on a message using the provided TsigProvider.
+// If the signature does not validate err contains the
+// error, otherwise it is nil.
+func TsigVerifyProvider(msg []byte, provider TsigProvider, requestMAC string, timersOnly bool) error {
 	return tsigVerify(msg, provider, requestMAC, timersOnly, uint64(time.Now().Unix()))
 }
 

--- a/tsig_test.go
+++ b/tsig_test.go
@@ -298,7 +298,7 @@ func TestTsigGenerateProvider(t *testing.T) {
 				Extra:    []RR{&tsig},
 			}
 
-			_, mac, err := tsigGenerateProvider(req, new(testProvider), "", false)
+			_, mac, err := TsigGenerateProvider(req, new(testProvider), "", false)
 			if err != table.err {
 				t.Fatalf("error doesn't match: expected '%s' but got '%s'", table.err, err)
 			}
@@ -341,7 +341,7 @@ func TestTsigVerifyProvider(t *testing.T) {
 			}
 
 			provider := &testProvider{true}
-			msgData, _, err := tsigGenerateProvider(req, provider, "", false)
+			msgData, _, err := TsigGenerateProvider(req, provider, "", false)
 			if err != nil {
 				t.Error(err)
 			}


### PR DESCRIPTION
Export `TsigProvider` functions to allow use when writing custom DNS server handlers.

Context in #1296
```
When you define a custom DNS handler there is no way to specify a custom TsigProvider.

TsigGenerate and TsigVerify pass hard-coded the default TsigProvider and the tsigGenerateProvider and tsigVerifyProvider are unexported.

The only place I saw that you can define the TsigProvider is in the DNS client which is unrelated to the DNS handler for receiving traffic.
```