### PR TITLE
chore: don't use deprecated ioutil package

### DIFF
--- a/clientconfig_test.go
+++ b/clientconfig_test.go
@@ -1,7 +1,6 @@
 package dns
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,14 +90,10 @@ func TestClientConfigFromReaderAttempts(t *testing.T) {
 }
 
 func TestReadFromFile(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("tempDir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	path := filepath.Join(tempDir, "resolv.conf")
-	if err := ioutil.WriteFile(path, []byte(normal), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(normal), 0o644); err != nil {
 		t.Fatalf("writeFile: %v", err)
 	}
 	cc, err := ClientConfigFromFile(path)
@@ -142,6 +137,7 @@ func TestNameListNdots1(t *testing.T) {
 		t.Errorf("NameList didn't return search last: %v", names[1])
 	}
 }
+
 func TestNameListNdots2(t *testing.T) {
 	cfg := ClientConfig{
 		Ndots: 2,

--- a/generate_test.go
+++ b/generate_test.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,22 +9,18 @@ import (
 )
 
 func TestGenerateRangeGuard(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "dns")
-	if err != nil {
-		t.Fatalf("could not create tmpdir for test: %v", err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	for i := 0; i <= 1; i++ {
 		path := filepath.Join(tmpdir, fmt.Sprintf("%04d.conf", i))
 		data := []byte(fmt.Sprintf("dhcp-%04d A 10.0.0.%d", i, i))
 
-		if err := ioutil.WriteFile(path, data, 0644); err != nil {
+		if err := os.WriteFile(path, data, 0o644); err != nil {
 			t.Fatalf("could not create tmpfile for test: %v", err)
 		}
 	}
 
-	var tests = [...]struct {
+	tests := [...]struct {
 		zone string
 		fail bool
 	}{
@@ -85,7 +80,7 @@ $GENERATE 0-2 dhcp-${0,4,d} A 10.1.0.$
 }
 
 func TestGenerateIncludeDepth(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "dns")
+	tmpfile, err := os.CreateTemp("", "dns")
 	if err != nil {
 		t.Fatalf("could not create tmpfile for test: %v", err)
 	}

--- a/scan_test.go
+++ b/scan_test.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"io"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -49,8 +48,7 @@ func TestZoneParserGenerate(t *testing.T) {
 }
 
 func TestZoneParserInclude(t *testing.T) {
-
-	tmpfile, err := ioutil.TempFile("", "dns")
+	tmpfile, err := os.CreateTemp("", "dns")
 	if err != nil {
 		t.Fatalf("could not create tmpfile for test: %s", err)
 	}
@@ -99,7 +97,7 @@ func TestZoneParserInclude(t *testing.T) {
 }
 
 func TestZoneParserIncludeDisallowed(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "dns")
+	tmpfile, err := os.CreateTemp("", "dns")
 	if err != nil {
 		t.Fatalf("could not create tmpfile for test: %s", err)
 	}


### PR DESCRIPTION
[ioutil](https://pkg.go.dev/io/ioutil) go deprecated as of go 1.16 so let's not use it and use replacements from e.g. `io` package.