### PR TITLE
Properly parse alpn values in SVCB

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1650,8 +1650,8 @@ func TestParseSVCB(t *testing.T) {
 		`example.com.   SVCB   1 foo.example.com. ipv6hint="2001:db8::1,2001:db8::53:1"`: `example.com.	3600	IN	SVCB	1 foo.example.com. ipv6hint="2001:db8::1,2001:db8::53:1"`,
 		`example.com.   SVCB   1 example.com. ipv6hint="2001:db8::198.51.100.100"`: `example.com.	3600	IN	SVCB	1 example.com. ipv6hint="2001:db8::c633:6464"`,
 		`example.com.   SVCB   16 foo.example.org. alpn=h2,h3-19 mandatory=ipv4hint,alpn ipv4hint=192.0.2.1`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="h2,h3-19" mandatory="ipv4hint,alpn" ipv4hint="192.0.2.1"`,
-		`example.com.   SVCB   16 foo.example.org. alpn="f\\\\oo\\,bar,h2"`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="f\\\\oo\\,bar,h2"`,
-		`example.com.   SVCB   16 foo.example.org. alpn=f\\\092oo\092,bar,h2`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="f\\\092oo\092,bar,h2"`,
+		`example.com.   SVCB   16 foo.example.org. alpn="f\\\\oo\\,bar,h2"`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="f\\\092oo\\\044bar,h2"`,
+		`example.com.   SVCB   16 foo.example.org. alpn=f\\\092oo\092,bar,h2`: `example.com.	3600	IN	SVCB	16 foo.example.org. alpn="f\\\092oo\\\044bar,h2"`,
 		// From draft-ietf-add-ddr-06
 		`_dns.example.net. SVCB 1 example.net. alpn=h2 dohpath=/dns-query{?dns}`: `_dns.example.net.	3600	IN	SVCB	1 example.net. alpn="h2" dohpath="/dns-query{?dns}"`,
 	}
@@ -1704,6 +1704,10 @@ func TestParseBadSVCB(t *testing.T) {
 		`1 . ipv4hint=`,           // empty ipv4
 		`1 . port=`,               // empty port
 		`1 . echconfig=YUd`,       // bad base64
+		`1 . alpn=h\`,             // unterminated escape
+		`1 . alpn=h2\\.h3`,        // comma-separated list with bad character
+		`1 . alpn=h2,,h3`,         // empty protocol identifier
+		`1 . alpn=h3,`,            // final protocol identifier empty
 	}
 	for _, o := range evils {
 		_, err := NewRR(header + o)

--- a/svcb.go
+++ b/svcb.go
@@ -365,8 +365,7 @@ func (s *SVCBAlpn) String() string {
 				continue
 			}
 			switch e {
-			// We escape a few characters which may confuse humans or
-			// parsers.
+			// We escape a few characters which may confuse humans or parsers.
 			case '"', ';', ' ':
 				str.WriteByte('\\')
 				str.WriteByte(e)

--- a/svcb.go
+++ b/svcb.go
@@ -354,6 +354,7 @@ func (s *SVCBAlpn) String() string {
 	// https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-08#appendix-A.1
 	var str strings.Builder
 	for i, alpn := range s.Alpn {
+		// 4*len(alpn) is the worst case where we escape every character in the alpn as \123, plus 1 byte for the ',' separating the alpn from others
 		str.Grow(4*len(alpn) + 1)
 		if i > 0 {
 			str.WriteByte(',')

--- a/svcb.go
+++ b/svcb.go
@@ -358,26 +358,26 @@ func (s *SVCBAlpn) String() string {
 		str.Grow(4 * len(alpn))
 		for j := 0; j < len(alpn); j++ {
 			e := alpn[j]
-			if ' ' <= e && e <= '~' {
-				switch e {
-				// We escape a few characters which may confuse humans or
-				// parsers.
-				case '"', ';', ' ':
-					str.WriteByte('\\')
-					str.WriteByte(e)
-				// The comma and backslash characters themselves must be
-				// doubly-escaped. We use `\\` for the first backslash and
-				// the escaped numeric value for the other value. We especially
-				// don't want a comma in the output.
-				case ',':
-					str.WriteString(`\\\044`)
-				case '\\':
-					str.WriteString(`\\\092`)
-				default:
-					str.WriteByte(e)
-				}
-			} else {
+			if ' ' > e || e > '~' {
 				str.WriteString(escapeByte(e))
+				continue
+			}
+			switch e {
+			// We escape a few characters which may confuse humans or
+			// parsers.
+			case '"', ';', ' ':
+				str.WriteByte('\\')
+				str.WriteByte(e)
+			// The comma and backslash characters themselves must be
+			// doubly-escaped. We use `\\` for the first backslash and
+			// the escaped numeric value for the other value. We especially
+			// don't want a comma in the output.
+			case ',':
+				str.WriteString(`\\\044`)
+			case '\\':
+				str.WriteString(`\\\092`)
+			default:
+				str.WriteByte(e)
 			}
 		}
 		esc[i] = str.String()

--- a/svcb.go
+++ b/svcb.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"net"
 	"sort"
 	"strconv"
@@ -460,7 +459,6 @@ func (s *SVCBAlpn) parse(b string) error {
 		return errors.New("dns: svcbalpn: last protocol identifier empty")
 	}
 	s.Alpn = append(alpn, string(a))
-	fmt.Println(s.Alpn)
 	return nil
 }
 

--- a/svcb.go
+++ b/svcb.go
@@ -352,10 +352,12 @@ func (s *SVCBAlpn) String() string {
 	// sequence of backslash in a zone file this may be why.
 	//
 	// https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-svcb-https-08#appendix-A.1
-	esc := make([]string, len(s.Alpn))
+	var str strings.Builder
 	for i, alpn := range s.Alpn {
-		var str strings.Builder
-		str.Grow(4 * len(alpn))
+		str.Grow(4*len(alpn) + 1)
+		if i > 0 {
+			str.WriteByte(',')
+		}
 		for j := 0; j < len(alpn); j++ {
 			e := alpn[j]
 			if ' ' > e || e > '~' {
@@ -380,9 +382,8 @@ func (s *SVCBAlpn) String() string {
 				str.WriteByte(e)
 			}
 		}
-		esc[i] = str.String()
 	}
-	return strings.Join(esc, ",")
+	return str.String()
 }
 
 func (s *SVCBAlpn) pack() ([]byte, error) {

--- a/svcb_test.go
+++ b/svcb_test.go
@@ -1,7 +1,6 @@
 package dns
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -126,8 +125,14 @@ func TestSVCBAlpn(t *testing.T) {
 			t.Error("failed to parse RR: ", err)
 			continue
 		}
-		if !reflect.DeepEqual(v, rr.(*SVCB).Value[0].(*SVCBAlpn).Alpn) {
-			t.Errorf("parsing alpn failed, wanted %v got %v", v, rr.(*SVCB).Value[0].(*SVCBAlpn).Alpn)
+		alpn := rr.(*SVCB).Value[0].(*SVCBAlpn).Alpn
+		if len(v) != len(alpn) {
+			t.Fatalf("parsing alpn failed, wanted %v got %v", v, alpn)
+		}
+		for i := range v {
+			if v[i] != alpn[i] {
+				t.Fatalf("parsing alpn failed, wanted %v got %v", v, alpn)
+			}
 		}
 	}
 }


### PR DESCRIPTION
PR for #1361 

This code adds more comprehensive parsing and string conversion to the alpn support in the HTTPS/SVCB types.

Before we were just splitting on `,`, but this version actually parses as per the draft, which allows alpn with a `,` in the value. This adds a ton of error cases and a fair bit of code, so I'm hoping the RFC simplifies this to just forbidding `,` in the alpn completely (am I too late to suggest that?). On the plus side, the examples in the tests now actually return correct values.

I used the existing `nextByte()` function in the `types.go` file, since I needed the same functionality. This means that we allow incorrect values like `\456`, but I figured fixing that was out of scope. Is it worth a separate PR? :thinking: Note that the parser for `SVCBLocal` uses `strconv.ParseUint()` and should actually bounds check, so we have different strictness/interpretations about escaped characters already.

The `String()` is also updated to handle outputting non-printable values, and also handles the double-escaping specified in the draft. I decided to output `\\044` instead of `\,` so that naive parsers (like the old one) would at least have a chance to split the output into something like what it should be (since there is no `,` because we use the numeric version). This shouldn't have any impact on the actual meaning, but I did have to update a couple of tests based on this format.

I added a few more tests to sanity check that everything is working as it is supposed to.

I noticed that the "dohpath" support was merged in while I was working on this. This introduces another place where `String()` will possibly produce incorrect output. :disappointed: I'll have a look tomorrow....