### PR TITLE
Record type APL: adjust error handling and tests

### DIFF
--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -781,6 +781,8 @@ func unpackDataAplPrefix(msg []byte, off int) (APLPrefix, int, error) {
 	if off+afdlen > len(msg) {
 		return APLPrefix{}, len(msg), &Error{err: "overflow unpacking APL address"}
 	}
+
+	// Address MUST NOT contain trailing zero bytes per RFC3123 Sections 4.1 and 4.2.
 	off += copy(ip, msg[off:off+afdlen])
 	if afdlen > 0 {
 		last := ip[afdlen-1]
@@ -791,10 +793,6 @@ func unpackDataAplPrefix(msg []byte, off int) (APLPrefix, int, error) {
 	ipnet := net.IPNet{
 		IP:   ip,
 		Mask: net.CIDRMask(int(prefix), 8*len(ip)),
-	}
-	network := ipnet.IP.Mask(ipnet.Mask)
-	if !network.Equal(ipnet.IP) {
-		return APLPrefix{}, len(msg), &Error{err: "invalid APL address length"}
 	}
 
 	return APLPrefix{


### PR DESCRIPTION
## Summary
This PR:
- Removes an error when processing APL record types where the address is not aligned with the prefix (netmask).
- Enhances testing so as to test for a specific `Error` with the goal of making it easier to understand which conditions were being tested.

## Reasoning

When processing an `APL` record where the address is not on the prefix (netmask) boundary the current code will emit the error `dns: invalid APL address length` and cease processing further `dns.RR` records.

https://github.com/miekg/dns/blob/1630ffe2ca114df2491e320f7aa488abb209b271/msg_helpers.go#L795-L798

For example, if the response includes `192.155.84.18/24` this would be an error because the correct boundary for a /24 CIDR would be `192.155.84.0` instead of `.18`.

In my opinion this response should not be treated as a fatal processing error because:
- Per [RFC3120](https://datatracker.ietf.org/doc/html/rfc3123) there is no requirement for the address to be on the netmask boundary
- This is not a packet decoding issue, this data accurately reflects what was sent on the wire
- This is user controlled data and users make mistakes. It would be similar to an incorrectly formatted SPF record that is valid on the wire but won't perform as expected.
- The failure here prevents other records in an `ANY` response from being processed.

While testing the changes I noticed that, in addition to the test I expected to fail, another test was now failing:

https://github.com/miekg/dns/blob/1630ffe2ca114df2491e320f7aa488abb209b271/msg_helpers_test.go#L408-L410

I wasn't sure what condition that test was trying to check for so I reworked the tests to check for specific `Error`s.  This enabled me to ensured that the major failure paths were being tested and added a bit of clarity that some of the test names were missing.


## Testing / Example output

For all testing below I've used the `q` example from the `master` branch of [github.com/miekg/exdns](github.com/miekg/exdns).  Testing was performed with `go version go1.17 darwin/amd64` on macOS Catalina. The problem was original noticed while running on Ubuntu 20.04 LTS.

### Example output - Current Code

`APL` record lookup
```bash
$ go run q.go --fallback @8.8.8.8  APL  IN ip4.loopy.limon.baker.org
;; dns: invalid APL address length
```

`ANY` record lookup
```bash
$ go run q.go --fallback @8.8.8.8  ANY  IN ip4.loopy.limon.baker.org
;; dns: invalid APL address length
``` 

### Example output - PR Code

`APL` record lookup
```bash
$ go run q.go --fallback @8.8.8.8  APL  IN ip4.loopy.limon.baker.org
;; opcode: QUERY, status: NOERROR, id: 33976
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;ip4.loopy.limon.baker.org.	IN	 APL

;; ANSWER SECTION:
ip4.loopy.limon.baker.org.	1795	IN	APL	1:192.155.84.18/24

;; query time: 45093 µs, server: 8.8.8.8:53(udp), size: 87 bytes
```

 `ANY` record lookup
```bash
$ go run q.go --fallback @8.8.8.8  ANY  IN ip4.loopy.limon.baker.org
;; opcode: QUERY, status: NOERROR, id: 11923
;; flags: qr rd ra; QUERY: 1, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;ip4.loopy.limon.baker.org.	IN	 ANY

;; ANSWER SECTION:
ip4.loopy.limon.baker.org.	1800	IN	APL	1:192.155.84.18/24
ip4.loopy.limon.baker.org.	1800	IN	A	192.155.84.18
ip4.loopy.limon.baker.org.	1800	IN	SSHFP	1 1 629D772D9EA6EB31B9E3C96D3982E02E6D5986E2
ip4.loopy.limon.baker.org.	1800	IN	SSHFP	1 2 70CC2CFC17EBA6AF8039A7246E091E727FF5DE109C3ACD8D61754048EA704A34
ip4.loopy.limon.baker.org.	1800	IN	SSHFP	2 1 E0F51B2F5D7C9D2F8C9FF9556088111C0A8908EB
ip4.loopy.limon.baker.org.	1800	IN	SSHFP	2 2 37BABEDDE292754BA3174472DD7DF91B8C047FFE98B5D3247792DD7F9B1CDF3C
ip4.loopy.limon.baker.org.	1800	IN	PTR	loopy.limon.baker.org.

;; query time: 167087 µs, server: 8.8.8.8:53(udp), size: 448 bytes

```

### Example output - `dig`

`APL` record lookup
```bash
$ dig @8.8.8.8 APL ip4.loopy.limon.baker.org

; <<>> DiG 9.10.6 <<>> @8.8.8.8 APL ip4.loopy.limon.baker.org
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24973
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;ip4.loopy.limon.baker.org.	IN	APL

;; ANSWER SECTION:
ip4.loopy.limon.baker.org. 1800	IN	APL	1:192.155.84.18/24

;; Query time: 1120 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Tue Sep 28 08:50:52 CDT 2021
;; MSG SIZE  rcvd: 74
```

`ANY` record lookup
```bash
$ dig @8.8.8.8 ANY ip4.loopy.limon.baker.org

; <<>> DiG 9.10.6 <<>> @8.8.8.8 ANY ip4.loopy.limon.baker.org
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 34224
;; flags: qr rd ra; QUERY: 1, ANSWER: 7, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;ip4.loopy.limon.baker.org.	IN	ANY

;; ANSWER SECTION:
ip4.loopy.limon.baker.org. 1800	IN	APL	1:192.155.84.18/24
ip4.loopy.limon.baker.org. 1800	IN	A	192.155.84.18
ip4.loopy.limon.baker.org. 1800	IN	SSHFP	2 1 E0F51B2F5D7C9D2F8C9FF9556088111C0A8908EB
ip4.loopy.limon.baker.org. 1800	IN	SSHFP	1 2 70CC2CFC17EBA6AF8039A7246E091E727FF5DE109C3ACD8D61754048 EA704A34
ip4.loopy.limon.baker.org. 1800	IN	SSHFP	2 2 37BABEDDE292754BA3174472DD7DF91B8C047FFE98B5D3247792DD7F 9B1CDF3C
ip4.loopy.limon.baker.org. 1800	IN	SSHFP	1 1 629D772D9EA6EB31B9E3C96D3982E02E6D5986E2
ip4.loopy.limon.baker.org. 1800	IN	PTR	loopy.limon.baker.org.

;; Query time: 80 msec
;; SERVER: 8.8.8.8#53(8.8.8.8)
;; WHEN: Tue Sep 28 08:49:55 CDT 2021
;; MSG SIZE  rcvd: 264
``` 
