### PR TITLE
Client.exchange: Use a minimum bufsize of DefaultMsgSize when EDNS0 is present

### DIFF
--- a/client.go
+++ b/client.go
@@ -206,6 +206,11 @@ func (c *Client) exchangeContext(ctx context.Context, m *Msg, co *Conn) (r *Msg,
 	// If EDNS0 is used use that for size.
 	if opt != nil && opt.UDPSize() >= MinMsgSize {
 		co.UDPSize = opt.UDPSize()
+		// Do not use a size lower than DefaultMsgSize (needed in case peer
+		// doesn't honor the edns0 bufsize)
+		if co.UDPSize < DefaultMsgSize {
+			co.UDPSize = DefaultMsgSize
+		}
 	}
 	// Otherwise use the client's configured UDP size.
 	if opt == nil && c.UDPSize >= MinMsgSize {


### PR DESCRIPTION
Some old peers do not properly honor the advertized EDNS0 bufsize,
sending a larger response.

As a result, the read buffer passed to 'co.Read()' is insufficient to
store the actual response, leading to a message parse error.

Let's be more liberal in the receive path: when EDNS0 is present, have
'co.UDPSize' at least 'DefaultMsgSize' (4096) bytes long, in order to
workaround such situations.