### PR TITLE
doc: added egbakou/domainverifier as user

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://github.com/slackhq/nebula
 * https://github.com/dnschecktool/dow-proxy
 * https://dnscheck.tools/
+* https://github.com/egbakou/domainverifier
 
 
 Send pull request if you want to be listed here.


### PR DESCRIPTION
https://github.com/egbakou/domainverifier is a domain name ownership verification library written in go.
It uses this project to implement both the TXT record and CNAME record verification methods.