### PR TITLE
QUIC/DoQ support using quic-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/miekg/dns
 go 1.14
 
 require (
+	github.com/lucas-clemente/quic-go v0.27.1
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c


### PR DESCRIPTION
# Work In Progress !

Draft implementation of DoQ support using quic-go, this PR serves as discussion forum for if this is the right way forward as the dependencies are quite large.

TODO:
- [ ] Should there be a `ListenAndServeDoQ()`?
- [ ] Add `_test` code
- [ ] Discuss usage of `response.tcp` when using QUIC

\+ all TODO's in the code

Example:
```
cert, _ := tls.LoadX509KeyPair("<cert>", "<key>")
config := tls.Config{
    Certificates: []tls.Certificate{cert},
}
server := &dns.Server{Addr: "<addr>", Net: "doq", TLSConfig: &config, Handler: <handle>})
```

ref #1370