### PR TITLE
Remove pre-go1.11 support from reuseport code

### DIFF
--- a/listen_no_reuseport.go
+++ b/listen_no_reuseport.go
@@ -1,5 +1,5 @@
-//go:build !go1.11 || (!aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd)
-// +build !go1.11 !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
+//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd
+// +build !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
 
 package dns
 

--- a/listen_reuseport.go
+++ b/listen_reuseport.go
@@ -1,5 +1,4 @@
-//go:build go1.11 && (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd)
-// +build go1.11
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd
 // +build aix darwin dragonfly freebsd linux netbsd openbsd
 
 package dns

--- a/server.go
+++ b/server.go
@@ -224,7 +224,7 @@ type Server struct {
 	// Maximum number of TCP queries before we close the socket. Default is maxTCPQueries (unlimited if -1).
 	MaxTCPQueries int
 	// Whether to set the SO_REUSEPORT socket option, allowing multiple listeners to be bound to a single address.
-	// It is only supported on go1.11+ and when using ListenAndServe.
+	// It is only supported on certain GOOSes and when using ListenAndServe.
 	ReusePort bool
 	// AcceptMsgFunc will check the incoming message and will reject it early in the process.
 	// By default DefaultMsgAcceptFunc will be used.


### PR DESCRIPTION
This is well outside our supported release range.