### PR TITLE
Fix typos

### DIFF
--- a/client.go
+++ b/client.go
@@ -185,7 +185,7 @@ func (c *Client) Exchange(m *Msg, address string) (r *Msg, rtt time.Duration, er
 // that entails when using "tcp" and especially "tcp-tls" clients.
 //
 // When the singleflight is set for this client the context is _not_ forwarded to the (shared) exchange, to
-// prevent one cancelation from canceling all outstanding requests.
+// prevent one cancellation from canceling all outstanding requests.
 func (c *Client) ExchangeWithConn(m *Msg, conn *Conn) (r *Msg, rtt time.Duration, err error) {
 	return c.exchangeWithConnContext(context.Background(), m, conn)
 }
@@ -198,7 +198,7 @@ func (c *Client) exchangeWithConnContext(ctx context.Context, m *Msg, conn *Conn
 	q := m.Question[0]
 	key := fmt.Sprintf("%s:%d:%d", q.Name, q.Qtype, q.Qclass)
 	r, rtt, err, shared := c.group.Do(key, func() (*Msg, time.Duration, error) {
-		// When we're doing singleflight we don't want one context cancelation, cancel _all_ outstanding queries.
+		// When we're doing singleflight we don't want one context cancellation, cancel _all_ outstanding queries.
 		// Hence we ignore the context and use Background().
 		return c.exchangeContext(context.Background(), m, conn)
 	})

--- a/dnsutil/util_test.go
+++ b/dnsutil/util_test.go
@@ -63,7 +63,7 @@ func TestTrimDomainName(t *testing.T) {
 	// Paranoid tests.
 	// These test shouldn't be needed but I was weary of off-by-one errors.
 	// In theory, these can't happen because there are no single-letter TLDs,
-	// but it is good to exercize the code this way.
+	// but it is good to exercise the code this way.
 	tests := []struct{ experiment, expected string }{
 		{"", "@"},
 		{".", "."},

--- a/msg_truncate_test.go
+++ b/msg_truncate_test.go
@@ -18,7 +18,7 @@ func TestRequestTruncateAnswer(t *testing.T) {
 
 	reply.Truncate(MinMsgSize)
 	if want, got := MinMsgSize, reply.Len(); want < got {
-		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
+		t.Errorf("message length should be below %d bytes, got %d bytes", want, got)
 	}
 	if !reply.Truncated {
 		t.Errorf("truncated bit should be set")
@@ -38,7 +38,7 @@ func TestRequestTruncateExtra(t *testing.T) {
 
 	reply.Truncate(MinMsgSize)
 	if want, got := MinMsgSize, reply.Len(); want < got {
-		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
+		t.Errorf("message length should be below %d bytes, got %d bytes", want, got)
 	}
 	if !reply.Truncated {
 		t.Errorf("truncated bit should be set")
@@ -62,7 +62,7 @@ func TestRequestTruncateExtraEdns0(t *testing.T) {
 
 	reply.Truncate(size)
 	if want, got := size, reply.Len(); want < got {
-		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
+		t.Errorf("message length should be below %d bytes, got %d bytes", want, got)
 	}
 	if !reply.Truncated {
 		t.Errorf("truncated bit should be set")
@@ -94,7 +94,7 @@ func TestRequestTruncateExtraRegression(t *testing.T) {
 
 	reply.Truncate(size)
 	if want, got := size, reply.Len(); want < got {
-		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
+		t.Errorf("message length should be below %d bytes, got %d bytes", want, got)
 	}
 	if !reply.Truncated {
 		t.Errorf("truncated bit should be set")
@@ -130,7 +130,7 @@ func TestTruncation(t *testing.T) {
 
 		copy.Truncate(bufsize)
 		if want, got := bufsize, copy.Len(); want < got {
-			t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
+			t.Errorf("message length should be below %d bytes, got %d bytes", want, got)
 		}
 	}
 }
@@ -150,7 +150,7 @@ func TestRequestTruncateAnswerExact(t *testing.T) {
 
 	reply.Truncate(size)
 	if want, got := size, reply.Len(); want < got {
-		t.Errorf("message length should be bellow %d bytes, got %d bytes", want, got)
+		t.Errorf("message length should be below %d bytes, got %d bytes", want, got)
 	}
 	if expected := 52; len(reply.Answer) != expected {
 		t.Errorf("wrong number of answers; expected %d, got %d", expected, len(reply.Answer))

--- a/server.go
+++ b/server.go
@@ -18,7 +18,7 @@ import (
 const maxTCPQueries = 128
 
 // aLongTimeAgo is a non-zero time, far in the past, used for
-// immediate cancelation of network operations.
+// immediate cancellation of network operations.
 var aLongTimeAgo = time.Unix(1, 0)
 
 // Handler is implemented by any value that implements ServeDNS.

--- a/svcb.go
+++ b/svcb.go
@@ -353,7 +353,7 @@ func (*SVCBAlpn) Key() SVCBKey { return SVCB_ALPN }
 func (s *SVCBAlpn) String() string {
 	// An ALPN value is a comma-separated list of values, each of which can be
 	// an arbitrary binary value. In order to allow parsing, the comma and
-	// backslash characters are themselves excaped.
+	// backslash characters are themselves escaped.
 	//
 	// However, this escaping is done in addition to the normal escaping which
 	// happens in zone files, meaning that these values must be

--- a/update_test.go
+++ b/update_test.go
@@ -92,7 +92,7 @@ func TestRemoveRRset(t *testing.T) {
 }
 
 func TestPreReqAndRemovals(t *testing.T) {
-	// Build a list of multiple prereqs and then somes removes followed by an insert.
+	// Build a list of multiple prereqs and then some removes followed by an insert.
 	// We should be able to add multiple prereqs and updates.
 	m := new(Msg)
 	m.SetUpdate("example.org.")


### PR DESCRIPTION
Found via `codespell -L ede,ans,te,crasher`