### PR TITLE
Add support for standalone Service Params parsing, encoding and stringifying

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -651,13 +651,12 @@ func (zp *ZoneParser) Next() (RR, bool) {
 	return nil, false
 }
 
-// SvcParamsParser is a parser for SVCB Service Params  that reads
-// from r.
+// SvcParamsParser is a parser for SVCB Service Params
 //
-// Basic usage pattern when reading from a string (z) containing the
+// Basic usage pattern when reading from a string (s) containing the
 // service params
 //
-//		spp := NewServiceParamsParser(strings.NewReader(z), "", "")
+//		spp := NewSvcParamsParser(strings.NewReader(s), "")
 //
 //		sp, ok := spp.Next()
 //	    if ok {
@@ -675,7 +674,7 @@ type SvcParamsParser struct {
 	file string
 }
 
-// NewZoneParser returns SVCB Service Params parser that reads
+// NewSvcParamsParser returns SVCB Service Params parser that reads
 // from r.
 func NewSvcParamsParser(r io.Reader, file string) *SvcParamsParser {
 	var pe *ParseError

--- a/svcb.go
+++ b/svcb.go
@@ -269,7 +269,7 @@ func (s SVCBKeyValues) Pack() ([]byte, error) {
 		return xs[i].Key() < xs[j].Key()
 	})
 	var wireBuf []byte
-	for i, _ := range xs {
+	for i := range xs {
 		wireBuf = append(wireBuf, HostToNetShort(uint16(xs[i].Key()))...)
 		wireVal, err := xs[i].pack()
 		if err != nil {
@@ -309,7 +309,7 @@ func (s SVCBKeyValues) String() string {
 	sort.Slice(xs, func(i, j int) bool {
 		return xs[i].Key() < xs[j].Key()
 	})
-	for i, _ := range s {
+	for i := range s {
 		outStr.WriteString(xs[i].Key().String())
 		outStr.WriteString("=")
 		outStr.WriteString(xs[i].String())
@@ -323,7 +323,7 @@ func (s SVCBKeyValues) String() string {
 func (s SVCBKeyValues) Copy() SvcParams {
 	xs := make(SVCBKeyValues, len(s))
 
-	for i, _ := range s {
+	for i := range s {
 		xs[i] = s[i].copy()
 	}
 	return xs

--- a/svcb.go
+++ b/svcb.go
@@ -258,7 +258,7 @@ type SvcParams interface {
 	Copy() SvcParams       // copy returns a deep-copy of the Service Params
 }
 
-// This is a concrete implementation of the SvcParams interface
+// SVCBKeyValues is a concrete implementation of the SvcParams interface
 type SVCBKeyValues []SVCBKeyValue
 
 func (s SVCBKeyValues) Pack() ([]byte, error) {

--- a/svcb.go
+++ b/svcb.go
@@ -253,9 +253,9 @@ func (rr *HTTPS) parse(c *zlexer, o string) *ParseError {
 // e.g. as defined in RFC 9463. For these purposes, being able to manipulate Service Params is not
 // necessary.
 type SvcParams interface {
-	Pack() ([]byte, error) // pack returns the wire encoding of all the Service Params
+	Pack() ([]byte, error) // Pack returns the wire encoding of all the Service Params
 	String() string        // String returns the presentation format of all the Service Params
-	Copy() SvcParams       // copy returns a deep-copy of the Service Params
+	Copy() SvcParams       // Copy returns a deep-copy of the Service Params
 }
 
 // SVCBKeyValues implements the SvcParams interface plus the Unpack method

--- a/svcb_test.go
+++ b/svcb_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"encoding/hex"
 	"testing"
 )
 
@@ -159,5 +160,25 @@ func TestCompareSVCB(t *testing.T) {
 	}
 	if val1[0].Key() != SVCB_PORT || val2[0].Key() != SVCB_ALPN {
 		t.Error("original svcb pairs were reordered during comparison")
+	}
+}
+
+func TestUnpackSVCBKeyValues(t *testing.T) {
+	// Note this example is taken from the Appendix of RFC 9463
+	wireBytes, _ := hex.DecodeString("00010003026832000700102F646E732D71756572797B3F646E737D")
+	expectedStr := "alpn=h2 dohpath=/dns-query{?dns}"
+
+	var s SVCBKeyValues
+
+	err := s.Unpack(wireBytes)
+
+	if err != nil {
+		t.Fatalf("Error unpacking SVCBKeyValues: %s", err)
+	}
+
+	outStr := s.String()
+
+	if outStr != expectedStr {
+		t.Fatalf("SVCBKeyValues did not output expected string, actual value was: %s", outStr)
 	}
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,9 @@
+package dns
+
+import "encoding/binary"
+
+func HostToNetShort(i uint16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, i)
+	return b
+}


### PR DESCRIPTION
As discussed in #1489. The primary aim is to to provide an API for developers who just want to parse, encode and decode standalone service params, without reference to SVCB records. 

- Adds a new parser for Service Params in scan.go, which returns a new type SvcParams, which implements encoding and stringify methods for all service params. This is probably most useful for server-side developers who would have service params in a config file.
- SVCBKeyValues type which implements SvcParams has additional Unpack method allowing construction and manipulation from wire-encoded params. This is useful for client-side developers who would read service params from the wire and then manipulate them.
- I've added basic tests in scan_test.go, as this seemed the most appropriate place. Also there is a test in svcb_test.go for the Unpack method.