### PR TITLE
Add SVCB dohpath key

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1652,6 +1652,8 @@ func TestParseSVCB(t *testing.T) {
 		`example.com.   SVCB   16 foo.example.org. alpn=h2,h3-19 mandatory=ipv4hint,alpn ipv4hint=192.0.2.1`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="h2,h3-19" mandatory="ipv4hint,alpn" ipv4hint="192.0.2.1"`,
 		`example.com.   SVCB   16 foo.example.org. alpn="f\\\\oo\\,bar,h2"`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="f\\\\oo\\,bar,h2"`,
 		`example.com.   SVCB   16 foo.example.org. alpn=f\\\092oo\092,bar,h2`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="f\\\092oo\092,bar,h2"`,
+		// From draft-ietf-add-ddr-06
+		`_dns.example.net. SVCB 1 example.net. alpn=h2 dohpath=/dns-query{?dns}`: `_dns.example.net.	3600	IN	SVCB	1 example.net. alpn="h2" dohpath="/dns-query{?dns}"`,
 	}
 	for s, o := range svcbs {
 		rr, err := NewRR(s)

--- a/svcb.go
+++ b/svcb.go
@@ -679,8 +679,8 @@ func (s *SVCBIPv6Hint) copy() SVCBKeyValue {
 // See RFC xxxx (https://datatracker.ietf.org/doc/html/draft-ietf-add-svcb-dns-02)
 // and RFC yyyy (https://datatracker.ietf.org/doc/html/draft-ietf-add-ddr-06).
 //
-// Basic use pattern for using the dohpath option together with an alpn
-// option:
+// A basic example of using the dohpath option together with the alpn
+// option to indicate support for DNS over HTTPS on a certain path:
 //
 //	s := new(dns.SVCB)
 //	s.Hdr = dns.RR_Header{Name: ".", Rrtype: dns.TypeSVCB, Class: dns.ClassINET}
@@ -690,35 +690,23 @@ func (s *SVCBIPv6Hint) copy() SVCBKeyValue {
 //	p.Template = "/dns-query{?dns}"
 //	s.Value = append(s.Value, e, p)
 //
-// The parsing currently only validates the length of Template.
-// It doesn't validate that Template is a valid RFC 6570 URI template.
+// The parsing currently doesn't validate that Template is a valid
+// RFC 6570 URI template.
 type SVCBDoHPath struct {
 	Template string
 }
 
-func (*SVCBDoHPath) Key() SVCBKey { return SVCB_DOHPATH }
-func (s *SVCBDoHPath) len() int   { return len(s.Template) }
-
-func (s *SVCBDoHPath) pack() ([]byte, error) {
-	if len(s.Template) > 65535 {
-		return nil, errors.New("dns: svcbdohpath: template too long")
-	}
-	return []byte(s.Template), nil
-}
+func (*SVCBDoHPath) Key() SVCBKey            { return SVCB_DOHPATH }
+func (s *SVCBDoHPath) String() string        { return s.Template }
+func (s *SVCBDoHPath) len() int              { return len(s.Template) }
+func (s *SVCBDoHPath) pack() ([]byte, error) { return []byte(s.Template), nil }
 
 func (s *SVCBDoHPath) unpack(b []byte) error {
 	s.Template = string(b)
 	return nil
 }
 
-func (s *SVCBDoHPath) String() string {
-	return s.Template
-}
-
 func (s *SVCBDoHPath) parse(b string) error {
-	if len(b) > 65535 {
-		return errors.New("dns: svcbdohpath: template too long")
-	}
 	s.Template = b
 	return nil
 }

--- a/svcb_test.go
+++ b/svcb_test.go
@@ -18,6 +18,7 @@ func TestSVCB(t *testing.T) {
 		{`no-default-alpn`, ``},
 		{`ipv6hint`, `1::4:4:4:4,1::3:3:3:3`},
 		{`ech`, `YUdWc2JHOD0=`},
+		{`dohpath`, `/dns-query{?dns}`},
 		{`key65000`, `4\ 3`},
 		{`key65001`, `\"\ `},
 		{`key65002`, ``},


### PR DESCRIPTION
The parameter is being added in [its own IETF draft][1] and also being used in
the [IETF draft about Discovery of Designated Resolvers][2].

Additionally, the mappings of the numeric key values to strings are exported,
under names consistent with the already existing exported mappings, to make it
easier for the clients of the module to validate and print SVCB keys.

Testing was done by sending SVCB queries for the "_dns.resolver.arpa" domain to
OpenDNS's 146.112.41.2 server.

[1]: https://datatracker.ietf.org/doc/html/draft-ietf-add-svcb-dns-02
[2]: https://datatracker.ietf.org/doc/html/draft-ietf-add-ddr-06.html