### PR TITLE
Swap closing order in `inAxfr` and `inIxfr`

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -81,6 +81,9 @@ func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 func (t *Transfer) inAxfr(q *Msg, c chan *Envelope) {
 	first := true
 	defer func() {
+		// First close the connection, then the channel. This allows functions blocked on
+		// the channel to assume that the connection is closed and no further operations are
+		// pending when they resume.
 		t.Close()
 		close(c)
 	}()
@@ -134,6 +137,9 @@ func (t *Transfer) inIxfr(q *Msg, c chan *Envelope) {
 	n := 0
 	qser := q.Ns[0].(*SOA).Serial
 	defer func() {
+		// First close the connection, then the channel. This allows functions blocked on
+		// the channel to assume that the connection is closed and no further operations are
+		// pending when they resume.
 		t.Close()
 		close(c)
 	}()

--- a/xfr.go
+++ b/xfr.go
@@ -80,8 +80,10 @@ func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 
 func (t *Transfer) inAxfr(q *Msg, c chan *Envelope) {
 	first := true
-	defer t.Close()
-	defer close(c)
+	defer func() {
+		t.Close()
+		close(c)
+	}()
 	timeout := dnsTimeout
 	if t.ReadTimeout != 0 {
 		timeout = t.ReadTimeout
@@ -131,8 +133,10 @@ func (t *Transfer) inIxfr(q *Msg, c chan *Envelope) {
 	axfr := true
 	n := 0
 	qser := q.Ns[0].(*SOA).Serial
-	defer t.Close()
-	defer close(c)
+	defer func() {
+		t.Close()
+		close(c)
+	}()
 	timeout := dnsTimeout
 	if t.ReadTimeout != 0 {
 		timeout = t.ReadTimeout


### PR DESCRIPTION
This PR swaps the order in which the connections and channels are closed in `inAxfr` and `inIxfr`. This makes the order more logical (consumers of the channel can be sure that the connection has been closed when the channel is closed).

The motivation for changing this is a heisenbug we had in our test pipeline. After closing the channel, the test code checked if the connection had been closed as well. Due to the nature of go routines, the test would randomly fail, depending on the scheduler. Swapping the order eliminates the problem, putting both deferred calls into the same function may even give (a very slight) performance improvement and it makes the order of operations more predictable and logical.

If you have any questions or suggestions I'm happy to incorporate them.

-- Tim