### PR TITLE
Print SSHFP fingerprint as lowercase hex

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1414,7 +1414,7 @@ func TestParseSSHFP(t *testing.T) {
 			"\t\t\t\t\tB6159E30723665DA95BB )",
 		"test.example.org.\t300\tSSHFP\t1 2 ( BC6533CDC  95A79078A39A56EA7635984ED655318AD  A9B6159E3072366 5DA95BB )",
 	}
-	result := "test.example.org.\t300\tIN\tSSHFP\t1 2 BC6533CDC95A79078A39A56EA7635984ED655318ADA9B6159E30723665DA95BB"
+	result := "test.example.org.\t300\tIN\tSSHFP\t1 2 bc6533cdc95a79078a39a56ea7635984ed655318ada9b6159e30723665da95bb"
 	for _, o := range lt {
 		rr, err := NewRR(o)
 		if err != nil {

--- a/types.go
+++ b/types.go
@@ -985,7 +985,7 @@ type SSHFP struct {
 func (rr *SSHFP) String() string {
 	return rr.Hdr.String() + strconv.Itoa(int(rr.Algorithm)) +
 		" " + strconv.Itoa(int(rr.Type)) +
-		" " + strings.ToUpper(rr.FingerPrint)
+		" " + strings.ToLower(rr.FingerPrint)
 }
 
 // KEY RR. See RFC RFC 2535.


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc4255#section-3.2 uses lowercase, doesn't mention case sensitivity, and some SSHFP validation implementations require lowercase.

Argument against this PR:
* it could break some users (e.g. test cases relying on string-representation of RRs)
* https://en.wikipedia.org/wiki/Robustness_principle suggests the burden is on validation implementations to be liberal (i.e. accept upper or lower case): hex is commonly understand to be case insensitive anyway