### PR TITLE
Add support for NXNAME type

### DIFF
--- a/types.go
+++ b/types.go
@@ -96,6 +96,7 @@ const (
 	TypeLP         uint16 = 107
 	TypeEUI48      uint16 = 108
 	TypeEUI64      uint16 = 109
+	TypeNXNAME     uint16 = 128
 	TypeURI        uint16 = 256
 	TypeCAA        uint16 = 257
 	TypeAVC        uint16 = 258
@@ -292,6 +293,19 @@ func (rr *NULL) String() string {
 
 func (*NULL) parse(c *zlexer, origin string) *ParseError {
 	return &ParseError{err: "NULL records do not have a presentation format"}
+}
+
+// NXNAME is a meta record. See https://www.iana.org/go/draft-ietf-dnsop-compact-denial-of-existence-04
+// Reference: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
+type NXNAME struct {
+	Hdr RR_Header
+	// Does not have any rdata
+}
+
+func (rr *NXNAME) String() string { return rr.Hdr.String() }
+
+func (*NXNAME) parse(c *zlexer, origin string) *ParseError {
+	return &ParseError{err: "NXNAME records do not have a presentation format"}
 }
 
 // CNAME RR. See RFC 1034.

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -886,6 +886,15 @@ func (r1 *NULL) isDuplicate(_r2 RR) bool {
 	return true
 }
 
+func (r1 *NXNAME) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*NXNAME)
+	if !ok {
+		return false
+	}
+	_ = r2
+	return true
+}
+
 func (r1 *NXT) isDuplicate(_r2 RR) bool {
 	r2, ok := _r2.(*NXT)
 	if !ok {

--- a/zmsg.go
+++ b/zmsg.go
@@ -706,6 +706,10 @@ func (rr *NULL) pack(msg []byte, off int, compression compressionMap, compress b
 	return off, nil
 }
 
+func (rr *NXNAME) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	return off, nil
+}
+
 func (rr *NXT) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packDomainName(rr.NextDomain, msg, off, compression, false)
 	if err != nil {
@@ -2263,6 +2267,13 @@ func (rr *NULL) unpack(msg []byte, off int) (off1 int, err error) {
 	if err != nil {
 		return off, err
 	}
+	return off, nil
+}
+
+func (rr *NXNAME) unpack(msg []byte, off int) (off1 int, err error) {
+	rdStart := off
+	_ = rdStart
+
 	return off, nil
 }
 

--- a/ztypes.go
+++ b/ztypes.go
@@ -60,6 +60,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeNSEC3:      func() RR { return new(NSEC3) },
 	TypeNSEC3PARAM: func() RR { return new(NSEC3PARAM) },
 	TypeNULL:       func() RR { return new(NULL) },
+	TypeNXNAME:     func() RR { return new(NXNAME) },
 	TypeNXT:        func() RR { return new(NXT) },
 	TypeOPENPGPKEY: func() RR { return new(OPENPGPKEY) },
 	TypeOPT:        func() RR { return new(OPT) },
@@ -146,6 +147,7 @@ var TypeToString = map[uint16]string{
 	TypeNSEC3:      "NSEC3",
 	TypeNSEC3PARAM: "NSEC3PARAM",
 	TypeNULL:       "NULL",
+	TypeNXNAME:     "NXNAME",
 	TypeNXT:        "NXT",
 	TypeNone:       "None",
 	TypeOPENPGPKEY: "OPENPGPKEY",
@@ -230,6 +232,7 @@ func (rr *NSEC) Header() *RR_Header       { return &rr.Hdr }
 func (rr *NSEC3) Header() *RR_Header      { return &rr.Hdr }
 func (rr *NSEC3PARAM) Header() *RR_Header { return &rr.Hdr }
 func (rr *NULL) Header() *RR_Header       { return &rr.Hdr }
+func (rr *NXNAME) Header() *RR_Header     { return &rr.Hdr }
 func (rr *NXT) Header() *RR_Header        { return &rr.Hdr }
 func (rr *OPENPGPKEY) Header() *RR_Header { return &rr.Hdr }
 func (rr *OPT) Header() *RR_Header        { return &rr.Hdr }
@@ -591,6 +594,11 @@ func (rr *NSEC3PARAM) len(off int, compression map[string]struct{}) int {
 func (rr *NULL) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
 	l += len(rr.Data)
+	return l
+}
+
+func (rr *NXNAME) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
 	return l
 }
 
@@ -1105,6 +1113,10 @@ func (rr *NSEC3PARAM) copy() RR {
 
 func (rr *NULL) copy() RR {
 	return &NULL{rr.Hdr, rr.Data}
+}
+
+func (rr *NXNAME) copy() RR {
+	return &NXNAME{rr.Hdr}
 }
 
 func (rr *NXT) copy() RR {


### PR DESCRIPTION
IANA har allocated the NXNAME meta type to indicate an NSEC/NSEC3 record signals that the name does not exist (corresponds to NXDOMAIN). NXNAME is a meta type only for use with NSEC/NSEC3 bitmaps and use is defined in https://datatracker.ietf.org/doc/draft-ietf-dnsop-compact-denial-of-existence/

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
