### PR TITLE
Set public key from private key in DNSKEY instead of copying it from DNSKEY to private key

### DIFF
--- a/dnssec_keyscan.go
+++ b/dnssec_keyscan.go
@@ -42,7 +42,11 @@ func (k *DNSKEY) ReadPrivateKey(q io.Reader, file string) (crypto.PrivateKey, er
 	if err != nil {
 		return nil, ErrPrivKey
 	}
-	if algo != k.Algorithm {
+
+	// if algorithm isn't set in dnskey, set it from loaded file
+	if k.Algorithm == 0 {
+		k.Algorithm = algo
+	} else if algo != k.Algorithm {
 		return nil, ErrKeyAlgMismatch
 	}
 	prevPublicKey := k.PublicKey

--- a/msg.go
+++ b/msg.go
@@ -48,27 +48,29 @@ const (
 
 // Errors defined in this package.
 var (
-	ErrAlg           error = &Error{err: "bad algorithm"}                  // ErrAlg indicates an error with the (DNSSEC) algorithm.
-	ErrAuth          error = &Error{err: "bad authentication"}             // ErrAuth indicates an error in the TSIG authentication.
-	ErrBuf           error = &Error{err: "buffer size too small"}          // ErrBuf indicates that the buffer used is too small for the message.
-	ErrConnEmpty     error = &Error{err: "conn has no connection"}         // ErrConnEmpty indicates a connection is being used before it is initialized.
-	ErrExtendedRcode error = &Error{err: "bad extended rcode"}             // ErrExtendedRcode ...
-	ErrFqdn          error = &Error{err: "domain must be fully qualified"} // ErrFqdn indicates that a domain name does not have a closing dot.
-	ErrId            error = &Error{err: "id mismatch"}                    // ErrId indicates there is a mismatch with the message's ID.
-	ErrKeyAlg        error = &Error{err: "bad key algorithm"}              // ErrKeyAlg indicates that the algorithm in the key is not valid.
-	ErrKey           error = &Error{err: "bad key"}
-	ErrKeySize       error = &Error{err: "bad key size"}
-	ErrLongDomain    error = &Error{err: fmt.Sprintf("domain name exceeded %d wire-format octets", maxDomainNameWireOctets)}
-	ErrNoSig         error = &Error{err: "no signature found"}
-	ErrPrivKey       error = &Error{err: "bad private key"}
-	ErrRcode         error = &Error{err: "bad rcode"}
-	ErrRdata         error = &Error{err: "bad rdata"}
-	ErrRRset         error = &Error{err: "bad rrset"}
-	ErrSecret        error = &Error{err: "no secrets defined"}
-	ErrShortRead     error = &Error{err: "short read"}
-	ErrSig           error = &Error{err: "bad signature"} // ErrSig indicates that a signature can not be cryptographically validated.
-	ErrSoa           error = &Error{err: "no SOA"}        // ErrSOA indicates that no SOA RR was seen when doing zone transfers.
-	ErrTime          error = &Error{err: "bad time"}      // ErrTime indicates a timing error in TSIG authentication.
+	ErrAlg            error = &Error{err: "bad algorithm"}                                // ErrAlg indicates an error with the (DNSSEC) algorithm.
+	ErrAuth           error = &Error{err: "bad authentication"}                           // ErrAuth indicates an error in the TSIG authentication.
+	ErrBuf            error = &Error{err: "buffer size too small"}                        // ErrBuf indicates that the buffer used is too small for the message.
+	ErrConnEmpty      error = &Error{err: "conn has no connection"}                       // ErrConnEmpty indicates a connection is being used before it is initialized.
+	ErrExtendedRcode  error = &Error{err: "bad extended rcode"}                           // ErrExtendedRcode ...
+	ErrFqdn           error = &Error{err: "domain must be fully qualified"}               // ErrFqdn indicates that a domain name does not have a closing dot.
+	ErrId             error = &Error{err: "id mismatch"}                                  // ErrId indicates there is a mismatch with the message's ID.
+	ErrKeyAlg         error = &Error{err: "bad key algorithm"}                            // ErrKeyAlg indicates that the algorithm in the key is not valid.
+	ErrKeyAlgMismatch error = &Error{err: "algorithm in file does not match key"}         // ErrKeyAlgMismatch indicates that the algorithm in the key doesn't match the loaded algorithm from file
+	ErrPubKeyMismatch error = &Error{err: "public key in file does not match public key"} // ErrPubKeyMismatch indicates that the public key in the key doesn't match the public key from the private key loaded from file
+	ErrKey            error = &Error{err: "bad key"}
+	ErrKeySize        error = &Error{err: "bad key size"}
+	ErrLongDomain     error = &Error{err: fmt.Sprintf("domain name exceeded %d wire-format octets", maxDomainNameWireOctets)}
+	ErrNoSig          error = &Error{err: "no signature found"}
+	ErrPrivKey        error = &Error{err: "bad private key"}
+	ErrRcode          error = &Error{err: "bad rcode"}
+	ErrRdata          error = &Error{err: "bad rdata"}
+	ErrRRset          error = &Error{err: "bad rrset"}
+	ErrSecret         error = &Error{err: "no secrets defined"}
+	ErrShortRead      error = &Error{err: "short read"}
+	ErrSig            error = &Error{err: "bad signature"} // ErrSig indicates that a signature can not be cryptographically validated.
+	ErrSoa            error = &Error{err: "no SOA"}        // ErrSOA indicates that no SOA RR was seen when doing zone transfers.
+	ErrTime           error = &Error{err: "bad time"}      // ErrTime indicates a timing error in TSIG authentication.
 )
 
 // Id by default returns a 16-bit random number to be used as a message id. The

--- a/parse_test.go
+++ b/parse_test.go
@@ -1331,13 +1331,15 @@ func TestNewPrivateKey(t *testing.T) {
 	ecdsapNewKey.Hdr.Ttl = 14400
 	ecdsapNewKey.Flags = 256
 	ecdsapNewKey.Protocol = 3
-	ecdsapNewKey.Algorithm = ECDSAP256SHA256
 	_, err = ecdsapNewKey.NewPrivateKey(ecdsapKey.PrivateKeyString(ecdsapPrivkey))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ecdsapNewKey.PublicKey != ecdsapKey.PublicKey {
 		t.Fatalf("PublicKey of new dnskey %s should match key in key loaded: %s", ecdsapNewKey.PublicKey, ecdsapKey.PublicKey)
+	}
+	if ecdsapNewKey.Algorithm != ECDSAP256SHA256 {
+		t.Fatalf("Algorithm of new dnskey %d is set to algorithm in key loaded", ecdsapNewKey.Algorithm)
 	}
 }
 


### PR DESCRIPTION
Previously when loading a PrivateKey into a DNSKEY we would return the PrivateKey with the PublicKey set from the DNSKEY struct. Now that behaviour is flipped and the PublicKey is taken from the PrivateKey and set in the DNSKEY.
