### PR TITLE
add option to some rr for extend

### DIFF
--- a/types.go
+++ b/types.go
@@ -277,6 +277,7 @@ func (*NULL) parse(c *zlexer, origin string) *ParseError {
 type CNAME struct {
 	Hdr    RR_Header
 	Target string `dns:"cdomain-name"`
+	opt    interface{}
 }
 
 func (rr *CNAME) String() string { return rr.Hdr.String() + sprintName(rr.Target) }
@@ -714,6 +715,7 @@ func (rr *DNAME) String() string {
 type A struct {
 	Hdr RR_Header
 	A   net.IP `dns:"a"`
+	opt interface{}
 }
 
 func (rr *A) String() string {
@@ -727,6 +729,7 @@ func (rr *A) String() string {
 type AAAA struct {
 	Hdr  RR_Header
 	AAAA net.IP `dns:"aaaa"`
+	opt  interface{}
 }
 
 func (rr *AAAA) String() string {

--- a/ztypes.go
+++ b/ztypes.go
@@ -698,10 +698,10 @@ func (rr *ZONEMD) len(off int, compression map[string]struct{}) int {
 
 // copy() functions
 func (rr *A) copy() RR {
-	return &A{rr.Hdr, copyIP(rr.A)}
+	return &A{rr.Hdr, copyIP(rr.A), nil}
 }
 func (rr *AAAA) copy() RR {
-	return &AAAA{rr.Hdr, copyIP(rr.AAAA)}
+	return &AAAA{rr.Hdr, copyIP(rr.AAAA), nil}
 }
 func (rr *AFSDB) copy() RR {
 	return &AFSDB{rr.Hdr, rr.Subtype, rr.Hostname}
@@ -734,7 +734,7 @@ func (rr *CERT) copy() RR {
 	return &CERT{rr.Hdr, rr.Type, rr.KeyTag, rr.Algorithm, rr.Certificate}
 }
 func (rr *CNAME) copy() RR {
-	return &CNAME{rr.Hdr, rr.Target}
+	return &CNAME{rr.Hdr, rr.Target, nil}
 }
 func (rr *CSYNC) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))


### PR DESCRIPTION
Signed-off-by: xuweiwei <xuweiwei_yewu@cmss.chinamobile.com>

**Why is this pull request needed and what does it do?**
In many cases we have some requirement for intelligent resolve, such as by line and weight. So need to extend the original A, AAAA, CNAME records.
For example, it can filter some rrs by the _opt interface{}_ . Following code implement a demo that filter rrs by city name in _coredns_.
```
type RROption struct {
	City   string
	Weight int
}

func autoLineFilter(ctx context.Context, rrs []dns.RR) []dns.RR {
	for index, item := range rrs {
		if a, ok := item.(*dns.A); ok {
			if getCityName := metadata.ValueFunc(ctx, "geoip/city/name"); getCityName != nil {
				if cityName := getCityName(); len(cityName) > 0 {
					aRR := a.opt.(RROption)
					if aRR.City == cityName {
						rrs = rrs[index : index+1]
					} 
				} 
			} 
		}
	}
	return rrs
}
```
This _opt interface{}_ can also be extended to enable more interesting functionality by add additional information to it.
