### PR TITLE
Add RFC4034 domain comparison + NSEC Cover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 tags
 test.out
 a.out
+.*.swp

--- a/labels.go
+++ b/labels.go
@@ -61,20 +61,18 @@ func CompareDomainName(s1, s2 string) (n int) {
 	i2 := len(l2) - 2
 	// the second check can be done here: last/only label
 	// before we fall through into the for-loop below
-	if equal(s1[l1[j1]:], s2[l2[j2]:]) {
-		n++
-	} else {
+	if !equal(s1[l1[j1]:], s2[l2[j2]:]) {
 		return
 	}
+	n++
 	for {
 		if i1 < 0 || i2 < 0 {
 			break
 		}
-		if equal(s1[l1[i1]:l1[j1]], s2[l2[i2]:l2[j2]]) {
-			n++
-		} else {
+		if !equal(s1[l1[i1]:l1[j1]], s2[l2[i2]:l2[j2]]) {
 			break
 		}
+		n++
 		j1--
 		i1--
 		j2--
@@ -262,26 +260,11 @@ func labelCompare(a, b string) int {
 // equal compares a and b while ignoring case. It returns true when equal otherwise false.
 func equal(a, b string) bool {
 	// might be lifted into API function.
-	la := len(a)
-	lb := len(b)
-	if la != lb {
+	if len(a) != len(b) {
 		return false
 	}
 
-	for i := la - 1; i >= 0; i-- {
-		ai := a[i]
-		bi := b[i]
-		if ai >= 'A' && ai <= 'Z' {
-			ai |= 'a' - 'A'
-		}
-		if bi >= 'A' && bi <= 'Z' {
-			bi |= 'a' - 'A'
-		}
-		if ai != bi {
-			return false
-		}
-	}
-	return true
+	return labelCompare(a, b) == 0
 }
 
 func doDDD(b []byte) {

--- a/labels.go
+++ b/labels.go
@@ -188,11 +188,11 @@ func PrevLabel(s string, n int) (i int, start bool) {
 // returns an integer value similar to strcmp
 // (0 for equal values, -1 if s1 < s2, 1 if s1 > s2)
 func Compare(s1, s2 string) int {
-	s1b := []byte(s1)
-	s2b := []byte(s2)
+	s1b := doDDD([]byte(s1))
+	s2b := doDDD([]byte(s2))
 
-	doDDD(s1b)
-	doDDD(s2b)
+	s1 = string(s1b)
+	s2 = string(s2b)
 
 	s1lend := len(s1)
 	s2lend := len(s2)
@@ -267,7 +267,7 @@ func equal(a, b string) bool {
 	return labelCompare(a, b) == 0
 }
 
-func doDDD(b []byte) {
+func doDDD(b []byte) []byte {
 	lb := len(b)
 	for i := 0; i < lb; i++ {
 		if i+3 < lb && b[i] == '\\' && isDigit(b[i+1]) && isDigit(b[i+2]) && isDigit(b[i+3]) {
@@ -278,4 +278,5 @@ func doDDD(b []byte) {
 			lb -= 3
 		}
 	}
+	return b[:lb]
 }

--- a/labels.go
+++ b/labels.go
@@ -186,6 +186,79 @@ func PrevLabel(s string, n int) (i int, start bool) {
 	return 0, n > 1
 }
 
+// Compare compares domains according to the canonical ordering specified in RFC4034
+// returns an integer value similar to strcmp
+// (0 for equal values, -1 if s1 < s2, 1 if s1 > s2)
+func Compare(s1, s2 string) int {
+	s1b := []byte(s1)
+	s2b := []byte(s2)
+
+	doDDD(s1b)
+	doDDD(s2b)
+
+	s1lend := len(s1)
+	s2lend := len(s2)
+
+	for i := 0; ; i++ {
+		s1lstart, end1 := PrevLabel(s1, i)
+		s2lstart, end2 := PrevLabel(s2, i)
+
+		if end1 && end2 {
+			return 0
+		}
+
+		s1l := string(s1b[s1lstart:s1lend])
+		s2l := string(s2b[s2lstart:s2lend])
+
+		if cmp := labelCompare(s1l, s2l); cmp != 0 {
+			return cmp
+		}
+
+		s1lend = s1lstart - 1
+		s2lend = s2lstart - 1
+		if s1lend == -1 {
+			s1lend = 0
+		}
+		if s2lend == -1 {
+			s2lend = 0
+		}
+	}
+}
+
+// essentially strcasecmp
+// (0 for equal values, -1 if s1 < s2, 1 if s1 > s2)
+func labelCompare(a, b string) int {
+	la := len(a)
+	lb := len(b)
+	minLen := la
+	if lb < la {
+		minLen = lb
+	}
+	for i := 0; i < minLen; i++ {
+		ai := a[i]
+		bi := b[i]
+		if ai >= 'A' && ai <= 'Z' {
+			ai |= 'a' - 'A'
+		}
+		if bi >= 'A' && bi <= 'Z' {
+			bi |= 'a' - 'A'
+		}
+		if ai != bi {
+			if ai > bi {
+				return 1
+			}
+			return -1
+		}
+	}
+
+	if la > lb {
+		return 1
+	} else if la < lb {
+		return -1
+	}
+	return 0
+}
+
 // equal compares a and b while ignoring case. It returns true when equal otherwise false.
 func equal(a, b string) bool {
 	// might be lifted into API function.
@@ -209,4 +282,17 @@ func equal(a, b string) bool {
 		}
 	}
 	return true
+}
+
+func doDDD(b []byte) {
+	lb := len(b)
+	for i := 0; i < lb; i++ {
+		if i+3 < lb && b[i] == '\\' && isDigit(b[i+1]) && isDigit(b[i+2]) && isDigit(b[i+3]) {
+			b[i] = dddToByte(b[i+1 : i+4])
+			for j := i + 1; j < lb-3; j++ {
+				b[j] = b[j+3]
+			}
+			lb -= 3
+		}
+	}
 }

--- a/labels_test.go
+++ b/labels_test.go
@@ -335,6 +335,13 @@ func BenchmarkPrevLabelMixed(b *testing.B) {
 	}
 }
 
+func BenchmarkCompare(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		Compare("\\097.", "A.")
+	}
+}
+
 func TestCompare(t *testing.T) {
 	domains := []string{ // based on an exanple from RFC 4034
 		"example.",
@@ -369,5 +376,9 @@ func TestCompare(t *testing.T) {
 				t.Fatalf("next comparison failure between %s and %s, %d and %d", domain, next_domain, Compare(domain, next_domain), Compare(next_domain, domain))
 			}
 		}
+	}
+
+	if Compare("\\097.", "A.") != 0 {
+		t.Fatal("failure to normalize DDD escape sequence")
 	}
 }

--- a/labels_test.go
+++ b/labels_test.go
@@ -334,3 +334,40 @@ func BenchmarkPrevLabelMixed(b *testing.B) {
 		PrevLabel(`www\\\.example.com`, 10)
 	}
 }
+
+func TestCompare(t *testing.T) {
+	domains := []string{ // based on an exanple from RFC 4034
+		"example.",
+		"a.example.",
+		"yljkjljk.a.example.",
+		"Z.a.example.",
+		"zABC.a.EXAMPLE.",
+		"a-.example.",
+		"z.example.",
+		"\001.z.example.",
+		"*.z.example.",
+		"\200.z.example.",
+	}
+
+	len_domains := len(domains)
+
+	for i, domain := range domains {
+		if i != 0 {
+			prev_domain := domains[i-1]
+			if !(Compare(prev_domain, domain) == -1 && Compare(domain, prev_domain) == 1) {
+				t.Fatalf("prev comparison failure between %s and %s", prev_domain, domain)
+			}
+		}
+
+		if Compare(domain, domain) != 0 {
+			t.Fatalf("self comparison failure for %s", domain)
+		}
+
+		if i != len_domains-1 {
+			next_domain := domains[i+1]
+			if !(Compare(domain, next_domain) == -1 && Compare(next_domain, domain) == 1) {
+				t.Fatalf("next comparison failure between %s and %s, %d and %d", domain, next_domain, Compare(domain, next_domain), Compare(next_domain, domain))
+			}
+		}
+	}
+}

--- a/nsecx.go
+++ b/nsecx.go
@@ -93,3 +93,8 @@ func (rr *NSEC3) Match(name string) bool {
 	}
 	return false
 }
+
+// Match returns true if the given name is covered by the NSEC record
+func (rr *NSEC) Cover(name string) bool {
+	return Compare(rr.Hdr.Name, name) <= 0 && Compare(name, rr.NextDomain) == -1
+}

--- a/nsecx_test.go
+++ b/nsecx_test.go
@@ -168,3 +168,23 @@ func BenchmarkHashName(b *testing.B) {
 		})
 	}
 }
+
+func TestNsecCover(t *testing.T) {
+	nsec := testRR("aaa.ee.	3600	IN	NSEC	aac.ee. NS RRSIG NSEC").(*NSEC)
+
+	if !nsec.Cover("aaaa.ee.") {
+		t.Fatal("nsec cover not covering in-range name")
+	}
+
+	if !nsec.Cover("aaa.ee.") {
+		t.Fatal("nsec cover not covering start of range")
+	}
+
+	if nsec.Cover("aac.ee.") {
+		t.Fatal("nsec cover range end failure")
+	}
+
+	if nsec.Cover("aad.ee.") {
+		t.Fatal("nsec cover covering out-of-range name")
+	}
+}


### PR DESCRIPTION
I noticed that this library has a good `Cover()` method for NSEC3 RRs, but not for NSEC. This PR adds a similar `Cover()` method for NSEC, plus a `DomainCompare` function for comparing domain names as defined by RFC4034's canonical ordering.

Feedback is welcome.