### PR TITLE
Expose destination ip to ResponseWriter

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -36,6 +36,9 @@ type SessionUDP struct {
 // RemoteAddr returns the remote network address.
 func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
 
+// DestinationAddr returns the destination network address.
+func (s *SessionUDP) DestinationIP() net.IP { return parseDstFromOOB(s.context) }
+
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
 func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {


### PR DESCRIPTION
This PR will add a `DestinationIP` field to `ResponseWriter` interface.
It will allow downstream applications to have the ability to make decisions based on the destination of the request; Which is useful in situations that we have DNS server listening on more than one IP address.

Fixes #1411

PS: I'm new to go, so if there is somethings that are done badly, please let me know. Thanks.