### PR TITLE
Use generics for ddd escape parsing

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -208,7 +208,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 			}
 
 			// check for \DDD
-			if i+3 < len(s) && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
+			if isDDD(s[i+1:]) {
 				i += 3
 				begin += 3
 			} else {

--- a/msg.go
+++ b/msg.go
@@ -252,7 +252,7 @@ loop:
 			}
 
 			// check for \DDD
-			if i+3 < ls && isDigit(bs[i+1]) && isDigit(bs[i+2]) && isDigit(bs[i+3]) {
+			if isDDD(bs[i+1:]) {
 				bs[i] = dddToByte(bs[i+1:])
 				copy(bs[i+1:ls-3], bs[i+4:])
 				ls -= 3
@@ -482,7 +482,7 @@ func packTxtString(s string, msg []byte, offset int) (int, error) {
 				break
 			}
 			// check for \DDD
-			if i+2 < len(s) && isDigit(s[i]) && isDigit(s[i+1]) && isDigit(s[i+2]) {
+			if isDDD(s[i:]) {
 				msg[offset] = dddToByte(s[i:])
 				i += 2
 			} else {
@@ -517,7 +517,7 @@ func packOctetString(s string, msg []byte, offset int, tmp []byte) (int, error) 
 				break
 			}
 			// check for \DDD
-			if i+2 < len(bs) && isDigit(bs[i]) && isDigit(bs[i+1]) && isDigit(bs[i+2]) {
+			if isDDD(bs[i:]) {
 				msg[offset] = dddToByte(bs[i:])
 				i += 2
 			} else {
@@ -545,6 +545,10 @@ func unpackTxt(msg []byte, off0 int) (ss []string, off int, err error) {
 
 // Helpers for dealing with escaped bytes
 func isDigit(b byte) bool { return b >= '0' && b <= '9' }
+
+func isDDD[T ~[]byte | ~string](s T) bool {
+	return len(s) >= 3 && isDigit(s[0]) && isDigit(s[1]) && isDigit(s[2])
+}
 
 func dddToByte[T ~[]byte | ~string](s T) byte {
 	_ = s[2] // bounds check hint to compiler; see golang.org/issue/14808
@@ -1014,7 +1018,7 @@ func escapedNameLen(s string) int {
 			continue
 		}
 
-		if i+3 < len(s) && isDigit(s[i+1]) && isDigit(s[i+2]) && isDigit(s[i+3]) {
+		if isDDD(s[i+1:]) {
 			nameLen -= 3
 			i += 3
 		} else {

--- a/msg.go
+++ b/msg.go
@@ -483,7 +483,7 @@ func packTxtString(s string, msg []byte, offset int) (int, error) {
 			}
 			// check for \DDD
 			if i+2 < len(s) && isDigit(s[i]) && isDigit(s[i+1]) && isDigit(s[i+2]) {
-				msg[offset] = dddStringToByte(s[i:])
+				msg[offset] = dddToByte(s[i:])
 				i += 2
 			} else {
 				msg[offset] = s[i]
@@ -546,12 +546,7 @@ func unpackTxt(msg []byte, off0 int) (ss []string, off int, err error) {
 // Helpers for dealing with escaped bytes
 func isDigit(b byte) bool { return b >= '0' && b <= '9' }
 
-func dddToByte(s []byte) byte {
-	_ = s[2] // bounds check hint to compiler; see golang.org/issue/14808
-	return byte((s[0]-'0')*100 + (s[1]-'0')*10 + (s[2] - '0'))
-}
-
-func dddStringToByte(s string) byte {
+func dddToByte[T ~[]byte | ~string](s T) byte {
 	_ = s[2] // bounds check hint to compiler; see golang.org/issue/14808
 	return byte((s[0]-'0')*100 + (s[1]-'0')*10 + (s[2] - '0'))
 }

--- a/types.go
+++ b/types.go
@@ -632,7 +632,7 @@ func nextByte(s string, offset int) (byte, int) {
 	case 2, 3: // too short to be \ddd
 	default: // maybe \ddd
 		if isDigit(s[offset+1]) && isDigit(s[offset+2]) && isDigit(s[offset+3]) {
-			return dddStringToByte(s[offset+1:]), 4
+			return dddToByte(s[offset+1:]), 4
 		}
 	}
 	// not \ddd, just an RFC 1035 "quoted" character

--- a/types.go
+++ b/types.go
@@ -631,7 +631,7 @@ func nextByte(s string, offset int) (byte, int) {
 		return 0, 0
 	case 2, 3: // too short to be \ddd
 	default: // maybe \ddd
-		if isDigit(s[offset+1]) && isDigit(s[offset+2]) && isDigit(s[offset+3]) {
+		if isDDD(s[offset+1:]) {
 			return dddToByte(s[offset+1:]), 4
 		}
 	}


### PR DESCRIPTION
We use generics to merge `dddToByte` and `dddStringToByte`.

We also introduce a generic `isDDD` helper that replaces nearly all uses of `isDigit`. The exception being `svcbParseParam` which implements stricter parsing.