### PR TITLE
Remove use of deprecated net.Error.Temporary

### DIFF
--- a/server.go
+++ b/server.go
@@ -476,9 +476,6 @@ func (srv *Server) serveTCP(l net.Listener) error {
 			if !srv.isStarted() {
 				return nil
 			}
-			if neterr, ok := err.(net.Error); ok && neterr.Temporary() {
-				continue
-			}
 			return err
 		}
 		srv.lock.Lock()
@@ -534,9 +531,6 @@ func (srv *Server) serveUDP(l net.PacketConn) error {
 		if err != nil {
 			if !srv.isStarted() {
 				return nil
-			}
-			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
-				continue
 			}
 			return err
 		}


### PR DESCRIPTION
net.Error.Temporary has been deprecated since Go 1.18. There has been some discussion around what to use in server accept loops instead [1], but the suggestion seems to be that it may be a mistake to have any sort of retries in place [2].

This PR removes it, which may expose some users to errors that were previously swallowed and retried, but at the expense of leaking file descriptors and the like.

1: https://groups.google.com/g/golang-nuts/c/-JcZzOkyqYI/m/xwaZzjCgAwAJ?pli=1
2: https://groups.google.com/g/golang-nuts/c/-JcZzOkyqYI/m/vNNiVn_LAwAJ

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
