### PR TITLE
Use correct string format IPv4 encoded as IPv6 for for AAAA records

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1686,6 +1686,33 @@ func TestNULLRecord(t *testing.T) {
 		t.Fatalf("Expected packet to contain NULL record")
 	}
 }
+func TestAAAAParsing(t *testing.T) {
+	tests := []string{
+		"2001:db8::1",
+		"1::1",
+		"2001:db81:d2b4:b6ba:50db:49cc:a8d1:5bb1",
+		"::ffff:192.0.2.0",
+	}
+
+	rrPrefix := ".\t1\tIN\tAAAA\t"
+
+	for num, tc := range tests {
+		t.Run(fmt.Sprintf("Test %d", num), func(t *testing.T) {
+			rr, err := NewRR(rrPrefix + tc)
+			if err != nil {
+				t.Fatalf("failed to parse RR: %s", err)
+			}
+			// Output presentation format and try to parse again
+			reparseRR, err := NewRR(rr.String())
+			if err != nil {
+				t.Fatalf("failed to reparse RR: %s", err)
+			}
+			if reparseRR.String() != rrPrefix+tc {
+				t.Errorf("expected %s,got %s", rrPrefix+tc, reparseRR.String())
+			}
+		})
+	}
+}
 
 func TestParseAPL(t *testing.T) {
 	tests := []struct {

--- a/types.go
+++ b/types.go
@@ -236,6 +236,9 @@ var CertTypeToString = map[uint16]string{
 	CertOID:     "OID",
 }
 
+// Prefix for IPv4 encoded as IPv6 address
+const ipv4InIPv6Prefix = "::ffff:"
+
 //go:generate go run types_generate.go
 
 // Question holds a DNS question. Usually there is just one. While the
@@ -751,6 +754,11 @@ func (rr *AAAA) String() string {
 	if rr.AAAA == nil {
 		return rr.Hdr.String()
 	}
+
+	if rr.AAAA.To4() != nil {
+		return rr.Hdr.String() + ipv4InIPv6Prefix + rr.AAAA.String()
+	}
+
 	return rr.Hdr.String() + rr.AAAA.String()
 }
 
@@ -1517,7 +1525,7 @@ func (a *APLPrefix) str() string {
 	case net.IPv6len:
 		// add prefix for IPv4-mapped IPv6
 		if v4 := a.Network.IP.To4(); v4 != nil {
-			sb.WriteString("::ffff:")
+			sb.WriteString(ipv4InIPv6Prefix)
 		}
 		sb.WriteString(a.Network.IP.String())
 	}


### PR DESCRIPTION
In order to parse an IPv4 address encoded as IPv6, it needs to have the prefix of "::ffff:", i.e. ::ffff:192.0.2.1

This allows export of parsed IPv4 encoded IPv6 AAAA records to be scanned back to a valid AAAA record.
Without it the following code fails as the address is "plain" dotted IPv4-format:
```
rr, err := dns.NewRR(". 1 IN AAAA ::ffff:192.0.2.1")
if err != nil {
    log.Fatalf("parse failure: %w", err)
}

_, err = dns.NewRR(rr.String())
if err != nil {
    log.Fatalf("parse failure: %w", err)
}
```

This comes from the std libs net.IP String() function which outputs IPv4-in-IPV6 as standard dotted-IPv4. net/netip.Addr type, in contrast, differs here in that the String() func outputs it with the proper prefix "::ffff:" Ref: https://pkg.go.dev/net/netip#Addr.String

The other attempt to fix this https://github.com/miekg/dns/issues/1107 and the code in PR https://github.com/miekg/dns/pull/1108 has worse performance than this PR, due to the use of fmt.Sprintf() which is not needed