### PR TITLE
fix: example in docs with invalid syntax

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -72,7 +72,7 @@ and port to use for the connection:
 		Port: 12345,
 		Zone: "",
 	}
-	c.Dialer := &net.Dialer{
+	c.Dialer = &net.Dialer{
 		Timeout: 200 * time.Millisecond,
 		LocalAddr: &laddr,
 	}


### PR DESCRIPTION
fixes invalid syntax in one of the examples of the README