### PR TITLE
Update server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -111,7 +111,7 @@ func ListenAndServeTLS(addr, certFile, keyFile string, handler Handler) error {
 	}
 
 	config := tls.Config{
-		Certificates: []tls.Certificate{cert},
+		Certificates: []tls.Certificate{cert},  MinVersion: tls.VersionTLS12
 	}
 
 	server := &Server{


### PR DESCRIPTION
use TLS12 as a minimal version

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
