### PR TITLE
Update nsecx.go

### DIFF
--- a/nsecx.go
+++ b/nsecx.go
@@ -1,7 +1,7 @@
 package dns
 
 import (
-	"crypto/sha1"
+	"crypto/sha3"
 	"encoding/hex"
 	"strings"
 )
@@ -26,7 +26,7 @@ func HashName(label string, ha uint8, iter uint16, salt string) string {
 	}
 	name = name[:off]
 
-	s := sha1.New()
+	s := sha3.New512()
 	// k = 0
 	s.Write(name)
 	s.Write(wireSalt)


### PR DESCRIPTION
use sha3

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
