### PR TITLE
Fix counting of escape sequences when splitting TXT strings

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -1098,18 +1098,41 @@ func TestTXT(t *testing.T) {
 		}
 	}
 
-	// Test TXT record with chunk larger than 255 bytes, they should be split up, by the parser
-	s := ""
-	for i := 0; i < 255; i++ {
-		s += "a"
-	}
-	s += "b"
-	rr, err = NewRR(`test.local. 60 IN TXT "` + s + `"`)
+	// Test TXT record with string larger than 255 bytes that should be split
+	// up by the parser. Add some escape sequences too to ensure their length
+	// is counted correctly.
+	s := `"\;\\\120` + strings.Repeat("a", 255) + `b"`
+	rr, err = NewRR(`test.local. 60 IN TXT ` + s)
 	if err != nil {
 		t.Error("failed to parse empty-string TXT record", err)
 	}
-	if rr.(*TXT).Txt[1] != "b" {
-		t.Errorf("Txt should have two chunk, last one my be 'b', but is %s", rr.(*TXT).Txt[1])
+	if rr.(*TXT).Txt[1] != "aaab" {
+		t.Errorf("Txt should have two strings, last one must be 'aaab', but is %s", rr.(*TXT).Txt[1])
+	}
+	rrContent := strings.Replace(rr.String(), rr.Header().String(), "", 1)
+	expectedRRContent := `";\\x` + strings.Repeat("a", 252) + `" "aaab"`
+	if expectedRRContent != rrContent {
+		t.Errorf("Expected TXT RR content to be %#q but got %#q", expectedRRContent, rrContent)
+	}
+
+	// Test TXT record that is already split up into strings of len <= 255.
+	s = fmt.Sprintf(
+		"%q %q %q %q %q %q",
+		strings.Repeat(`a`, 255),
+		strings.Repeat("b", 255),
+		strings.Repeat("c", 255),
+		strings.Repeat("d", 0),
+		strings.Repeat("e", 1),
+		strings.Repeat("f", 123),
+	)
+	rr, err = NewRR(`test.local. 60 IN TXT ` + s)
+	if err != nil {
+		t.Error("failed to parse empty-string TXT record", err)
+	}
+	rrContent = strings.Replace(rr.String(), rr.Header().String(), "", 1)
+	expectedRRContent = s // same as input
+	if expectedRRContent != rrContent {
+		t.Errorf("Expected TXT RR content to be %#q but got %#q", expectedRRContent, rrContent)
 	}
 }
 

--- a/scan_test.go
+++ b/scan_test.go
@@ -427,3 +427,31 @@ func BenchmarkZoneParser(b *testing.B) {
 		}
 	}
 }
+
+func TestEscapedStringOffset(t *testing.T) {
+	var cases = []struct {
+		input          string
+		inputOffset    int
+		expectedOffset int
+	}{
+		{"simple string with no escape sequences", 20, 20},
+		{"simple string with no escape sequences", 500, -1},
+		{`\;\088\\\;\120\\`, 0, 0},
+		{`\;\088\\\;\120\\`, 1, 2},
+		{`\;\088\\\;\120\\`, 2, 6},
+		{`\;\088\\\;\120\\`, 3, 8},
+		{`\;\088\\\;\120\\`, 4, 10},
+		{`\;\088\\\;\120\\`, 5, 14},
+		{`\;\088\\\;\120\\`, 6, 16},
+		{`\;\088\\\;\120\\`, 7, -1},
+	}
+	for i, test := range cases {
+		outputOffset := escapedStringOffset(test.input, test.inputOffset)
+		if outputOffset != test.expectedOffset {
+			t.Errorf(
+				"Test %d (input %#q offset %d) returned offset %d but expected %d",
+				i, test.input, test.inputOffset, outputOffset, test.expectedOffset,
+			)
+		}
+	}
+}


### PR DESCRIPTION
`endingToTxtSlice`, used by TXT, SPF and a few other types, parses a string such as `"hello world"` from an RR's content in a zone file. These strings are limited to 255 characters, and `endingToTxtSlice` automatically splits them if they're longer than that. However, it didn't count the length correctly: escape sequences such as `\\` or `\123` were counted as multiple characters (2 and 4 respectively in these examples), but they should only count as one character because they represent a single byte in wire format (which is where this 255 character limit comes from). This commit fixes that.