### PR TITLE
Tweaks

### DIFF
--- a/duplicate_generate.go
+++ b/duplicate_generate.go
@@ -162,7 +162,7 @@ func main() {
 				o2("if r1.%s != r2.%s {\nreturn false\n}")
 			}
 		}
-		fmt.Fprintf(b, "return true\n}\n\n")
+		fmt.Fprint(b, "return true\n}\n\n")
 	}
 
 	// gofmt

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -302,7 +302,7 @@ return off, err
 			}
 			// If we've hit len(msg) we return without error.
 			if i < st.NumFields()-1 {
-				fmt.Fprintf(b, `if off == len(msg) {
+				fmt.Fprint(b, `if off == len(msg) {
 return off, nil
 	}
 `)

--- a/parse_test.go
+++ b/parse_test.go
@@ -2018,7 +2018,10 @@ func TestParseZONEMD(t *testing.T) {
 
 func TestParseIPSECKEY(t *testing.T) {
 	dt := map[string]string{
-		"ipseckey. 3600 IN IPSECKEY 10 0 2 . AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==": "ipseckey.\t3600\tIN\tIPSECKEY\t10 0 2 . AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==",
+		"ipseckey. 3600 IN IPSECKEY 10 0 2 . AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==":                                  "ipseckey.\t3600\tIN\tIPSECKEY\t10 0 2 . AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==",
+		"ipseckey. 3600 IN IPSECKEY 10 1 2 1.2.3.4 AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==":                            "ipseckey.\t3600\tIN\tIPSECKEY\t10 1 2 1.2.3.4 AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==",
+		"ipseckey. 3600 IN IPSECKEY 10 2 2 2001:470:30:84:e276:63ff:fe72:3900 AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==": "ipseckey.\t3600\tIN\tIPSECKEY\t10 2 2 2001:470:30:84:e276:63ff:fe72:3900 AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==",
+		"ipseckey. 3600 IN IPSECKEY 10 3 2 ipseckey2. AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==":                         "ipseckey.\t3600\tIN\tIPSECKEY\t10 3 2 ipseckey2. AQNRU3mG7TVTO2BkR47usntb102uFJtugbo6BSGvgqt4AQ==",
 	}
 
 	for i, o := range dt {
@@ -2031,8 +2034,10 @@ func TestParseIPSECKEY(t *testing.T) {
 
 func TestParseAMTRELAY(t *testing.T) {
 	dt := map[string]string{
-		"amtrelay. 3600 IN AMTRELAY 10 0 2 2001:470:30:84:e276:63ff:fe72:3900": "amtrelay.\t3600\tIN\tAMTRELAY\t10 0 2 2001:470:30:84:e276:63ff:fe72:3900",
+		"amtrelay. 3600 IN AMTRELAY 10 0 0 .":                                  "amtrelay.\t3600\tIN\tAMTRELAY\t10 0 0 .",
+		"amtrelay. 3600 IN AMTRELAY 10 0 1 1.2.3.4":                            "amtrelay.\t3600\tIN\tAMTRELAY\t10 0 1 1.2.3.4",
 		"amtrelay. 3600 IN AMTRELAY 10 1 2 2001:470:30:84:e276:63ff:fe72:3900": "amtrelay.\t3600\tIN\tAMTRELAY\t10 1 2 2001:470:30:84:e276:63ff:fe72:3900",
+		"amtrelay. 3600 IN AMTRELAY 10 1 3 amtrelay2.":                         "amtrelay.\t3600\tIN\tAMTRELAY\t10 1 3 amtrelay2.",
 	}
 
 	for i, o := range dt {

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1249,7 +1249,7 @@ func (rr *IPSECKEY) parse(c *zlexer, o string) *ParseError {
 
 	rr.GatewayAddr, rr.GatewayHost, err = parseAddrHostUnion(l.token, o, rr.GatewayType)
 	if err != nil {
-		return &ParseError{"", "AMTRELAY " + err.Error(), l}
+		return &ParseError{"", "IPSECKEY " + err.Error(), l}
 	}
 
 	c.Next() // zBlank

--- a/types.go
+++ b/types.go
@@ -1531,7 +1531,7 @@ func (a *APLPrefix) str() string {
 // equals reports whether two APL prefixes are identical.
 func (a *APLPrefix) equals(b *APLPrefix) bool {
 	return a.Negation == b.Negation &&
-		bytes.Equal(a.Network.IP, b.Network.IP) &&
+		a.Network.IP.Equal(b.Network.IP) &&
 		bytes.Equal(a.Network.Mask, b.Network.Mask)
 }
 

--- a/types_generate.go
+++ b/types_generate.go
@@ -261,7 +261,7 @@ func main() {
 				log.Fatalln(name, st.Field(i).Name(), st.Tag(i))
 			}
 		}
-		fmt.Fprintf(b, "return l }\n")
+		fmt.Fprint(b, "return l }\n\n")
 	}
 
 	// Generate copy()
@@ -319,7 +319,7 @@ func main() {
 		}
 	WriteCopy:
 		fmt.Fprintf(b, "return &%s{%s}\n", name, strings.Join(fields, ","))
-		fmt.Fprintf(b, "}\n")
+		fmt.Fprint(b, "}\n\n")
 	}
 
 	// gofmt

--- a/ztypes.go
+++ b/ztypes.go
@@ -263,6 +263,7 @@ func (rr *A) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *AAAA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	if len(rr.AAAA) != 0 {
@@ -270,12 +271,14 @@ func (rr *AAAA) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *AFSDB) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Subtype
 	l += domainNameLen(rr.Hostname, off+l, compression, false)
 	return l
 }
+
 func (rr *AMTRELAY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Precedence
@@ -290,10 +293,12 @@ func (rr *AMTRELAY) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *ANY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	return l
 }
+
 func (rr *APL) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	for _, x := range rr.Prefixes {
@@ -301,6 +306,7 @@ func (rr *APL) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *AVC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	for _, x := range rr.Txt {
@@ -308,6 +314,7 @@ func (rr *AVC) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *CAA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Flag
@@ -315,6 +322,7 @@ func (rr *CAA) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Value)
 	return l
 }
+
 func (rr *CERT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Type
@@ -323,21 +331,25 @@ func (rr *CERT) len(off int, compression map[string]struct{}) int {
 	l += base64.StdEncoding.DecodedLen(len(rr.Certificate))
 	return l
 }
+
 func (rr *CNAME) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Target, off+l, compression, true)
 	return l
 }
+
 func (rr *DHCID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += base64.StdEncoding.DecodedLen(len(rr.Digest))
 	return l
 }
+
 func (rr *DNAME) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Target, off+l, compression, false)
 	return l
 }
+
 func (rr *DNSKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Flags
@@ -346,6 +358,7 @@ func (rr *DNSKEY) len(off int, compression map[string]struct{}) int {
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
 	return l
 }
+
 func (rr *DS) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // KeyTag
@@ -354,26 +367,31 @@ func (rr *DS) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Digest) / 2
 	return l
 }
+
 func (rr *EID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Endpoint) / 2
 	return l
 }
+
 func (rr *EUI48) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 6 // Address
 	return l
 }
+
 func (rr *EUI64) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 8 // Address
 	return l
 }
+
 func (rr *GID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 4 // Gid
 	return l
 }
+
 func (rr *GPOS) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Longitude) + 1
@@ -381,12 +399,14 @@ func (rr *GPOS) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Altitude) + 1
 	return l
 }
+
 func (rr *HINFO) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Cpu) + 1
 	l += len(rr.Os) + 1
 	return l
 }
+
 func (rr *HIP) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++    // HitLength
@@ -399,6 +419,7 @@ func (rr *HIP) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *IPSECKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Precedence
@@ -415,12 +436,14 @@ func (rr *IPSECKEY) len(off int, compression map[string]struct{}) int {
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
 	return l
 }
+
 func (rr *KX) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
 	l += domainNameLen(rr.Exchanger, off+l, compression, false)
 	return l
 }
+
 func (rr *L32) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
@@ -429,12 +452,14 @@ func (rr *L32) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *L64) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
 	l += 8 // Locator64
 	return l
 }
+
 func (rr *LOC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++    // Version
@@ -446,49 +471,58 @@ func (rr *LOC) len(off int, compression map[string]struct{}) int {
 	l += 4 // Altitude
 	return l
 }
+
 func (rr *LP) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
 	l += domainNameLen(rr.Fqdn, off+l, compression, false)
 	return l
 }
+
 func (rr *MB) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Mb, off+l, compression, true)
 	return l
 }
+
 func (rr *MD) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Md, off+l, compression, true)
 	return l
 }
+
 func (rr *MF) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Mf, off+l, compression, true)
 	return l
 }
+
 func (rr *MG) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Mg, off+l, compression, true)
 	return l
 }
+
 func (rr *MINFO) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Rmail, off+l, compression, true)
 	l += domainNameLen(rr.Email, off+l, compression, true)
 	return l
 }
+
 func (rr *MR) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Mr, off+l, compression, true)
 	return l
 }
+
 func (rr *MX) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
 	l += domainNameLen(rr.Mx, off+l, compression, true)
 	return l
 }
+
 func (rr *NAPTR) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Order
@@ -499,17 +533,20 @@ func (rr *NAPTR) len(off int, compression map[string]struct{}) int {
 	l += domainNameLen(rr.Replacement, off+l, compression, false)
 	return l
 }
+
 func (rr *NID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
 	l += 8 // NodeID
 	return l
 }
+
 func (rr *NIMLOC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Locator) / 2
 	return l
 }
+
 func (rr *NINFO) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	for _, x := range rr.ZSData {
@@ -517,16 +554,19 @@ func (rr *NINFO) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *NS) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Ns, off+l, compression, true)
 	return l
 }
+
 func (rr *NSAPPTR) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Ptr, off+l, compression, false)
 	return l
 }
+
 func (rr *NSEC3PARAM) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++    // Hash
@@ -536,21 +576,25 @@ func (rr *NSEC3PARAM) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Salt) / 2
 	return l
 }
+
 func (rr *NULL) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Data)
 	return l
 }
+
 func (rr *OPENPGPKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
 	return l
 }
+
 func (rr *PTR) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Ptr, off+l, compression, true)
 	return l
 }
+
 func (rr *PX) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
@@ -558,11 +602,13 @@ func (rr *PX) len(off int, compression map[string]struct{}) int {
 	l += domainNameLen(rr.Mapx400, off+l, compression, false)
 	return l
 }
+
 func (rr *RFC3597) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Rdata) / 2
 	return l
 }
+
 func (rr *RKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Flags
@@ -571,12 +617,14 @@ func (rr *RKEY) len(off int, compression map[string]struct{}) int {
 	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
 	return l
 }
+
 func (rr *RP) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Mbox, off+l, compression, false)
 	l += domainNameLen(rr.Txt, off+l, compression, false)
 	return l
 }
+
 func (rr *RRSIG) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // TypeCovered
@@ -590,12 +638,14 @@ func (rr *RRSIG) len(off int, compression map[string]struct{}) int {
 	l += base64.StdEncoding.DecodedLen(len(rr.Signature))
 	return l
 }
+
 func (rr *RT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Preference
 	l += domainNameLen(rr.Host, off+l, compression, false)
 	return l
 }
+
 func (rr *SMIMEA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Usage
@@ -604,6 +654,7 @@ func (rr *SMIMEA) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Certificate) / 2
 	return l
 }
+
 func (rr *SOA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Ns, off+l, compression, true)
@@ -615,6 +666,7 @@ func (rr *SOA) len(off int, compression map[string]struct{}) int {
 	l += 4 // Minttl
 	return l
 }
+
 func (rr *SPF) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	for _, x := range rr.Txt {
@@ -622,6 +674,7 @@ func (rr *SPF) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *SRV) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Priority
@@ -630,6 +683,7 @@ func (rr *SRV) len(off int, compression map[string]struct{}) int {
 	l += domainNameLen(rr.Target, off+l, compression, false)
 	return l
 }
+
 func (rr *SSHFP) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Algorithm
@@ -637,6 +691,7 @@ func (rr *SSHFP) len(off int, compression map[string]struct{}) int {
 	l += len(rr.FingerPrint) / 2
 	return l
 }
+
 func (rr *SVCB) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Priority
@@ -646,6 +701,7 @@ func (rr *SVCB) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *TA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // KeyTag
@@ -654,12 +710,14 @@ func (rr *TA) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Digest) / 2
 	return l
 }
+
 func (rr *TALINK) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.PreviousName, off+l, compression, false)
 	l += domainNameLen(rr.NextName, off+l, compression, false)
 	return l
 }
+
 func (rr *TKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Algorithm, off+l, compression, false)
@@ -673,6 +731,7 @@ func (rr *TKEY) len(off int, compression map[string]struct{}) int {
 	l += len(rr.OtherData) / 2
 	return l
 }
+
 func (rr *TLSA) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l++ // Usage
@@ -681,6 +740,7 @@ func (rr *TLSA) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Certificate) / 2
 	return l
 }
+
 func (rr *TSIG) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += domainNameLen(rr.Algorithm, off+l, compression, false)
@@ -694,6 +754,7 @@ func (rr *TSIG) len(off int, compression map[string]struct{}) int {
 	l += len(rr.OtherData) / 2
 	return l
 }
+
 func (rr *TXT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	for _, x := range rr.Txt {
@@ -701,16 +762,19 @@ func (rr *TXT) len(off int, compression map[string]struct{}) int {
 	}
 	return l
 }
+
 func (rr *UID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 4 // Uid
 	return l
 }
+
 func (rr *UINFO) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Uinfo) + 1
 	return l
 }
+
 func (rr *URI) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 2 // Priority
@@ -718,11 +782,13 @@ func (rr *URI) len(off int, compression map[string]struct{}) int {
 	l += len(rr.Target)
 	return l
 }
+
 func (rr *X25) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.PSDNAddress) + 1
 	return l
 }
+
 func (rr *ZONEMD) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += 4 // Serial
@@ -736,18 +802,23 @@ func (rr *ZONEMD) len(off int, compression map[string]struct{}) int {
 func (rr *A) copy() RR {
 	return &A{rr.Hdr, copyIP(rr.A)}
 }
+
 func (rr *AAAA) copy() RR {
 	return &AAAA{rr.Hdr, copyIP(rr.AAAA)}
 }
+
 func (rr *AFSDB) copy() RR {
 	return &AFSDB{rr.Hdr, rr.Subtype, rr.Hostname}
 }
+
 func (rr *AMTRELAY) copy() RR {
 	return &AMTRELAY{rr.Hdr, rr.Precedence, rr.GatewayType, copyIP(rr.GatewayAddr), rr.GatewayHost}
 }
+
 func (rr *ANY) copy() RR {
 	return &ANY{rr.Hdr}
 }
+
 func (rr *APL) copy() RR {
 	Prefixes := make([]APLPrefix, len(rr.Prefixes))
 	for i, e := range rr.Prefixes {
@@ -755,153 +826,199 @@ func (rr *APL) copy() RR {
 	}
 	return &APL{rr.Hdr, Prefixes}
 }
+
 func (rr *AVC) copy() RR {
 	Txt := make([]string, len(rr.Txt))
 	copy(Txt, rr.Txt)
 	return &AVC{rr.Hdr, Txt}
 }
+
 func (rr *CAA) copy() RR {
 	return &CAA{rr.Hdr, rr.Flag, rr.Tag, rr.Value}
 }
+
 func (rr *CDNSKEY) copy() RR {
 	return &CDNSKEY{*rr.DNSKEY.copy().(*DNSKEY)}
 }
+
 func (rr *CDS) copy() RR {
 	return &CDS{*rr.DS.copy().(*DS)}
 }
+
 func (rr *CERT) copy() RR {
 	return &CERT{rr.Hdr, rr.Type, rr.KeyTag, rr.Algorithm, rr.Certificate}
 }
+
 func (rr *CNAME) copy() RR {
 	return &CNAME{rr.Hdr, rr.Target}
 }
+
 func (rr *CSYNC) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
 	copy(TypeBitMap, rr.TypeBitMap)
 	return &CSYNC{rr.Hdr, rr.Serial, rr.Flags, TypeBitMap}
 }
+
 func (rr *DHCID) copy() RR {
 	return &DHCID{rr.Hdr, rr.Digest}
 }
+
 func (rr *DLV) copy() RR {
 	return &DLV{*rr.DS.copy().(*DS)}
 }
+
 func (rr *DNAME) copy() RR {
 	return &DNAME{rr.Hdr, rr.Target}
 }
+
 func (rr *DNSKEY) copy() RR {
 	return &DNSKEY{rr.Hdr, rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
 }
+
 func (rr *DS) copy() RR {
 	return &DS{rr.Hdr, rr.KeyTag, rr.Algorithm, rr.DigestType, rr.Digest}
 }
+
 func (rr *EID) copy() RR {
 	return &EID{rr.Hdr, rr.Endpoint}
 }
+
 func (rr *EUI48) copy() RR {
 	return &EUI48{rr.Hdr, rr.Address}
 }
+
 func (rr *EUI64) copy() RR {
 	return &EUI64{rr.Hdr, rr.Address}
 }
+
 func (rr *GID) copy() RR {
 	return &GID{rr.Hdr, rr.Gid}
 }
+
 func (rr *GPOS) copy() RR {
 	return &GPOS{rr.Hdr, rr.Longitude, rr.Latitude, rr.Altitude}
 }
+
 func (rr *HINFO) copy() RR {
 	return &HINFO{rr.Hdr, rr.Cpu, rr.Os}
 }
+
 func (rr *HIP) copy() RR {
 	RendezvousServers := make([]string, len(rr.RendezvousServers))
 	copy(RendezvousServers, rr.RendezvousServers)
 	return &HIP{rr.Hdr, rr.HitLength, rr.PublicKeyAlgorithm, rr.PublicKeyLength, rr.Hit, rr.PublicKey, RendezvousServers}
 }
+
 func (rr *HTTPS) copy() RR {
 	return &HTTPS{*rr.SVCB.copy().(*SVCB)}
 }
+
 func (rr *IPSECKEY) copy() RR {
 	return &IPSECKEY{rr.Hdr, rr.Precedence, rr.GatewayType, rr.Algorithm, copyIP(rr.GatewayAddr), rr.GatewayHost, rr.PublicKey}
 }
+
 func (rr *KEY) copy() RR {
 	return &KEY{*rr.DNSKEY.copy().(*DNSKEY)}
 }
+
 func (rr *KX) copy() RR {
 	return &KX{rr.Hdr, rr.Preference, rr.Exchanger}
 }
+
 func (rr *L32) copy() RR {
 	return &L32{rr.Hdr, rr.Preference, copyIP(rr.Locator32)}
 }
+
 func (rr *L64) copy() RR {
 	return &L64{rr.Hdr, rr.Preference, rr.Locator64}
 }
+
 func (rr *LOC) copy() RR {
 	return &LOC{rr.Hdr, rr.Version, rr.Size, rr.HorizPre, rr.VertPre, rr.Latitude, rr.Longitude, rr.Altitude}
 }
+
 func (rr *LP) copy() RR {
 	return &LP{rr.Hdr, rr.Preference, rr.Fqdn}
 }
+
 func (rr *MB) copy() RR {
 	return &MB{rr.Hdr, rr.Mb}
 }
+
 func (rr *MD) copy() RR {
 	return &MD{rr.Hdr, rr.Md}
 }
+
 func (rr *MF) copy() RR {
 	return &MF{rr.Hdr, rr.Mf}
 }
+
 func (rr *MG) copy() RR {
 	return &MG{rr.Hdr, rr.Mg}
 }
+
 func (rr *MINFO) copy() RR {
 	return &MINFO{rr.Hdr, rr.Rmail, rr.Email}
 }
+
 func (rr *MR) copy() RR {
 	return &MR{rr.Hdr, rr.Mr}
 }
+
 func (rr *MX) copy() RR {
 	return &MX{rr.Hdr, rr.Preference, rr.Mx}
 }
+
 func (rr *NAPTR) copy() RR {
 	return &NAPTR{rr.Hdr, rr.Order, rr.Preference, rr.Flags, rr.Service, rr.Regexp, rr.Replacement}
 }
+
 func (rr *NID) copy() RR {
 	return &NID{rr.Hdr, rr.Preference, rr.NodeID}
 }
+
 func (rr *NIMLOC) copy() RR {
 	return &NIMLOC{rr.Hdr, rr.Locator}
 }
+
 func (rr *NINFO) copy() RR {
 	ZSData := make([]string, len(rr.ZSData))
 	copy(ZSData, rr.ZSData)
 	return &NINFO{rr.Hdr, ZSData}
 }
+
 func (rr *NS) copy() RR {
 	return &NS{rr.Hdr, rr.Ns}
 }
+
 func (rr *NSAPPTR) copy() RR {
 	return &NSAPPTR{rr.Hdr, rr.Ptr}
 }
+
 func (rr *NSEC) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
 	copy(TypeBitMap, rr.TypeBitMap)
 	return &NSEC{rr.Hdr, rr.NextDomain, TypeBitMap}
 }
+
 func (rr *NSEC3) copy() RR {
 	TypeBitMap := make([]uint16, len(rr.TypeBitMap))
 	copy(TypeBitMap, rr.TypeBitMap)
 	return &NSEC3{rr.Hdr, rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt, rr.HashLength, rr.NextDomain, TypeBitMap}
 }
+
 func (rr *NSEC3PARAM) copy() RR {
 	return &NSEC3PARAM{rr.Hdr, rr.Hash, rr.Flags, rr.Iterations, rr.SaltLength, rr.Salt}
 }
+
 func (rr *NULL) copy() RR {
 	return &NULL{rr.Hdr, rr.Data}
 }
+
 func (rr *OPENPGPKEY) copy() RR {
 	return &OPENPGPKEY{rr.Hdr, rr.PublicKey}
 }
+
 func (rr *OPT) copy() RR {
 	Option := make([]EDNS0, len(rr.Option))
 	for i, e := range rr.Option {
@@ -909,47 +1026,61 @@ func (rr *OPT) copy() RR {
 	}
 	return &OPT{rr.Hdr, Option}
 }
+
 func (rr *PTR) copy() RR {
 	return &PTR{rr.Hdr, rr.Ptr}
 }
+
 func (rr *PX) copy() RR {
 	return &PX{rr.Hdr, rr.Preference, rr.Map822, rr.Mapx400}
 }
+
 func (rr *RFC3597) copy() RR {
 	return &RFC3597{rr.Hdr, rr.Rdata}
 }
+
 func (rr *RKEY) copy() RR {
 	return &RKEY{rr.Hdr, rr.Flags, rr.Protocol, rr.Algorithm, rr.PublicKey}
 }
+
 func (rr *RP) copy() RR {
 	return &RP{rr.Hdr, rr.Mbox, rr.Txt}
 }
+
 func (rr *RRSIG) copy() RR {
 	return &RRSIG{rr.Hdr, rr.TypeCovered, rr.Algorithm, rr.Labels, rr.OrigTtl, rr.Expiration, rr.Inception, rr.KeyTag, rr.SignerName, rr.Signature}
 }
+
 func (rr *RT) copy() RR {
 	return &RT{rr.Hdr, rr.Preference, rr.Host}
 }
+
 func (rr *SIG) copy() RR {
 	return &SIG{*rr.RRSIG.copy().(*RRSIG)}
 }
+
 func (rr *SMIMEA) copy() RR {
 	return &SMIMEA{rr.Hdr, rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
 }
+
 func (rr *SOA) copy() RR {
 	return &SOA{rr.Hdr, rr.Ns, rr.Mbox, rr.Serial, rr.Refresh, rr.Retry, rr.Expire, rr.Minttl}
 }
+
 func (rr *SPF) copy() RR {
 	Txt := make([]string, len(rr.Txt))
 	copy(Txt, rr.Txt)
 	return &SPF{rr.Hdr, Txt}
 }
+
 func (rr *SRV) copy() RR {
 	return &SRV{rr.Hdr, rr.Priority, rr.Weight, rr.Port, rr.Target}
 }
+
 func (rr *SSHFP) copy() RR {
 	return &SSHFP{rr.Hdr, rr.Algorithm, rr.Type, rr.FingerPrint}
 }
+
 func (rr *SVCB) copy() RR {
 	Value := make([]SVCBKeyValue, len(rr.Value))
 	for i, e := range rr.Value {
@@ -957,38 +1088,49 @@ func (rr *SVCB) copy() RR {
 	}
 	return &SVCB{rr.Hdr, rr.Priority, rr.Target, Value}
 }
+
 func (rr *TA) copy() RR {
 	return &TA{rr.Hdr, rr.KeyTag, rr.Algorithm, rr.DigestType, rr.Digest}
 }
+
 func (rr *TALINK) copy() RR {
 	return &TALINK{rr.Hdr, rr.PreviousName, rr.NextName}
 }
+
 func (rr *TKEY) copy() RR {
 	return &TKEY{rr.Hdr, rr.Algorithm, rr.Inception, rr.Expiration, rr.Mode, rr.Error, rr.KeySize, rr.Key, rr.OtherLen, rr.OtherData}
 }
+
 func (rr *TLSA) copy() RR {
 	return &TLSA{rr.Hdr, rr.Usage, rr.Selector, rr.MatchingType, rr.Certificate}
 }
+
 func (rr *TSIG) copy() RR {
 	return &TSIG{rr.Hdr, rr.Algorithm, rr.TimeSigned, rr.Fudge, rr.MACSize, rr.MAC, rr.OrigId, rr.Error, rr.OtherLen, rr.OtherData}
 }
+
 func (rr *TXT) copy() RR {
 	Txt := make([]string, len(rr.Txt))
 	copy(Txt, rr.Txt)
 	return &TXT{rr.Hdr, Txt}
 }
+
 func (rr *UID) copy() RR {
 	return &UID{rr.Hdr, rr.Uid}
 }
+
 func (rr *UINFO) copy() RR {
 	return &UINFO{rr.Hdr, rr.Uinfo}
 }
+
 func (rr *URI) copy() RR {
 	return &URI{rr.Hdr, rr.Priority, rr.Weight, rr.Target}
 }
+
 func (rr *X25) copy() RR {
 	return &X25{rr.Hdr, rr.PSDNAddress}
 }
+
 func (rr *ZONEMD) copy() RR {
 	return &ZONEMD{rr.Hdr, rr.Serial, rr.Scheme, rr.Hash, rr.Digest}
 }


### PR DESCRIPTION
This PR is primarily to fix a typo that was in my last PR, where some IPSECKEY RR parsing errors are incorrectly marked as AMTRELAY errors due to *ahem* some copy-pasting.
Alongside that are some other small tweaks:
* couple more tests for IPSECKEY/AMTRELAY
* using `(net.IP).Equal` for `net.IP` comparison instead of `bytes.Equal`
* use `fmt.Fprint` instead of `fmt.Fprintf` when no formatted arguments are passed in `*_generate.go`, and make `types_generate.go` generate code that gofumpt won't try to format, with an additional newline