### PR TITLE
Add back support for *net.UnixCon with seqpacket type

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ func isPacketConn(c net.Conn) bool {
 	}
 
 	if ua, ok := c.LocalAddr().(*net.UnixAddr); ok {
-		return ua.Net == "unixgram"
+		return ua.Net == "unixgram" || ua.Net == "unixpacket"
 	}
 
 	return true

--- a/client_test.go
+++ b/client_test.go
@@ -68,6 +68,27 @@ func TestIsPacketConn(t *testing.T) {
 		t.Error("Unix datagram connection (wrapped type) should be a packet conn")
 	}
 
+	// Unix Seqpacket
+	shutChan, addrstr, err := RunLocalUnixSeqPacketServer(filepath.Join(t.TempDir(), "unixpacket.sock"))
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+
+	defer func() {
+		shutChan <- &struct{}{}
+	}()
+	c, err = net.Dial("unixpacket", addrstr)
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+	defer c.Close()
+	if !isPacketConn(c) {
+		t.Error("Unix datagram connection should be a packet conn")
+	}
+	if !isPacketConn(struct{ *net.UnixConn }{c.(*net.UnixConn)}) {
+		t.Error("Unix datagram connection (wrapped type) should be a packet conn")
+	}
+
 	// Unix stream
 	s, addrstr, _, err = RunLocalUnixServer(filepath.Join(t.TempDir(), "unixstream.sock"))
 	if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -159,6 +159,21 @@ func RunLocalUnixGramServer(laddr string, opts ...func(*Server)) (*Server, strin
 	return RunLocalServer(pc, nil, opts...)
 }
 
+func RunLocalUnixSeqPacketServer(laddr string) (chan interface{}, string, error) {
+	pc, err := net.Listen("unixpacket", laddr)
+	if err != nil {
+		return nil, "", err
+	}
+
+	shutdownChan := make(chan interface{})
+	go func() {
+		pc.Accept()
+		<-shutdownChan
+	}()
+
+	return shutdownChan, pc.Addr().String(), nil
+}
+
 func TestServing(t *testing.T) {
 	for _, tc := range []struct {
 		name      string


### PR DESCRIPTION
This was broken by PR: https://github.com/miekg/dns/pull/1322