### PR TITLE
up go version for testing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ 1.19.x, 1.20.x ]
+        go: [ 1.20.x, 1.21.x ]
     steps:
 
     - name: Set up Go


### PR DESCRIPTION
Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
