### PR TITLE
Use strings.Builder in endingToString

### DIFF
--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1,7 +1,6 @@
 package dns
 
 import (
-	"bytes"
 	"encoding/base64"
 	"errors"
 	"net"
@@ -12,15 +11,15 @@ import (
 // A remainder of the rdata with embedded spaces, return the parsed string (sans the spaces)
 // or an error
 func endingToString(c *zlexer, errstr string) (string, *ParseError) {
-	var buffer bytes.Buffer
+	var s strings.Builder
 	l, _ := c.Next() // zString
 	for l.value != zNewline && l.value != zEOF {
 		if l.err {
-			return buffer.String(), &ParseError{"", errstr, l}
+			return s.String(), &ParseError{"", errstr, l}
 		}
 		switch l.value {
 		case zString:
-			buffer.WriteString(l.token)
+			s.WriteString(l.token)
 		case zBlank: // Ok
 		default:
 			return "", &ParseError{"", errstr, l}
@@ -28,7 +27,7 @@ func endingToString(c *zlexer, errstr string) (string, *ParseError) {
 		l, _ = c.Next()
 	}
 
-	return buffer.String(), nil
+	return s.String(), nil
 }
 
 // A remainder of the rdata with embedded spaces, split on unquoted whitespace


### PR DESCRIPTION
This will cause one less allocation as `String` allocates on a `bytes.Buffer` but not on a `strings.Builder`.