### PR TITLE
The small `(*dns.OPT).SetDo` documentation tweak

### DIFF
--- a/edns.go
+++ b/edns.go
@@ -185,7 +185,7 @@ func (rr *OPT) Do() bool {
 
 // SetDo sets the DO (DNSSEC OK) bit.
 // If we pass an argument, set the DO bit to that value.
-// It is possible to pass 2 or more arguments. Any arguments after the 1st is silently ignored.
+// It is possible to pass 2 or more arguments, but they will be ignored.
 func (rr *OPT) SetDo(do ...bool) {
 	if len(do) == 1 {
 		if do[0] {
@@ -508,6 +508,7 @@ func (e *EDNS0_LLQ) String() string {
 		" " + strconv.FormatUint(uint64(e.LeaseLife), 10)
 	return s
 }
+
 func (e *EDNS0_LLQ) copy() EDNS0 {
 	return &EDNS0_LLQ{e.Code, e.Version, e.Opcode, e.Error, e.Id, e.LeaseLife}
 }


### PR DESCRIPTION
As I identified in #1460, there is a mistake in the documentation appeared, that I would like to address through the following pull request.  I've tried to change as few symbols, as possible, to keep the documentation comprehensive and concise.

Best regards, @EugeneOne1.