### PR TITLE
Define MaxGoroutines to limit the number goroutines created by the server

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -119,6 +119,12 @@ func RunLocalUDPServer(laddr string, opts ...func(*Server)) (*Server, string, ch
 	return RunLocalServer(pc, nil, opts...)
 }
 
+func RunLocalUDPServerLimited(laddr string, opts ...func(*Server)) (*Server, string, chan error, error) {
+	return RunLocalUDPServer(laddr, append(opts, func(srv *Server) {
+		srv.MaxGoroutines = 1
+	})...)
+}
+
 func RunLocalPacketConnServer(laddr string, opts ...func(*Server)) (*Server, string, chan error, error) {
 	return RunLocalUDPServer(laddr, append(opts, func(srv *Server) {
 		// Make srv.PacketConn opaque to trigger the generic code paths.
@@ -133,6 +139,12 @@ func RunLocalTCPServer(laddr string, opts ...func(*Server)) (*Server, string, ch
 	}
 
 	return RunLocalServer(nil, l, opts...)
+}
+
+func RunLocalTCPServerLimited(laddr string, opts ...func(*Server)) (*Server, string, chan error, error) {
+	return RunLocalTCPServer(laddr, append(opts, func(srv *Server) {
+		srv.MaxGoroutines = 1
+	})...)
 }
 
 func RunLocalTLSServer(laddr string, config *tls.Config) (*Server, string, chan error, error) {
@@ -182,6 +194,8 @@ func TestServing(t *testing.T) {
 	}{
 		{"udp", "udp", RunLocalUDPServer},
 		{"tcp", "tcp", RunLocalTCPServer},
+		{"udp-limited", "udp", RunLocalUDPServerLimited},
+		{"tcp-limited", "tcp", RunLocalTCPServerLimited},
 		{"PacketConn", "udp", RunLocalPacketConnServer},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
A DNS flood attack can simply cause an OOM due to creation of unlimited goroutines by the server.

This attack can be simulated using [dns-flood](https://github.com/nickwinn/dns-flood):

```bash
clone https://github.com/nickwinn/dns-flood.git
cd dns-flood
gcc -o dns-flood dnsflood.c
./dns-flood <domain> <server-ip> -r -i 0 -p <server-port>
```