### PR TITLE
Pass DNS Msg via context into TSIG Verify and Generate functions

### DIFF
--- a/acceptfunc_test.go
+++ b/acceptfunc_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"testing"
 )
 
@@ -28,7 +29,7 @@ func TestAcceptNotify(t *testing.T) {
 	}
 }
 
-func handleNotify(w ResponseWriter, req *Msg) {
+func handleNotify(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	w.WriteMsg(m)

--- a/client.go
+++ b/client.go
@@ -358,7 +358,7 @@ func (co *Conn) WriteMsg(m *Msg) (err error) {
 	var out []byte
 	if t := m.IsTsig(); t != nil {
 		// Set tsigRequestMAC for the next read, although only used in zone transfers.
-		out, co.tsigRequestMAC, err = tsigGenerateProvider(m, co.tsigProvider(), co.tsigRequestMAC, false)
+		out, co.tsigRequestMAC, err = tsigGenerateProvider(context.Background(), m, co.tsigProvider(), co.tsigRequestMAC, false)
 	} else {
 		out, err = m.Pack()
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -342,7 +342,7 @@ func TestClientEDNS0Local(t *testing.T) {
 	optStr1 := "1979:0x0707"
 	optStr2 := strconv.Itoa(EDNS0LOCALSTART) + ":0x0601"
 
-	handler := func(w ResponseWriter, req *Msg) {
+	handler := func(ctx context.Context, w ResponseWriter, req *Msg) {
 		m := new(Msg)
 		m.SetReply(req)
 
@@ -667,7 +667,7 @@ func TestConcurrentExchanges(t *testing.T) {
 
 	for _, m := range cases {
 		mm := m // redeclare m so as not to trip the race detector
-		handler := func(w ResponseWriter, req *Msg) {
+		handler := func(ctx context.Context, w ResponseWriter, req *Msg) {
 			r := mm.Copy()
 			r.SetReply(req)
 

--- a/serve_mux.go
+++ b/serve_mux.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"sync"
 )
 
@@ -70,7 +71,7 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 }
 
 // HandleFunc adds a handler function to the ServeMux for pattern.
-func (mux *ServeMux) HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
+func (mux *ServeMux) HandleFunc(pattern string, handler func(context.Context, ResponseWriter, *Msg)) {
 	mux.Handle(pattern, HandlerFunc(handler))
 }
 
@@ -93,16 +94,16 @@ func (mux *ServeMux) HandleRemove(pattern string) {
 //
 // If no handler is found, or there is no question, a standard REFUSED
 // message is returned
-func (mux *ServeMux) ServeDNS(w ResponseWriter, req *Msg) {
+func (mux *ServeMux) ServeDNS(ctx context.Context, w ResponseWriter, req *Msg) {
 	var h Handler
 	if len(req.Question) >= 1 { // allow more than one question
 		h = mux.match(req.Question[0].Name, req.Question[0].Qtype)
 	}
 
 	if h != nil {
-		h.ServeDNS(w, req)
+		h.ServeDNS(ctx, w, req)
 	} else {
-		handleRefused(w, req)
+		handleRefused(ctx, w, req)
 	}
 }
 
@@ -117,6 +118,6 @@ func HandleRemove(pattern string) { DefaultServeMux.HandleRemove(pattern) }
 
 // HandleFunc registers the handler function with the given pattern
 // in the DefaultServeMux.
-func HandleFunc(pattern string, handler func(ResponseWriter, *Msg)) {
+func HandleFunc(pattern string, handler func(context.Context, ResponseWriter, *Msg)) {
 	DefaultServeMux.HandleFunc(pattern, handler)
 }

--- a/server.go
+++ b/server.go
@@ -729,7 +729,7 @@ func (w *response) WriteMsg(m *Msg) (err error) {
 	var data []byte
 	if w.tsigProvider != nil { // if no provider, dont check for the tsig (which is a longer check)
 		if t := m.IsTsig(); t != nil {
-			data, w.tsigRequestMAC, err = tsigGenerateProvider(m, w.tsigProvider, w.tsigRequestMAC, w.tsigTimersOnly)
+			data, w.tsigRequestMAC, err = tsigGenerateProvider(context.Background(), m, w.tsigProvider, w.tsigRequestMAC, w.tsigTimersOnly)
 			if err != nil {
 				return err
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func HelloServer(w ResponseWriter, req *Msg) {
+func HelloServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 
@@ -25,7 +25,7 @@ func HelloServer(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func HelloServerBadID(w ResponseWriter, req *Msg) {
+func HelloServerBadID(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Id++
@@ -35,7 +35,7 @@ func HelloServerBadID(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func HelloServerBadThenGoodID(w ResponseWriter, req *Msg) {
+func HelloServerBadThenGoodID(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Id++
@@ -48,7 +48,7 @@ func HelloServerBadThenGoodID(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func HelloServerEchoAddrPort(w ResponseWriter, req *Msg) {
+func HelloServerEchoAddrPort(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 
@@ -58,7 +58,7 @@ func HelloServerEchoAddrPort(w ResponseWriter, req *Msg) {
 	w.WriteMsg(m)
 }
 
-func AnotherHelloServer(w ResponseWriter, req *Msg) {
+func AnotherHelloServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 
@@ -345,8 +345,8 @@ func TestServingTLSConnectionState(t *testing.T) {
 	handlerResponse := "Hello example"
 	// tlsHandlerTLS is a HandlerFunc that can be set to expect or not TLS
 	// connection state.
-	tlsHandlerTLS := func(tlsExpected bool) func(ResponseWriter, *Msg) {
-		return func(w ResponseWriter, req *Msg) {
+	tlsHandlerTLS := func(tlsExpected bool) func(context.Context, ResponseWriter, *Msg) {
+		return func(ctx context.Context, w ResponseWriter, req *Msg) {
 			m := new(Msg)
 			m.SetReply(req)
 			tlsFound := true
@@ -546,7 +546,7 @@ func BenchmarkServe6(b *testing.B) {
 	runtime.GOMAXPROCS(a)
 }
 
-func HelloServerCompress(w ResponseWriter, req *Msg) {
+func HelloServerCompress(ctx context.Context, w ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Extra = make([]RR, 1)
@@ -586,7 +586,7 @@ type maxRec struct {
 
 var M = new(maxRec)
 
-func HelloServerLargeResponse(resp ResponseWriter, req *Msg) {
+func HelloServerLargeResponse(ctx context.Context, resp ResponseWriter, req *Msg) {
 	m := new(Msg)
 	m.SetReply(req)
 	m.Authoritative = true
@@ -710,7 +710,7 @@ func checkInProgressQueriesAtShutdownServer(t *testing.T, srv *Server, addr stri
 	defer errOnce.Do(func() {})
 
 	toHandle := int32(requests)
-	HandleFunc("example.com.", func(w ResponseWriter, req *Msg) {
+	HandleFunc("example.com.", func(ctx context.Context, w ResponseWriter, req *Msg) {
 		defer atomic.AddInt32(&toHandle, -1)
 
 		// Wait until ShutdownContext is called before replying.
@@ -871,7 +871,7 @@ func TestHandlerCloseTCP(t *testing.T) {
 
 	hname := "testhandlerclosetcp."
 	triggered := make(chan struct{})
-	HandleFunc(hname, func(w ResponseWriter, r *Msg) {
+	HandleFunc(hname, func(ctx context.Context, w ResponseWriter, r *Msg) {
 		close(triggered)
 		w.Close()
 	})
@@ -1042,7 +1042,7 @@ func TestServerRoundtripTsig(t *testing.T) {
 	defer s.Shutdown()
 
 	handlerFired := make(chan struct{})
-	HandleFunc("example.com.", func(w ResponseWriter, r *Msg) {
+	HandleFunc("example.com.", func(ctx context.Context, w ResponseWriter, r *Msg) {
 		close(handlerFired)
 
 		m := new(Msg)

--- a/xfr.go
+++ b/xfr.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -247,7 +248,7 @@ func (t *Transfer) ReadMsg() (*Msg, error) {
 func (t *Transfer) WriteMsg(m *Msg) (err error) {
 	var out []byte
 	if ts, tp := m.IsTsig(), t.tsigProvider(); ts != nil && tp != nil {
-		out, t.tsigRequestMAC, err = tsigGenerateProvider(m, tp, t.tsigRequestMAC, t.tsigTimersOnly)
+		out, t.tsigRequestMAC, err = tsigGenerateProvider(context.Background(), m, tp, t.tsigRequestMAC, t.tsigTimersOnly)
 	} else {
 		out, err = m.Pack()
 	}

--- a/xfr_test.go
+++ b/xfr_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -13,7 +14,7 @@ var (
 	xfrTestData = []RR{xfrSoa, xfrA, xfrMX, xfrSoa}
 )
 
-func InvalidXfrServer(w ResponseWriter, req *Msg) {
+func InvalidXfrServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	ch := make(chan *Envelope)
 	tr := new(Transfer)
 
@@ -23,7 +24,7 @@ func InvalidXfrServer(w ResponseWriter, req *Msg) {
 	w.Hijack()
 }
 
-func SingleEnvelopeXfrServer(w ResponseWriter, req *Msg) {
+func SingleEnvelopeXfrServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	ch := make(chan *Envelope)
 	tr := new(Transfer)
 
@@ -33,7 +34,7 @@ func SingleEnvelopeXfrServer(w ResponseWriter, req *Msg) {
 	w.Hijack()
 }
 
-func MultipleEnvelopeXfrServer(w ResponseWriter, req *Msg) {
+func MultipleEnvelopeXfrServer(ctx context.Context, w ResponseWriter, req *Msg) {
 	ch := make(chan *Envelope)
 	tr := new(Transfer)
 


### PR DESCRIPTION
This gives the server operator a lot more flexibility as to how they manage the verification and generation of tsigs.
The test TestServerRoundtripTsigProvider displays some of these possibilities.

For example:

1. Establish a sync.RWMutex on the secret map so that secrets can be dynamically updated even after the server has been started.
2. Establish more granular secret maps. I.E to ensure that many zones can share TSIG names without collisions in the map.

You could do other things like have zone specific verification or generation.

Fixes #1347 