### PR TITLE
feat: add support for ReuseAddr

### DIFF
--- a/listen_no_reuseport.go
+++ b/listen_no_reuseport.go
@@ -7,16 +7,18 @@ import "net"
 
 const supportsReusePort = false
 
-func listenTCP(network, addr string, reuseport bool) (net.Listener, error) {
-	if reuseport {
+func listenTCP(network, addr string, reuseport, reuseaddr bool) (net.Listener, error) {
+	if reuseport || reuseaddr {
 		// TODO(tmthrgd): return an error?
 	}
 
 	return net.Listen(network, addr)
 }
 
-func listenUDP(network, addr string, reuseport bool) (net.PacketConn, error) {
-	if reuseport {
+const supportsReuseAddr = false
+
+func listenUDP(network, addr string, reuseport, reuseaddr bool) (net.PacketConn, error) {
+	if reuseport || reuseaddr {
 		// TODO(tmthrgd): return an error?
 	}
 

--- a/listen_reuseport.go
+++ b/listen_reuseport.go
@@ -25,19 +25,41 @@ func reuseportControl(network, address string, c syscall.RawConn) error {
 	return opErr
 }
 
-func listenTCP(network, addr string, reuseport bool) (net.Listener, error) {
+const supportsReuseAddr = true
+
+func reuseaddrControl(network, address string, c syscall.RawConn) error {
+	var opErr error
+	err := c.Control(func(fd uintptr) {
+		opErr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+	})
+	if err != nil {
+		return err
+	}
+
+	return opErr
+}
+
+func listenTCP(network, addr string, reuseport bool, reuseaddr bool) (net.Listener, error) {
 	var lc net.ListenConfig
-	if reuseport {
+	switch {
+	case reuseaddr && reuseport:
+	case reuseport:
 		lc.Control = reuseportControl
+	case reuseaddr:
+		lc.Control = reuseaddrControl
 	}
 
 	return lc.Listen(context.Background(), network, addr)
 }
 
-func listenUDP(network, addr string, reuseport bool) (net.PacketConn, error) {
+func listenUDP(network, addr string, reuseport bool, reuseaddr bool) (net.PacketConn, error) {
 	var lc net.ListenConfig
-	if reuseport {
+	switch {
+	case reuseaddr && reuseport:
+	case reuseport:
 		lc.Control = reuseportControl
+	case reuseaddr:
+		lc.Control = reuseaddrControl
 	}
 
 	return lc.ListenPacket(context.Background(), network, addr)

--- a/server.go
+++ b/server.go
@@ -226,6 +226,10 @@ type Server struct {
 	// Whether to set the SO_REUSEPORT socket option, allowing multiple listeners to be bound to a single address.
 	// It is only supported on certain GOOSes and when using ListenAndServe.
 	ReusePort bool
+	// Whether to set the SO_REUSEADDR socket option, allowing multiple listeners to be bound to a single address.
+	// Crucially this allows binding when an existing server is listening on `0.0.0.0` or `::`.
+	// It is only supported on certain GOOSes and when using ListenAndServe.
+	ReuseAddr bool
 	// AcceptMsgFunc will check the incoming message and will reject it early in the process.
 	// By default DefaultMsgAcceptFunc will be used.
 	MsgAcceptFunc MsgAcceptFunc
@@ -304,7 +308,7 @@ func (srv *Server) ListenAndServe() error {
 
 	switch srv.Net {
 	case "tcp", "tcp4", "tcp6":
-		l, err := listenTCP(srv.Net, addr, srv.ReusePort)
+		l, err := listenTCP(srv.Net, addr, srv.ReusePort, srv.ReuseAddr)
 		if err != nil {
 			return err
 		}
@@ -317,7 +321,7 @@ func (srv *Server) ListenAndServe() error {
 			return errors.New("dns: neither Certificates nor GetCertificate set in Config")
 		}
 		network := strings.TrimSuffix(srv.Net, "-tls")
-		l, err := listenTCP(network, addr, srv.ReusePort)
+		l, err := listenTCP(network, addr, srv.ReusePort, srv.ReuseAddr)
 		if err != nil {
 			return err
 		}
@@ -327,7 +331,7 @@ func (srv *Server) ListenAndServe() error {
 		unlock()
 		return srv.serveTCP(l)
 	case "udp", "udp4", "udp6":
-		l, err := listenUDP(srv.Net, addr, srv.ReusePort)
+		l, err := listenUDP(srv.Net, addr, srv.ReusePort, srv.ReuseAddr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add support for the `SO_REUSEADDR` socket option.
