### PR TITLE
ReadMsgHeader use bytes pool

### DIFF
--- a/client.go
+++ b/client.go
@@ -319,7 +319,6 @@ func (co *Conn) ReadMsgHeader(hdr *Header) ([]byte, error) {
 		return nil, ErrShortRead
 	}
 
-	p = p[:n]
 	if hdr != nil {
 		dh, _, err := unpackMsgHdr(p, 0)
 		if err != nil {


### PR DESCRIPTION
I find the  makeslice of ReadMsgHeader will cost much GC time. So I suggest to use bytes pool to avoid the GC cost. 