### PR TITLE
Simplify CanonicalName

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"unicode"
 )
 
 const hexDigit = "0123456789abcdef"
@@ -330,19 +329,15 @@ func Fqdn(s string) string {
 }
 
 // CanonicalName returns the domain name in canonical form. A name in canonical
-// form is lowercase and fully qualified. See Section 6.2 in RFC 4034.
-// According to the RFC all uppercase US-ASCII letters in the owner name of the
-// RR areeplaced by the corresponding lowercase US-ASCII letters.
+// form is lowercase and fully qualified. Only US-ASCII letters are affected. See
+// Section 6.2 in RFC 4034.
 func CanonicalName(s string) string {
-	var result strings.Builder
-	for _, ch := range s {
-		if unicode.IsUpper(ch) && (ch >= 0x00 && ch <= 0x7F) {
-			result.WriteRune(unicode.ToLower(ch))
-		} else {
-			result.WriteRune(ch)
+	return strings.Map(func(r rune) rune {
+		if r >= 'A' && r <= 'Z' {
+			r += 'a' - 'A'
 		}
-	}
-	return Fqdn(result.String())
+		return r
+	}, Fqdn(s))
 }
 
 // Copied from the official Go code.


### PR DESCRIPTION
This function was previously changed from using `strings.ToLower` to a custom loop to ensure it only lowercases ASCII characters. This was more complicated than it needed to be and introduced more allocations than is necessary.

Instead of that approach we call `strings.Map` with a simple ASCII lowercase mapping function. Sadly we still use the nice ASCII-only fast path that `strings.ToLower` had, but it's unlikely to be worth all the extra code.

Updates #1434
Updates #1470