### PR TITLE
Add https://github.com/markdingo/autoreverse into list of README.md users

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://www.misaka.io/services/dns
 * https://ping.sx/dig
 * https://fleetdeck.io/
+* https://github.com/markdingo/autoreverse
 
 
 Send pull request if you want to be listed here.


### PR DESCRIPTION
As requested on the README.md page. I've created a pull request to add a new application into the user mix.

It's not clear whether there is any order to this list, so I just added it at the end. Obviously that can be changed as needed.