### PR TITLE
edns: add missing dig options

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -81,7 +81,7 @@ func (rr *OPT) String() string {
 		s += "flags:; "
 	}
 	if rr.Hdr.Ttl&0x7FFF != 0 {
-		s += "MBZ: " + fmt.Sprintf("0x%04x", rr.Hdr.Ttl&0x7FFF) + ", "
+		s += fmt.Sprintf("MBZ: 0x%04x, ", rr.Hdr.Ttl&0x7FFF)
 	}
 	s += "udp: " + strconv.Itoa(int(rr.UDPSize()))
 

--- a/edns.go
+++ b/edns.go
@@ -78,7 +78,10 @@ func (rr *OPT) String() string {
 	if rr.Do() {
 		s += "flags: do; "
 	} else {
-		s += "flags: ; "
+		s += "flags:; "
+	}
+	if rr.Hdr.Ttl&0x7FFF != 0 {
+		s += "MBZ: " + fmt.Sprintf("0x%04x", rr.Hdr.Ttl&0x7FFF) + ", "
 	}
 	s += "udp: " + strconv.Itoa(int(rr.UDPSize()))
 
@@ -98,6 +101,8 @@ func (rr *OPT) String() string {
 			s += "\n; SUBNET: " + o.String()
 		case *EDNS0_COOKIE:
 			s += "\n; COOKIE: " + o.String()
+		case *EDNS0_EXPIRE:
+			s += "\n; EXPIRE: " + o.String()
 		case *EDNS0_TCP_KEEPALIVE:
 			s += "\n; KEEPALIVE: " + o.String()
 		case *EDNS0_UL:


### PR DESCRIPTION
Adds to `opt.String()` making the opt printing more like dig.

The &0x7FFF is like dig, which doesn't display the DO flag even when set (see below)
```
❯ dig +ednsflags=12 +expire github.com +qr +dnssec

; <<>> DiG 9.18.4-2-Debian <<>> +ednsflags +expire github.com +qr +dnssec
;; global options: +cmd
;; Sending:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 56825
;; flags: rd ad; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; MBZ: 0x000c, udp: 1232
; COOKIE: 
; EXPIRE:
;; QUESTION SECTION:
;github.com.                    IN      A

;; QUERY SIZE: 55
```