### PR TITLE
Fix RSAMD5 keytag calucation.

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -140,12 +140,12 @@ func (k *DNSKEY) KeyTag() uint16 {
 	var keytag int
 	switch k.Algorithm {
 	case RSAMD5:
-		// Look at the bottom two bytes of the modules, which the last
-		// item in the pubkey.
 		// This algorithm has been deprecated, but keep this key-tag calculation.
+		// Look at the bottom two bytes of the modules, which the last item in the pubkey.
+		// See https://www.rfc-editor.org/errata/eid193 .
 		modulus, _ := fromBase64([]byte(k.PublicKey))
 		if len(modulus) > 1 {
-			x := binary.BigEndian.Uint16(modulus[len(modulus)-2:])
+			x := binary.BigEndian.Uint16(modulus[len(modulus)-3:])
 			keytag = int(x)
 		}
 	default:

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -855,3 +855,16 @@ func TestParseKeyReadError(t *testing.T) {
 		t.Errorf("expected a nil map, but got %v", m)
 	}
 }
+
+func TestRSAMD5KeyTag(t *testing.T) {
+	rr1, _ := NewRR("test.  IN DNSKEY  257 3 1 AwEAAcntNdoMnY8pvyPcpDTAaiqHyAhf53XUBANq166won/fjBFvmuzhTuP5r4el/pV0tzEBL73zpoU48BqF66uiL+qRijXCySJiaBUvLNll5rpwuduAOoVpmwOmkC4fV6izHOAx/Uy8c+pYP0YR8+1P7GuTFxgnMmt9sUGtoe+la0X/ ;{id = 27461 (ksk), size = 1024b}")
+	rr2, _ := NewRR("test.  IN DNSKEY  257 3 1 AwEAAf0bKO/m45ylk5BlSLmQHQRBLx1m/ZUXvyPFB387bJXxnTk6so3ub97L1RQ+8bOoiRh3Qm5EaYihjco7J8b/W5WbS3tVsE79nY584RfTKT2zcZ9AoFP2XLChXxPIf/6l0H9n6sH0aBjsG8vabEIp8e06INM3CXVPiMRPPeGNa0Ub ;{id = 27461 (ksk), size = 1024b}")
+
+	exp := uint16(27461)
+	if x := rr1.(*DNSKEY).KeyTag(); x != exp {
+		t.Errorf("expected %d, got %d, as keytag for rr1", exp, x)
+	}
+	if x := rr2.(*DNSKEY).KeyTag(); x != exp { // yes, same key tag
+		t.Errorf("expected %d, got %d, as keytag for rr2", exp, x)
+	}
+}


### PR DESCRIPTION
Of course the wording was changed (for the better) in an errata:
https://www.rfc-editor.org/errata/eid193

We still followed the original RFC4034 text. Note I haven't given this
much thought, just changed the 2 into a 3 and ran the test.

Fixes: #1352

Signed-off-by: Miek Gieben <miek@miek.nl>
