### PR TITLE
readme: add sdns to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://addr.tools/
 * https://dnscheck.tools/
 * https://github.com/egbakou/domainverifier
+* https://github.com/semihalev/sdns
 
 
 Send pull request if you want to be listed here.


### PR DESCRIPTION
Before `sdns` was added to users list but deleted some reasons. I read the reasons but the project never be selling anything nor nxdomain/404. That was described like that on https://github.com/miekg/dns/commit/68df4402de4a2303c8dad5aea62450485d589d81

Could you please check and add again? 

Thanks.
