### PR TITLE
Correct TODO in udp_windows.go

### DIFF
--- a/udp_windows.go
+++ b/udp_windows.go
@@ -1,6 +1,9 @@
 //go:build windows
 // +build windows
 
+// TODO(tmthrgd): Remove this Windows-specific code if go.dev/issue/7175 and
+//   go.dev/issue/7174 are ever fixed.
+
 package dns
 
 import "net"
@@ -15,7 +18,6 @@ func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
 
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
-// TODO(fastest963): Once go1.10 is released, use ReadMsgUDP.
 func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 	n, raddr, err := conn.ReadFrom(b)
 	if err != nil {
@@ -25,12 +27,9 @@ func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
 }
 
 // WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
-// TODO(fastest963): Once go1.10 is released, use WriteMsgUDP.
 func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
 	return conn.WriteTo(b, session.raddr)
 }
 
-// TODO(fastest963): Once go1.10 is released and we can use *MsgUDP methods
-// use the standard method in udp.go for these.
 func setUDPSocketOptions(*net.UDPConn) error { return nil }
 func parseDstFromOOB([]byte, net.IP) net.IP  { return nil }


### PR DESCRIPTION
These TODOs were not correct as x/net/ipv4 and x/net/ipv6 still don't have Windows support.

Updates #738
Updates #765
Updates coredns/coredns#2138
See golang/go#7175
See golang/go#7174