### PR TITLE
Disallow names that start with '.' in IsDomainName()

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -218,6 +218,11 @@ func IsDomainName(s string) (labels int, ok bool) {
 
 			wasDot = false
 		case '.':
+			if i == 0 && len(s) > 1 {
+				// leading dots are not legal except for the root zone
+				return labels, false
+			}
+
 			if wasDot {
 				// two dots back to back is not legal
 				return labels, false

--- a/labels_test.go
+++ b/labels_test.go
@@ -176,7 +176,10 @@ func TestIsDomainName(t *testing.T) {
 		lab int
 	}
 	names := map[string]*ret{
-		"..":                     {false, 1},
+		".":                      {true, 1},
+		"..":                     {false, 0},
+		"double-dot..test":       {false, 1},
+		".leading-dot.test":      {false, 0},
 		"@.":                     {true, 1},
 		"www.example.com":        {true, 3},
 		"www.e%ample.com":        {true, 3},

--- a/msg.go
+++ b/msg.go
@@ -265,6 +265,11 @@ loop:
 
 			wasDot = false
 		case '.':
+			if i == 0 && len(s) > 1 {
+				// leading dots are not legal except for the root zone
+				return len(msg), ErrRdata
+			}
+
 			if wasDot {
 				// two dots back to back is not legal
 				return len(msg), ErrRdata


### PR DESCRIPTION
We noticed that `IsDomainName()` was allowing names that start with at `.`. This is an error, which this PR fixes.