### PR TITLE
Return ErrBuf when records processed < actual records send by upstream

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -868,7 +868,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	if err == nil {
 		dns.Extra, _, err = unpackRRslice(int(dh.Arcount), msg, off)
 	}
-	if err == nil && int(dh.Arcount) > len(dns.Extra) {
+	if err == nil && int(dh.Arcount) != len(dns.Extra) {
 		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it

--- a/msg.go
+++ b/msg.go
@@ -852,15 +852,24 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	}
 
 	dns.Answer, off, err = unpackRRslice(int(dh.Ancount), msg, off)
+	if err == nil && int(dh.Ancount) > int(len(dns.Answer)) {
+		return ErrBuf
+	}
 	// The header counts might have been wrong so we need to update it
 	dh.Ancount = uint16(len(dns.Answer))
 	if err == nil {
 		dns.Ns, off, err = unpackRRslice(int(dh.Nscount), msg, off)
 	}
+	if err == nil && int(dh.Nscount) > int(len(dns.Ns)) {
+		return ErrBuf
+	}
 	// The header counts might have been wrong so we need to update it
 	dh.Nscount = uint16(len(dns.Ns))
 	if err == nil {
 		dns.Extra, _, err = unpackRRslice(int(dh.Arcount), msg, off)
+	}
+	if err == nil && int(dh.Arcount) > int(len(dns.Extra)) {
+		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it
 	dh.Arcount = uint16(len(dns.Extra))

--- a/msg.go
+++ b/msg.go
@@ -852,7 +852,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	}
 
 	dns.Answer, off, err = unpackRRslice(int(dh.Ancount), msg, off)
-	if err == nil && int(dh.Ancount) > int(len(dns.Answer)) {
+	if err == nil && int(dh.Ancount) > len(dns.Answer) {
 		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it
@@ -860,7 +860,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	if err == nil {
 		dns.Ns, off, err = unpackRRslice(int(dh.Nscount), msg, off)
 	}
-	if err == nil && int(dh.Nscount) > int(len(dns.Ns)) {
+	if err == nil && int(dh.Nscount) > (len(dns.Ns)) {
 		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it
@@ -868,7 +868,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	if err == nil {
 		dns.Extra, _, err = unpackRRslice(int(dh.Arcount), msg, off)
 	}
-	if err == nil && int(dh.Arcount) > int(len(dns.Extra)) {
+	if err == nil && int(dh.Arcount) > (len(dns.Extra)) {
 		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it

--- a/msg.go
+++ b/msg.go
@@ -860,7 +860,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	if err == nil {
 		dns.Ns, off, err = unpackRRslice(int(dh.Nscount), msg, off)
 	}
-	if err == nil && int(dh.Nscount) > (len(dns.Ns)) {
+	if err == nil && int(dh.Nscount) > len(dns.Ns) {
 		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it
@@ -868,7 +868,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	if err == nil {
 		dns.Extra, _, err = unpackRRslice(int(dh.Arcount), msg, off)
 	}
-	if err == nil && int(dh.Arcount) > (len(dns.Extra)) {
+	if err == nil && int(dh.Arcount) > len(dns.Extra) {
 		return ErrBuf
 	}
 	// The header counts might have been wrong so we need to update it

--- a/msg_test.go
+++ b/msg_test.go
@@ -324,3 +324,89 @@ func TestLenDynamicA(t *testing.T) {
 		}
 	}
 }
+
+func TestUnPackForErrBuf(t *testing.T) {
+	var testCases = []struct {
+		domainName   string
+		noOfARecords int
+		udpSize      uint16
+		expectErrBuf bool
+	}{
+		// Testing with 15 characters in the domain name.
+		// ----------------------------------------------------------------------------------------------------------------------
+		// Length of response for 15 A records will be 482 bytes and UDPSize is 512. Response is not truncated.
+		{domainName: "example123.org.", noOfARecords: 15, udpSize: 512, expectErrBuf: false},
+
+		// Length of response for 16 A records will be 512 bytes and UDPSize is 512. Response is not truncated.
+		{domainName: "example123.org.", noOfARecords: 16, udpSize: 512, expectErrBuf: false},
+
+		// Length of response for 17 A records will be 542 bytes and UDPSize is 512. Response is truncated, so expect ErrBuf.
+		{domainName: "example123.org.", noOfARecords: 17, udpSize: 512, expectErrBuf: true},
+
+		// Length of response for 17 A records will be 542 bytes and UDPSize is 542. Response is not truncated.
+		{domainName: "example123.org.", noOfARecords: 17, udpSize: 542, expectErrBuf: false},
+
+		// Testing with 19 characters in the domain name.
+		// ----------------------------------------------------------------------------------------------------------------------
+		// Length of response for 13 A records will be 478 bytes and UDPSize is 512. Response is not truncated.
+		{domainName: "testingexample.org.", noOfARecords: 13, udpSize: 512, expectErrBuf: false},
+
+		// Length of response for 14 A records will be 512 bytes and UDPSize is 512. Response is not truncated.
+		{domainName: "testingexample.org.", noOfARecords: 14, udpSize: 512, expectErrBuf: false},
+
+		// Length of response for 15 A records will be 546 bytes and UDPSize is 512. Response is truncated, so expect ErrBuf.
+		{domainName: "testingexample.org.", noOfARecords: 15, udpSize: 512, expectErrBuf: true},
+
+		// Length of response for 15 A records will be 546 bytes and UDPSize is 546. Response is not truncated.
+		{domainName: "testingexample.org.", noOfARecords: 15, udpSize: 546, expectErrBuf: false},
+	}
+
+	for _, tc := range testCases {
+		testName := tc.domainName + " with " + strconv.Itoa(tc.noOfARecords) + " A-records"
+		t.Run(testName, func(t *testing.T) {
+			testLongResponseDNSServer(t, tc.domainName, tc.noOfARecords, tc.udpSize, tc.expectErrBuf)
+		})
+	}
+}
+
+func testLongResponseDNSServer(t *testing.T, domainName string, noOfARecords int, UDPSize uint16, expectErrBuf bool) {
+	HandleFunc(domainName, HelloServerLargeResponse)
+	defer HandleRemove(domainName)
+
+	srv, address, _, err := RunLocalUDPServer(":0")
+	if err != nil {
+		t.Fatalf("unable to run test server: %v", err)
+	}
+	defer srv.Shutdown()
+
+	reqm := new(Msg)
+	reqm.SetQuestion(domainName, TypeA)
+
+	c := new(Client)
+	c.Net = "udp"
+	c.UDPSize = UDPSize
+
+	M.Lock()
+	M.max = noOfARecords
+	M.Unlock()
+
+	response := new(Msg)
+	response, _, err = c.Exchange(reqm, address)
+
+	if expectErrBuf {
+		if err != ErrBuf {
+			t.Error("Expected ErrBuf due to truncation")
+		}
+	} else {
+
+		if err != nil {
+			t.Errorf("failed to exchange: %v", err)
+		}
+		if len(response.Answer) != M.max {
+			t.Errorf("Expected no of A records %v, but got %v", len(response.Answer), M.max)
+		}
+		if response.Rcode != RcodeSuccess {
+			t.Errorf("Expected No error, but got %v", response.Rcode)
+		}
+	}
+}

--- a/msg_test.go
+++ b/msg_test.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -326,40 +327,67 @@ func TestLenDynamicA(t *testing.T) {
 }
 
 func TestUnPackForErrBuf(t *testing.T) {
-	HandleFunc("example123.org.", HelloServerLargeResponse)
-	defer HandleRemove("example123.org.")
+	var testCases = []struct {
+		domainName   string
+		noOfARecords int
+		expectErrBuf bool
+	}{
+		// Length of response for 15 A records will be 482 bytes and UDPSize is 512. Response is not truncated, so expect no error.
+		{domainName: "example123.org.", noOfARecords: 15, expectErrBuf: false},
 
-	srv, address, _, err := RunLocalUDPServer(":0")
+		// Length of response for 17 A records will be 542 bytes and UDPSize is 512. Response is truncated, so expect ErrBuf.
+		{domainName: "example123.org.", noOfARecords: 17, expectErrBuf: true},
+
+		// Length of response for 16 A records will be 512 bytes and UDPSize is 512. Response is not truncated, so expect no error.
+		{domainName: "example123.org.", noOfARecords: 16, expectErrBuf: false},
+	}
+	for _, tc := range testCases {
+		testName := tc.domainName + " with " + strconv.Itoa(tc.noOfARecords) + " A-records"
+		t.Run(testName, func(t *testing.T) {
+			testpackUnpack(t, tc.domainName, tc.noOfARecords, tc.expectErrBuf)
+		})
+	}
+}
+
+func testpackUnpack(t *testing.T, domainName string, noOfARecords int, expectErrBuf bool) {
+	m := new(Msg)
+	m.SetQuestion(domainName, TypeA)
+	m.Authoritative = true
+	rrHeader := RR_Header{
+		Name:   domainName,
+		Rrtype: TypeA,
+		Class:  ClassINET,
+		Ttl:    0,
+	}
+
+	m.Answer = make([]RR, noOfARecords)
+	for i := 0; i < noOfARecords; i++ {
+		ip := net.IPv4(127, 0, 0, byte(i+1))
+		aRec := &A{
+			Hdr: rrHeader,
+			A:   ip.To4(),
+		}
+		m.Answer[i] = aRec
+	}
+
+	packedmsg, err := m.Pack()
 	if err != nil {
-		t.Fatalf("unable to run test server: %v", err)
-	}
-	defer srv.Shutdown()
-
-	reqm := new(Msg)
-	reqm.SetQuestion("example123.org.", TypeA)
-	c := new(Client)
-	c.Net = "udp"
-
-	M.Lock()
-	M.max = 17 // Response is truncated, so expect ErrBuf.
-	M.Unlock()
-	response := new(Msg)
-	_, _, err = c.Exchange(reqm, address)
-	if err != ErrBuf {
-		t.Error("Expected ErrBuf due to truncation")
+		t.Fatalf("Pack failed for %v", err)
 	}
 
-	M.Lock()
-	M.max = 16 // Response is not truncated. so expect no error.
-	M.Unlock()
-	response, _, err = c.Exchange(reqm, address)
-	if err != nil {
-		t.Errorf("failed to exchange: %v", err)
+	// Default buffer size is 512 bytes for UDP.
+	if len(packedmsg) > MinMsgSize {
+		packedmsg = packedmsg[:MinMsgSize]
 	}
-	if len(response.Answer) != M.max {
-		t.Errorf("Expected no of A records %v, but got %v", M.max, len(response.Answer))
-	}
-	if response.Rcode != RcodeSuccess {
-		t.Errorf("Expected No error, but got %v", response.Rcode)
+
+	err = m.Unpack(packedmsg)
+	if expectErrBuf {
+		if err != ErrBuf {
+			t.Error("Expected ErrBuf due to truncation")
+		}
+	} else {
+		if err != nil {
+			t.Errorf("Expected no error, but got: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
This proposed PR is to address the bug outlined here - https://github.com/miekg/dns/issues/1492

Additional reference - https://github.com/coredns/coredns/pull/6371#discussion_r1374384048 

**Issue Description**
If there is a misbehaving upstream server which does not set TC bit and sends back a response length greater than pc.c.UDPSize or 512 default size, then there is a corner case where offset is equal to len(msg) as calculated in unpackHeader defined here github.com/miekg/msg_helpers.go. In this case, there is no Overflow/ErrBuff error returned, so the response will be truncated without TC bit set.

For example -

- When domain name has 15 characters, offset after unpackQuestion will be 32.
- Each loop adds 30 to offset and when number of A records in response is more than 15, then offset calculated in unpackRRslice will keep increasing in this sequence 62,92,122,152,182.....482,512
- In 16th loop, offset (32 question bytes + 30 * 16) == 512 which will be == len(msg) for default UDPsize, so in this case, there is no Overflow error returned.
- And the response will be truncated (ie response does not contain all the A records) and TC flag is false. This is a failure scenario.

Similarly,

- When domain name has 19 characters, offset after unpackQuestion will be 36.
- Each loop adds 34 to offset and when number of A records in response is more than 14, then offset calculated in unpackRRslice will keep increasing in this sequence 70,104,138,.....512
- In 14th loop, offset (36 question bytes + 34 * 14) == 512 which will be == len(msg) for default UDPsize, so in this case, there is no Overflow error returned.
- And the response will be truncated (ie response does not contain all the A records) and TC flag is false. This is a failure scenario.

```
As we can see, response is truncated and TC bit is false.
~----------------------------------------------------------------------------
kubectl exec dnsutils -- dig corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
; <<>> DiG 9.9.5-9+deb8u19-Debian <<>> corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 35567
;; flags: qr rd ra; QUERY: 1, ANSWER: 30, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;corednse2e.com. IN A

;; ANSWER SECTION:
corednse2e.com. 30 IN A 10.96.0.55
corednse2e.com. 30 IN A 10.96.0.51
corednse2e.com. 30 IN A 10.96.0.246
corednse2e.com. 30 IN A 10.96.0.93
corednse2e.com. 30 IN A 10.96.0.54
corednse2e.com. 30 IN A 10.96.0.97
corednse2e.com. 30 IN A 76.223.105.230
corednse2e.com. 30 IN A 10.96.0.98
corednse2e.com. 30 IN A 10.96.0.242
corednse2e.com. 30 IN A 10.96.0.50
corednse2e.com. 30 IN A 10.96.0.91
corednse2e.com. 30 IN A 10.96.0.96
corednse2e.com. 30 IN A 10.96.0.250
corednse2e.com. 30 IN A 10.96.0.252
corednse2e.com. 30 IN A 10.96.0.99
corednse2e.com. 30 IN A 10.96.0.248
corednse2e.com. 30 IN A 13.248.243.5
corednse2e.com. 30 IN A 10.96.0.254
corednse2e.com. 30 IN A 10.96.0.92
corednse2e.com. 30 IN A 10.96.0.249
corednse2e.com. 30 IN A 10.96.0.52
corednse2e.com. 30 IN A 10.96.0.251
corednse2e.com. 30 IN A 10.96.0.244
corednse2e.com. 30 IN A 10.96.0.53
corednse2e.com. 30 IN A 10.96.0.243
corednse2e.com. 30 IN A 10.96.0.247
corednse2e.com. 30 IN A 10.96.0.253
corednse2e.com. 30 IN A 10.96.0.255
corednse2e.com. 30 IN A 10.96.0.95
corednse2e.com. 30 IN A 10.96.0.94

;; Query time: 37 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Thu Oct 26 05:31:44 UTC 2023
;; MSG SIZE rcvd: 512

Whereas full response should have 64 records.
~----------------------------------------------------------------------------
kubectl exec dnsutils -- dig corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @168.63.129.16
; <<>> DiG 9.9.5-9+deb8u19-Debian <<>> corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @168.63.129.16
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 59586
;; flags: qr rd ra; QUERY: 1, ANSWER: 64, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;corednse2e.com. IN A

;; ANSWER SECTION:
corednse2e.com. 600 IN A 76.223.105.230
corednse2e.com. 600 IN A 13.248.243.5
corednse2e.com. 600 IN A 10.96.0.91
corednse2e.com. 600 IN A 10.96.0.92
corednse2e.com. 600 IN A 10.96.0.93
corednse2e.com. 600 IN A 10.96.0.94
corednse2e.com. 600 IN A 10.96.0.95
corednse2e.com. 600 IN A 10.96.0.96
corednse2e.com. 600 IN A 10.96.0.97
corednse2e.com. 600 IN A 10.96.0.98
corednse2e.com. 600 IN A 10.96.0.242
corednse2e.com. 600 IN A 10.96.0.243
corednse2e.com. 600 IN A 10.96.0.99
corednse2e.com. 600 IN A 10.96.0.244
corednse2e.com. 600 IN A 10.96.0.246
corednse2e.com. 600 IN A 10.96.0.247
corednse2e.com. 600 IN A 10.96.0.248
corednse2e.com. 600 IN A 10.96.0.249
corednse2e.com. 600 IN A 10.96.0.250
corednse2e.com. 600 IN A 10.96.0.251
corednse2e.com. 600 IN A 10.96.0.252
corednse2e.com. 600 IN A 10.96.0.253
corednse2e.com. 600 IN A 10.96.0.254
corednse2e.com. 600 IN A 10.96.0.255
corednse2e.com. 600 IN A 10.96.0.50
corednse2e.com. 600 IN A 10.96.0.51
corednse2e.com. 600 IN A 10.96.0.52
corednse2e.com. 600 IN A 10.96.0.53
corednse2e.com. 600 IN A 10.96.0.54
corednse2e.com. 600 IN A 10.96.0.55
corednse2e.com. 600 IN A 10.96.0.57
corednse2e.com. 600 IN A 10.96.0.58
corednse2e.com. 600 IN A 10.96.0.59
corednse2e.com. 600 IN A 10.96.0.60
corednse2e.com. 600 IN A 10.96.0.61
corednse2e.com. 600 IN A 10.96.0.62
corednse2e.com. 600 IN A 10.96.0.63
corednse2e.com. 600 IN A 10.96.0.64
corednse2e.com. 600 IN A 10.96.0.65
corednse2e.com. 600 IN A 10.96.0.66
corednse2e.com. 600 IN A 10.96.0.67
corednse2e.com. 600 IN A 10.96.0.68
corednse2e.com. 600 IN A 10.96.0.69
corednse2e.com. 600 IN A 10.96.0.70
corednse2e.com. 600 IN A 10.96.0.71
corednse2e.com. 600 IN A 10.96.0.72
corednse2e.com. 600 IN A 10.96.0.73
corednse2e.com. 600 IN A 10.96.0.74
corednse2e.com. 600 IN A 10.96.0.75
corednse2e.com. 600 IN A 10.96.0.76
corednse2e.com. 600 IN A 10.96.0.77
corednse2e.com. 600 IN A 10.96.0.78
corednse2e.com. 600 IN A 10.96.0.79
corednse2e.com. 600 IN A 10.96.0.80
corednse2e.com. 600 IN A 10.96.0.81
corednse2e.com. 600 IN A 10.96.0.82
corednse2e.com. 600 IN A 10.96.0.83
corednse2e.com. 600 IN A 10.96.0.84
corednse2e.com. 600 IN A 10.96.0.85
corednse2e.com. 600 IN A 10.96.0.86
corednse2e.com. 600 IN A 10.96.0.87
corednse2e.com. 600 IN A 10.96.0.88
corednse2e.com. 600 IN A 10.96.0.89
corednse2e.com. 600 IN A 10.96.0.90

;; Query time: 38 msec
;; SERVER: 168.63.129.16#53(168.63.129.16)
;; WHEN: Thu Oct 26 05:32:22 UTC 2023
;; MSG SIZE rcvd: 1056

With the proposed fix, below is the expected response.
~----------------------------------------------------------------------------
kubectl exec dnsutils -- dig corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
; <<>> DiG 9.9.5-9+deb8u19-Debian <<>> corednse2e.com +ignore +noedns +search +noshowsearch +time=10 +tries=6 @10.96.0.10
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 49592
;; flags: qr tc rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;corednse2e.com. IN A

;; Query time: 82 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Thu Oct 26 05:35:25 UTC 2023
;; MSG SIZE rcvd: 32
```