### PR TITLE
Add basic support for contexts in handlers

### DIFF
--- a/serve_mux.go
+++ b/serve_mux.go
@@ -1,34 +1,34 @@
 package dns
 
 import (
+	"context"
 	"sync"
 )
 
-// ServeMux is an DNS request multiplexer. It matches the zone name of
-// each incoming request against a list of registered patterns add calls
-// the handler for the pattern that most closely matches the zone name.
+// handlerContextFromHandler is used internally to wrap a Handler into a
+// HandlerContext, to aid in maintaining backwards compatibility.
+func handlerContextFromHandler(h Handler) HandlerContext {
+	return HandlerFuncContext(func(_ context.Context, w ResponseWriter, r *Msg) {
+		h.ServeDNS(w, r)
+	})
+}
+
+// ServeMuxContext is a context-aware version of ServeMux.
 //
-// ServeMux is DNSSEC aware, meaning that queries for the DS record are
-// redirected to the parent zone (if that is also registered), otherwise
-// the child gets the query.
+// ServeMuxContext is safe for concurrent access from multiple goroutines.
 //
-// ServeMux is also safe for concurrent access from multiple goroutines.
-//
-// The zero ServeMux is empty and ready for use.
-type ServeMux struct {
-	z map[string]Handler
+// The zero ServeMuxContext is empty and ready for use.
+type ServeMuxContext struct {
+	z map[string]HandlerContext
 	m sync.RWMutex
 }
 
-// NewServeMux allocates and returns a new ServeMux.
-func NewServeMux() *ServeMux {
-	return new(ServeMux)
+// NewServeMuxContext allocates and returns a new NewServeMuxContext.
+func NewServeMuxContext() *ServeMuxContext {
+	return new(ServeMuxContext)
 }
 
-// DefaultServeMux is the default ServeMux used by Serve.
-var DefaultServeMux = NewServeMux()
-
-func (mux *ServeMux) match(q string, t uint16) Handler {
+func (mux *ServeMuxContext) match(q string, t uint16) HandlerContext {
 	mux.m.RLock()
 	defer mux.m.RUnlock()
 	if mux.z == nil {
@@ -37,7 +37,7 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 
 	q = CanonicalName(q)
 
-	var handler Handler
+	var handler HandlerContext
 	for off, end := 0, false; !end; off, end = NextLabel(q, off) {
 		if h, ok := mux.z[q[off:]]; ok {
 			if t != TypeDS {
@@ -57,31 +57,88 @@ func (mux *ServeMux) match(q string, t uint16) Handler {
 }
 
 // Handle adds a handler to the ServeMux for pattern.
-func (mux *ServeMux) Handle(pattern string, handler Handler) {
+func (mux *ServeMuxContext) Handle(pattern string, handler HandlerContext) {
 	if pattern == "" {
 		panic("dns: invalid pattern " + pattern)
 	}
 	mux.m.Lock()
 	if mux.z == nil {
-		mux.z = make(map[string]Handler)
+		mux.z = make(map[string]HandlerContext)
 	}
 	mux.z[CanonicalName(pattern)] = handler
 	mux.m.Unlock()
 }
 
-// HandleFunc adds a handler function to the ServeMux for pattern.
-func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
-	mux.Handle(pattern, HandlerFunc(handler))
+// HandleFunc adds a handler function to the ServeMuxContext for pattern.
+func (mux *ServeMuxContext) HandleFunc(pattern string, handler func(context.Context, ResponseWriter, *Msg)) {
+	mux.Handle(pattern, HandlerFuncContext(handler))
 }
 
-// HandleRemove deregisters the handler specific for pattern from the ServeMux.
-func (mux *ServeMux) HandleRemove(pattern string) {
+// HandleRemove deregisters the handler specific for pattern from the ServeMuxContext.
+func (mux *ServeMuxContext) HandleRemove(pattern string) {
 	if pattern == "" {
 		panic("dns: invalid pattern " + pattern)
 	}
 	mux.m.Lock()
 	delete(mux.z, CanonicalName(pattern))
 	mux.m.Unlock()
+}
+
+// ServeDNS is the same as in ServeMux, but also passes on the context
+// when calling handlers.
+func (mux *ServeMuxContext) ServeDNS(ctx context.Context, w ResponseWriter, req *Msg) {
+	var h HandlerContext
+	if len(req.Question) >= 1 { // allow more than one question
+		h = mux.match(req.Question[0].Name, req.Question[0].Qtype)
+	}
+
+	if h != nil {
+		h.ServeDNS(ctx, w, req)
+	} else {
+		handleRefused(w, req)
+	}
+}
+
+// ServeMux is an DNS request multiplexer. It matches the zone name of
+// each incoming request against a list of registered patterns add calls
+// the handler for the pattern that most closely matches the zone name.
+//
+// ServeMux is DNSSEC aware, meaning that queries for the DS record are
+// redirected to the parent zone (if that is also registered), otherwise
+// the child gets the query.
+//
+// ServeMux is also safe for concurrent access from multiple goroutines.
+//
+// The zero ServeMux is empty and ready for use.
+type ServeMux struct {
+	m ServeMuxContext
+}
+
+// NewServeMux allocates and returns a new ServeMux.
+func NewServeMux() *ServeMux {
+	return new(ServeMux)
+}
+
+// DefaultServeMux is the default ServeMux used by Serve.
+var DefaultServeMux = NewServeMux()
+
+// Handle adds a handler to the ServeMux for pattern.
+func (mux *ServeMux) Handle(pattern string, handler Handler) {
+	mux.m.Handle(pattern, HandlerFuncContext(func(_ context.Context, w ResponseWriter, req *Msg) {
+		handler.ServeDNS(w, req)
+	}))
+}
+
+// HandleFunc adds a handler function to the ServeMux for pattern.
+func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
+	mux.m.Handle(pattern, HandlerFuncContext(func(_ context.Context, w ResponseWriter, req *Msg) {
+		handler(w, req)
+	}))
+}
+
+// HandleRemove deregisters the handler specific for pattern from the ServeMux.
+func (mux *ServeMux) HandleRemove(pattern string) {
+	mux.m.HandleRemove(pattern)
 }
 
 // ServeDNS dispatches the request to the handler whose pattern most
@@ -94,16 +151,9 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 // If no handler is found, or there is no question, a standard REFUSED
 // message is returned
 func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
-	var h Handler
-	if len(req.Question) >= 1 { // allow more than one question
-		h = mux.match(req.Question[0].Name, req.Question[0].Qtype)
-	}
-
-	if h != nil {
-		h.ServeDNS(w, req)
-	} else {
-		handleRefused(w, req)
-	}
+	// Note: context.Background() is a placeholder to satisfy the function interface.
+	// The value is never actually used.
+	mux.m.ServeDNS(context.Background(), w, req)
 }
 
 // Handle registers the handler with the given pattern

--- a/serve_mux_test.go
+++ b/serve_mux_test.go
@@ -1,11 +1,13 @@
 package dns
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestDotAsCatchAllWildcard(t *testing.T) {
-	mux := NewServeMux()
-	mux.Handle(".", HandlerFunc(HelloServer))
-	mux.Handle("example.com.", HandlerFunc(AnotherHelloServer))
+	mux := NewServeMuxContext()
+	mux.Handle(".", handlerContextFromHandler(HandlerFunc(HelloServer)))
+	mux.Handle("example.com.", handlerContextFromHandler(HandlerFunc(AnotherHelloServer)))
 
 	handler := mux.match("www.miek.nl.", TypeTXT)
 	if handler == nil {
@@ -29,8 +31,8 @@ func TestDotAsCatchAllWildcard(t *testing.T) {
 }
 
 func TestCaseFolding(t *testing.T) {
-	mux := NewServeMux()
-	mux.Handle("_udp.example.com.", HandlerFunc(HelloServer))
+	mux := NewServeMuxContext()
+	mux.Handle("_udp.example.com.", handlerContextFromHandler(HandlerFunc(HelloServer)))
 
 	handler := mux.match("_dns._udp.example.com.", TypeSRV)
 	if handler == nil {
@@ -44,8 +46,8 @@ func TestCaseFolding(t *testing.T) {
 }
 
 func TestRootServer(t *testing.T) {
-	mux := NewServeMux()
-	mux.Handle(".", HandlerFunc(HelloServer))
+	mux := NewServeMuxContext()
+	mux.Handle(".", handlerContextFromHandler(HandlerFunc(HelloServer)))
 
 	handler := mux.match(".", TypeNS)
 	if handler == nil {
@@ -54,8 +56,8 @@ func TestRootServer(t *testing.T) {
 }
 
 func BenchmarkMuxMatch(b *testing.B) {
-	mux := NewServeMux()
-	mux.Handle("_udp.example.com.", HandlerFunc(HelloServer))
+	mux := NewServeMuxContext()
+	mux.Handle("_udp.example.com.", handlerContextFromHandler(HandlerFunc(HelloServer)))
 
 	bench := func(q string) func(*testing.B) {
 		return func(b *testing.B) {


### PR DESCRIPTION
This change adds basic context-aware versions of ServeMux and the Handler types.

The request context pattern in Go is very useful when writing servers, since they can propagate metadata about the request, such as deadlines. I currently have code that implements a custom wrapper around `ResponseWriter` to inject and propagate request contexts through nested ServeMuxes. However this approach is somewhat ugly and I'd much rather see the upstream library have built-in support for contexts.

Please take a look to see if this code is a reasonable approach. Care has been taken to preserve backwards compatibility with existing code.

Alternatives considered:

- Add a `Context` getter to `*Msg` in the same fashion as in `*http.Request`. This doesn't seem like a good idea, since `*Msg` is useful independent of the server, and adding a context field to it seems like it's polluting the API.
- Add a `Context` getter to `ResponseWriter`. This doesn't seem to make much semantic sense (the context is associated with the request, not the response). It also can break compatibility with existing code that implement custom ResponseWriters (since adding a function to the interface would require the user to implement a new method).