### PR TITLE
Fix (easy) linter warnings

### DIFF
--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1212,7 +1212,7 @@ func (rr *SSHFP) parse(c *zlexer, o string) *ParseError {
 	return nil
 }
 
-func (rr *DNSKEY) parseDNSKEY(c *zlexer, o, typ string) *ParseError {
+func (rr *DNSKEY) parseDNSKEY(c *zlexer, _, typ string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {
@@ -1430,7 +1430,7 @@ func (rr *GPOS) parse(c *zlexer, o string) *ParseError {
 	return slurpRemainder(c)
 }
 
-func (rr *DS) parseDS(c *zlexer, o, typ string) *ParseError {
+func (rr *DS) parseDS(c *zlexer, _, typ string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)
 	if e != nil || l.err {

--- a/server.go
+++ b/server.go
@@ -476,9 +476,6 @@ func (srv *Server) serveTCP(l net.Listener) error {
 			if !srv.isStarted() {
 				return nil
 			}
-			if neterr, ok := err.(net.Error); ok && neterr.Temporary() {
-				continue
-			}
 			return err
 		}
 		srv.lock.Lock()
@@ -534,9 +531,6 @@ func (srv *Server) serveUDP(l net.PacketConn) error {
 		if err != nil {
 			if !srv.isStarted() {
 				return nil
-			}
-			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
-				continue
 			}
 			return err
 		}


### PR DESCRIPTION
## Commits

### [Anonymize unused variable](https://github.com/miekg/dns/commit/21bc4017c313ce81ce89bde51d2368fd696729f6)

### [Remove use of deprecated net.Error.Temporary](https://github.com/miekg/dns/commit/625f7e9694edc0a1bb47f658c8a144bc9760f261)

net.Error.Temporary has been deprecated since Go 1.18. There
has been some discussion around what to use in server accept loops
instead [1], but the suggestion seems to be that it may be a mistake
to have any sort of retries in place [2].

This PR removes it, which may expose some users to errors that were
previously swallowed and retried, but at the expense of leaking file
descriptors and the like.

1: https://groups.google.com/g/golang-nuts/c/-JcZzOkyqYI/m/xwaZzjCgAwAJ?pli=1
2: https://groups.google.com/g/golang-nuts/c/-JcZzOkyqYI/m/vNNiVn_LAwAJ

## Discussion

I could add a staticcheck CI job if preferred. I intend to submit a fix for #1578 separately.