### PR TITLE
Do not sign BADKEY and BADSIG TSIG error responses

### DIFF
--- a/tsig.go
+++ b/tsig.go
@@ -162,20 +162,31 @@ func tsigGenerateProvider(m *Msg, provider TsigProvider, requestMAC string, time
 	if err != nil {
 		return nil, "", err
 	}
-	buf, err := tsigBuffer(mbuf, rr, requestMAC, timersOnly)
-	if err != nil {
-		return nil, "", err
-	}
 
 	t := new(TSIG)
-	// Copy all TSIG fields except MAC and its size, which are filled using the computed digest.
-	*t = *rr
-	mac, err := provider.Generate(buf, rr)
-	if err != nil {
-		return nil, "", err
+
+	if rr.Error == RcodeSuccess || rr.Error == RcodeBadTime {
+		// Only compute response MAC for non-errors and bad time errors (RFC 8945 5.3.2)
+		buf, err := tsigBuffer(mbuf, rr, requestMAC, timersOnly)
+		if err != nil {
+			return nil, "", err
+		}
+		// Copy all TSIG fields except MAC and its size, which are filled using the computed digest.
+		*t = *rr
+		mac, err := provider.Generate(buf, rr)
+		if err != nil {
+			return nil, "", err
+		}
+		t.TimeSigned = rr.TimeSigned
+		t.MAC = hex.EncodeToString(mac)
+		t.MACSize = uint16(len(t.MAC) / 2) // Size is half!
+	} else {
+		// Copy all TSIG fields except MAC, its size and time signed, since we aren't signing.
+		*t = *rr
+		t.TimeSigned = 0
+		t.MAC = ""
+		t.MACSize = 0
 	}
-	t.MAC = hex.EncodeToString(mac)
-	t.MACSize = uint16(len(t.MAC) / 2) // Size is half!
 
 	tbuf := make([]byte, Len(t))
 	off, err := PackRR(t, tbuf, 0, nil, false)

--- a/tsig.go
+++ b/tsig.go
@@ -175,8 +175,8 @@ func tsigGenerateProvider(m *Msg, provider TsigProvider, requestMAC string, time
 	t.MAC = ""
 	t.MACSize = 0
 
-	if rr.Error == RcodeSuccess || rr.Error == RcodeBadTime {
-		// Only sign TSIGs for non-errors and bad time errors (RFC 8945 5.3.2)
+	// Sign unless there is a key or MAC validation error (RFC 8945 5.3.2)
+	if rr.Error != RcodeBadKey && rr.Error != RcodeBadSig {
 		mac, err := provider.Generate(buf, rr)
 		if err != nil {
 			return nil, "", err


### PR DESCRIPTION
Per RFC 8945 5.3.2, responses with BADKEY and BADSIG errors must not be signed.

> When a server detects an error relating to the key or MAC in the
   incoming request, the server SHOULD send back an unsigned error
   message (MAC Size == 0 and empty MAC).  It MUST NOT send back a
   signed error message.

https://datatracker.ietf.org/doc/html/rfc8945#section-5.3.2

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>