### PR TITLE
Fix for IsDomainName length check issue

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -183,7 +183,7 @@ func IsDomainName(s string) (labels int, ok bool) {
 	// XXX: The logic in this function was copied from packDomainName and
 	// should be kept in sync with that function.
 
-	const lenmsg = 256
+	const lenmsg = 254
 
 	if len(s) == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return 0, false

--- a/labels_test.go
+++ b/labels_test.go
@@ -188,6 +188,7 @@ func TestIsDomainName(t *testing.T) {
 		"mi\\k.nl":               {true, 2},
 		longestDomain:            {true, 4},
 		longestUnprintableDomain: {true, 4},
+		domainTooLong:            {false, 3},
 	}
 	for d, ok := range names {
 		l, k := IsDomainName(d)

--- a/msg_test.go
+++ b/msg_test.go
@@ -26,6 +26,7 @@ var (
 	// These are the longest possible domain names in presentation format.
 	longestDomain            = maxPrintableLabel[:61] + strings.Join([]string{".", ".", ".", "."}, maxPrintableLabel)
 	longestUnprintableDomain = maxUnprintableLabel[:61*4] + strings.Join([]string{".", ".", ".", "."}, maxUnprintableLabel)
+	domainTooLong            = maxPrintableLabel[:62] + strings.Join([]string{".", ".", ".", "."}, maxPrintableLabel)
 )
 
 func TestPackNoSideEffect(t *testing.T) {


### PR DESCRIPTION
IsDomainName okays domain names 2 octets larger than the maximum allowed. [#1544](https://github.com/miekg/dns/issues/1544)