### PR TITLE
IsDomainName: check for escape as last character

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -198,10 +198,12 @@ func IsDomainName(s string) (labels int, ok bool) {
 		off    int
 		begin  int
 		wasDot bool
+		escape bool
 	)
 	for i := 0; i < len(s); i++ {
 		switch s[i] {
 		case '\\':
+			escape = !escape
 			if off+1 > lenmsg {
 				return labels, false
 			}
@@ -217,6 +219,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 
 			wasDot = false
 		case '.':
+			escape = false
 			if i == 0 && len(s) > 1 {
 				// leading dots are not legal except for the root zone
 				return labels, false
@@ -243,10 +246,13 @@ func IsDomainName(s string) (labels int, ok bool) {
 			labels++
 			begin = i + 1
 		default:
+			escape = false
 			wasDot = false
 		}
 	}
-
+	if escape {
+		return labels, false
+	}
 	return labels, true
 }
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -359,6 +359,15 @@ func TestParseKnownRRAsRFC3597(t *testing.T) {
 	})
 }
 
+func TestParseOpenEscape(t *testing.T) {
+	if _, err := NewRR("example.net IN CNAME example.net."); err != nil {
+		t.Fatalf("expected no error, but got: %s", err)
+	}
+	if _, err := NewRR("example.net IN CNAME example.org\\"); err == nil {
+		t.Fatalf("expected an error, but got none")
+	}
+}
+
 func BenchmarkNewRR(b *testing.B) {
 	const name1 = "12345678901234567890123456789012345.12345678.123."
 	const s = name1 + " 3600 IN MX 10 " + name1


### PR DESCRIPTION
Keep track if the escape, if still true when returning isDomainName
should return false.

TODO:
- Should still be done in packDomainName as well.
- And that should be tested
- Some tests now fail

There are multiple other places that supposedly also check for this, but
they are not called in the parsing.

Fixes: #1528

Signed-off-by: Miek Gieben <miek@miek.nl>
