### PR TITLE
Only treat a *net.UnixConn of unixgram as a packet conn

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,11 @@ const (
 	tcpIdleTimeout time.Duration = 8 * time.Second
 )
 
+func isPacketConn(c net.Conn) bool {
+	_, ok := c.(net.PacketConn)
+	return ok
+}
+
 // A Conn represents a connection to a DNS server.
 type Conn struct {
 	net.Conn                         // a net.Conn holding the connection
@@ -221,7 +226,7 @@ func (c *Client) exchangeContext(ctx context.Context, m *Msg, co *Conn) (r *Msg,
 		return nil, 0, err
 	}
 
-	if _, ok := co.Conn.(net.PacketConn); ok {
+	if isPacketConn(co.Conn) {
 		for {
 			r, err = co.ReadMsg()
 			// Ignore replies with mismatched IDs because they might be
@@ -282,7 +287,7 @@ func (co *Conn) ReadMsgHeader(hdr *Header) ([]byte, error) {
 		err error
 	)
 
-	if _, ok := co.Conn.(net.PacketConn); ok {
+	if isPacketConn(co.Conn) {
 		if co.UDPSize > MinMsgSize {
 			p = make([]byte, co.UDPSize)
 		} else {
@@ -322,7 +327,7 @@ func (co *Conn) Read(p []byte) (n int, err error) {
 		return 0, ErrConnEmpty
 	}
 
-	if _, ok := co.Conn.(net.PacketConn); ok {
+	if isPacketConn(co.Conn) {
 		// UDP connection
 		return co.Conn.Read(p)
 	}
@@ -371,7 +376,7 @@ func (co *Conn) Write(p []byte) (int, error) {
 		return 0, &Error{err: "message too large"}
 	}
 
-	if _, ok := co.Conn.(net.PacketConn); ok {
+	if isPacketConn(co.Conn) {
 		return co.Conn.Write(p)
 	}
 

--- a/client.go
+++ b/client.go
@@ -19,6 +19,10 @@ const (
 )
 
 func isPacketConn(c net.Conn) bool {
+	if uc, ok := c.(*net.UnixConn); ok {
+		return uc.LocalAddr().Network() == "unixgram"
+	}
+
 	_, ok := c.(net.PacketConn)
 	return ok
 }

--- a/client.go
+++ b/client.go
@@ -19,12 +19,15 @@ const (
 )
 
 func isPacketConn(c net.Conn) bool {
-	if uc, ok := c.(*net.UnixConn); ok {
-		return uc.LocalAddr().Network() == "unixgram"
+	if _, ok := c.(net.PacketConn); !ok {
+		return false
 	}
 
-	_, ok := c.(net.PacketConn)
-	return ok
+	if ua, ok := c.LocalAddr().(*net.UnixAddr); ok {
+		return ua.Net == "unixgram"
+	}
+
+	return true
 }
 
 // A Conn represents a connection to a DNS server.

--- a/client_test.go
+++ b/client_test.go
@@ -6,11 +6,74 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestIsPacketConn(t *testing.T) {
+	// UDP
+	s, addrstr, _, err := RunLocalUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+	c, err := net.Dial("udp", addrstr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer c.Close()
+	if !isPacketConn(c) {
+		t.Fatal("UDP connection should be a packet conn")
+	}
+
+	// TCP
+	s, addrstr, _, err = RunLocalTCPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+	c, err = net.Dial("tcp", addrstr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer c.Close()
+	if isPacketConn(c) {
+		t.Fatal("TCP connection should not be a packet conn")
+	}
+
+	// Unix datagram
+	s, addrstr, _, err = RunLocalUnixGramServer(filepath.Join(t.TempDir(), "unixgram.sock"))
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+	c, err = net.Dial("unixgram", addrstr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer c.Close()
+	if !isPacketConn(c) {
+		t.Fatal("Unix datagram connection should be a packet conn")
+	}
+
+	// Unix stream
+	s, addrstr, _, err = RunLocalUnixServer(filepath.Join(t.TempDir(), "unixstream.sock"))
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer s.Shutdown()
+	c, err = net.Dial("unix", addrstr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer c.Close()
+	if isPacketConn(c) {
+		t.Fatal("Unix stream connection should not be a packet conn")
+	}
+}
 
 func TestDialUDP(t *testing.T) {
 	HandleFunc("miek.nl.", HelloServer)

--- a/client_test.go
+++ b/client_test.go
@@ -28,6 +28,9 @@ func TestIsPacketConn(t *testing.T) {
 	if !isPacketConn(c) {
 		t.Fatal("UDP connection should be a packet conn")
 	}
+	if !isPacketConn(struct{ *net.UDPConn }{c.(*net.UDPConn)}) {
+		t.Fatal("UDP connection (wrapped type) should be a packet conn")
+	}
 
 	// TCP
 	s, addrstr, _, err = RunLocalTCPServer(":0")
@@ -42,6 +45,9 @@ func TestIsPacketConn(t *testing.T) {
 	defer c.Close()
 	if isPacketConn(c) {
 		t.Fatal("TCP connection should not be a packet conn")
+	}
+	if isPacketConn(struct{ *net.TCPConn }{c.(*net.TCPConn)}) {
+		t.Fatal("TCP connection (wrapped type) should not be a packet conn")
 	}
 
 	// Unix datagram
@@ -58,6 +64,9 @@ func TestIsPacketConn(t *testing.T) {
 	if !isPacketConn(c) {
 		t.Fatal("Unix datagram connection should be a packet conn")
 	}
+	if !isPacketConn(struct{ *net.UnixConn }{c.(*net.UnixConn)}) {
+		t.Fatal("Unix datagram connection (wrapped type) should be a packet conn")
+	}
 
 	// Unix stream
 	s, addrstr, _, err = RunLocalUnixServer(filepath.Join(t.TempDir(), "unixstream.sock"))
@@ -72,6 +81,9 @@ func TestIsPacketConn(t *testing.T) {
 	defer c.Close()
 	if isPacketConn(c) {
 		t.Fatal("Unix stream connection should not be a packet conn")
+	}
+	if isPacketConn(struct{ *net.UnixConn }{c.(*net.UnixConn)}) {
+		t.Fatal("Unix stream connection (wrapped type) should not be a packet conn")
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -26,10 +26,10 @@ func TestIsPacketConn(t *testing.T) {
 	}
 	defer c.Close()
 	if !isPacketConn(c) {
-		t.Fatal("UDP connection should be a packet conn")
+		t.Error("UDP connection should be a packet conn")
 	}
 	if !isPacketConn(struct{ *net.UDPConn }{c.(*net.UDPConn)}) {
-		t.Fatal("UDP connection (wrapped type) should be a packet conn")
+		t.Error("UDP connection (wrapped type) should be a packet conn")
 	}
 
 	// TCP
@@ -44,10 +44,10 @@ func TestIsPacketConn(t *testing.T) {
 	}
 	defer c.Close()
 	if isPacketConn(c) {
-		t.Fatal("TCP connection should not be a packet conn")
+		t.Error("TCP connection should not be a packet conn")
 	}
 	if isPacketConn(struct{ *net.TCPConn }{c.(*net.TCPConn)}) {
-		t.Fatal("TCP connection (wrapped type) should not be a packet conn")
+		t.Error("TCP connection (wrapped type) should not be a packet conn")
 	}
 
 	// Unix datagram
@@ -62,10 +62,10 @@ func TestIsPacketConn(t *testing.T) {
 	}
 	defer c.Close()
 	if !isPacketConn(c) {
-		t.Fatal("Unix datagram connection should be a packet conn")
+		t.Error("Unix datagram connection should be a packet conn")
 	}
 	if !isPacketConn(struct{ *net.UnixConn }{c.(*net.UnixConn)}) {
-		t.Fatal("Unix datagram connection (wrapped type) should be a packet conn")
+		t.Error("Unix datagram connection (wrapped type) should be a packet conn")
 	}
 
 	// Unix stream
@@ -80,10 +80,10 @@ func TestIsPacketConn(t *testing.T) {
 	}
 	defer c.Close()
 	if isPacketConn(c) {
-		t.Fatal("Unix stream connection should not be a packet conn")
+		t.Error("Unix stream connection should not be a packet conn")
 	}
 	if isPacketConn(struct{ *net.UnixConn }{c.(*net.UnixConn)}) {
-		t.Fatal("Unix stream connection (wrapped type) should not be a packet conn")
+		t.Error("Unix stream connection (wrapped type) should not be a packet conn")
 	}
 }
 


### PR DESCRIPTION
Go supports three different types of unix connections `SOCK_STREAM` (unix), `SOCK_DGRAM` (unixgram) and `SOCK_SEQPACKET` (unixpacket) all of which are `*net.UnixConn`s. That means `*net.UnixConn` always implements `net.PacketConn` regardless of the socket type, though certain methods will return errors.

`SOCK_DGRAM` is the only one we want to treat as a packet connection and use the UDP framing for (IIUC). To do this we special case `*net.UnixConn`s and only treat `SOCK_DGRAM` as a `net.PacketConn`.

This will make it possible to properly use the DNS client over unix `SOCK_STREAM` connections (the most common type).

Fixes #1321