### PR TITLE
Annotate unpack* function errors with where the error happened.

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -871,7 +871,7 @@ func (dns *Msg) unpack(dh Header, msg []byte, off int) (err error) {
 	// TODO(miek) make this an error?
 	// use PackOpt to let people tell how detailed the error reporting should be?
 	// if off != len(msg) {
-	// 	// println("dns: extra bytes in dns packet", off, "<", len(msg))
+	//	// println("dns: extra bytes in dns packet", off, "<", len(msg))
 	// }
 	return err
 
@@ -1123,23 +1123,28 @@ func unpackQuestion(msg []byte, off int) (Question, int, error) {
 	)
 	q.Name, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return q, off, err
+		return q, off, fmt.Errorf("question.Name: %w", err)
 	}
 	if off == len(msg) {
 		return q, off, nil
 	}
 	q.Qtype, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return q, off, err
+		return q, off, fmt.Errorf("question.Qtype: %w", err)
 	}
 	if off == len(msg) {
 		return q, off, nil
 	}
 	q.Qclass, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return q, off, fmt.Errorf("question.Qclass: %w", err)
+	}
+
 	if off == len(msg) {
 		return q, off, nil
 	}
-	return q, off, err
+
+	return q, off, nil
 }
 
 func (dh *Header) pack(msg []byte, off int, compression compressionMap, compress bool) (int, error) {
@@ -1177,27 +1182,27 @@ func unpackMsgHdr(msg []byte, off int) (Header, int, error) {
 	)
 	dh.Id, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return dh, off, err
+		return dh, off, fmt.Errorf("header.Id: %w", err)
 	}
 	dh.Bits, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return dh, off, err
+		return dh, off, fmt.Errorf("header.Bits: %w", err)
 	}
 	dh.Qdcount, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return dh, off, err
+		return dh, off, fmt.Errorf("header.Qdcount: %w", err)
 	}
 	dh.Ancount, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return dh, off, err
+		return dh, off, fmt.Errorf("header.Ancount: %w", err)
 	}
 	dh.Nscount, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return dh, off, err
+		return dh, off, fmt.Errorf("header.Nscount: %w", err)
 	}
 	dh.Arcount, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return dh, off, err
+		return dh, off, fmt.Errorf("header.Arcount: %w", err)
 	}
 	return dh, off, nil
 }

--- a/msg_generate.go
+++ b/msg_generate.go
@@ -24,6 +24,7 @@ var packageHdr = `
 
 package dns
 
+import "fmt"
 `
 
 // getTypeStruct will take a type and the package scope, and return the
@@ -208,10 +209,15 @@ _ = rdStart
 		for i := 1; i < st.NumFields(); i++ {
 			o := func(s string) {
 				fmt.Fprintf(b, s, st.Field(i).Name())
-				fmt.Fprint(b, `if err != nil {
-return off, err
+
+				err_name := name
+				if name != st.Field(i).Name() {
+					err_name += "." + st.Field(i).Name()
+				}
+				fmt.Fprintf(b, `if err != nil {
+return off, fmt.Errorf("%s: %%w", err)
 }
-`)
+`, err_name)
 			}
 
 			// size-* are special, because they reference a struct member we should use for the length.

--- a/zmsg.go
+++ b/zmsg.go
@@ -2,6 +2,8 @@
 
 package dns
 
+import "fmt"
+
 // pack*() functions
 
 func (rr *A) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
@@ -1210,7 +1212,7 @@ func (rr *A) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.A, off, err = unpackDataA(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("A: %w", err)
 	}
 	return off, nil
 }
@@ -1221,7 +1223,7 @@ func (rr *AAAA) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.AAAA, off, err = unpackDataAAAA(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AAAA: %w", err)
 	}
 	return off, nil
 }
@@ -1232,14 +1234,14 @@ func (rr *AFSDB) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Subtype, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AFSDB.Subtype: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Hostname, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AFSDB.Hostname: %w", err)
 	}
 	return off, nil
 }
@@ -1250,14 +1252,14 @@ func (rr *AMTRELAY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Precedence, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AMTRELAY.Precedence: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.GatewayType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AMTRELAY.GatewayType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -1267,7 +1269,7 @@ func (rr *AMTRELAY) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.GatewayAddr, rr.GatewayHost, off, err = unpackIPSECGateway(msg, off, rr.GatewayType)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AMTRELAY.GatewayHost: %w", err)
 	}
 	return off, nil
 }
@@ -1285,7 +1287,7 @@ func (rr *APL) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Prefixes, off, err = unpackDataApl(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("APL.Prefixes: %w", err)
 	}
 	return off, nil
 }
@@ -1296,7 +1298,7 @@ func (rr *AVC) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("AVC.Txt: %w", err)
 	}
 	return off, nil
 }
@@ -1307,21 +1309,21 @@ func (rr *CAA) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Flag, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CAA.Flag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Tag, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CAA.Tag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Value, off, err = unpackStringOctet(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CAA.Value: %w", err)
 	}
 	return off, nil
 }
@@ -1332,28 +1334,28 @@ func (rr *CDNSKEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDNSKEY.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDNSKEY.Protocol: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDNSKEY.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDNSKEY.PublicKey: %w", err)
 	}
 	return off, nil
 }
@@ -1364,28 +1366,28 @@ func (rr *CDS) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDS.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDS.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDS.DigestType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CDS.Digest: %w", err)
 	}
 	return off, nil
 }
@@ -1396,28 +1398,28 @@ func (rr *CERT) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Type, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CERT.Type: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CERT.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CERT.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Certificate, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CERT.Certificate: %w", err)
 	}
 	return off, nil
 }
@@ -1428,7 +1430,7 @@ func (rr *CNAME) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CNAME.Target: %w", err)
 	}
 	return off, nil
 }
@@ -1439,21 +1441,21 @@ func (rr *CSYNC) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Serial, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CSYNC.Serial: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CSYNC.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("CSYNC.TypeBitMap: %w", err)
 	}
 	return off, nil
 }
@@ -1464,7 +1466,7 @@ func (rr *DHCID) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Digest, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DHCID.Digest: %w", err)
 	}
 	return off, nil
 }
@@ -1475,28 +1477,28 @@ func (rr *DLV) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DLV.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DLV.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DLV.DigestType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DLV.Digest: %w", err)
 	}
 	return off, nil
 }
@@ -1507,7 +1509,7 @@ func (rr *DNAME) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DNAME.Target: %w", err)
 	}
 	return off, nil
 }
@@ -1518,28 +1520,28 @@ func (rr *DNSKEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DNSKEY.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DNSKEY.Protocol: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DNSKEY.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DNSKEY.PublicKey: %w", err)
 	}
 	return off, nil
 }
@@ -1550,28 +1552,28 @@ func (rr *DS) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DS.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DS.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DS.DigestType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("DS.Digest: %w", err)
 	}
 	return off, nil
 }
@@ -1582,7 +1584,7 @@ func (rr *EID) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Endpoint, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("EID.Endpoint: %w", err)
 	}
 	return off, nil
 }
@@ -1593,7 +1595,7 @@ func (rr *EUI48) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Address, off, err = unpackUint48(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("EUI48.Address: %w", err)
 	}
 	return off, nil
 }
@@ -1604,7 +1606,7 @@ func (rr *EUI64) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Address, off, err = unpackUint64(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("EUI64.Address: %w", err)
 	}
 	return off, nil
 }
@@ -1615,7 +1617,7 @@ func (rr *GID) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Gid, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("GID.Gid: %w", err)
 	}
 	return off, nil
 }
@@ -1626,21 +1628,21 @@ func (rr *GPOS) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Longitude, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("GPOS.Longitude: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Latitude, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("GPOS.Latitude: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Altitude, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("GPOS.Altitude: %w", err)
 	}
 	return off, nil
 }
@@ -1651,14 +1653,14 @@ func (rr *HINFO) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Cpu, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HINFO.Cpu: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Os, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HINFO.Os: %w", err)
 	}
 	return off, nil
 }
@@ -1669,21 +1671,21 @@ func (rr *HIP) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.HitLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HIP.HitLength: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKeyAlgorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HIP.PublicKeyAlgorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKeyLength, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HIP.PublicKeyLength: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -1698,7 +1700,7 @@ func (rr *HIP) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.RendezvousServers, off, err = unpackDataDomainNames(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HIP.RendezvousServers: %w", err)
 	}
 	return off, nil
 }
@@ -1709,21 +1711,21 @@ func (rr *HTTPS) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HTTPS.Priority: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HTTPS.Target: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Value, off, err = unpackDataSVCB(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("HTTPS.Value: %w", err)
 	}
 	return off, nil
 }
@@ -1734,21 +1736,21 @@ func (rr *IPSECKEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Precedence, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("IPSECKEY.Precedence: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.GatewayType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("IPSECKEY.GatewayType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("IPSECKEY.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -1758,14 +1760,14 @@ func (rr *IPSECKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.GatewayAddr, rr.GatewayHost, off, err = unpackIPSECGateway(msg, off, rr.GatewayType)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("IPSECKEY.GatewayHost: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("IPSECKEY.PublicKey: %w", err)
 	}
 	return off, nil
 }
@@ -1776,14 +1778,14 @@ func (rr *ISDN) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Address, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("ISDN.Address: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.SubAddress, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("ISDN.SubAddress: %w", err)
 	}
 	return off, nil
 }
@@ -1794,28 +1796,28 @@ func (rr *KEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("KEY.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("KEY.Protocol: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("KEY.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("KEY.PublicKey: %w", err)
 	}
 	return off, nil
 }
@@ -1826,14 +1828,14 @@ func (rr *KX) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("KX.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Exchanger, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("KX.Exchanger: %w", err)
 	}
 	return off, nil
 }
@@ -1844,14 +1846,14 @@ func (rr *L32) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("L32.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Locator32, off, err = unpackDataA(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("L32.Locator32: %w", err)
 	}
 	return off, nil
 }
@@ -1862,14 +1864,14 @@ func (rr *L64) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("L64.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Locator64, off, err = unpackUint64(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("L64.Locator64: %w", err)
 	}
 	return off, nil
 }
@@ -1880,49 +1882,49 @@ func (rr *LOC) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Version, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.Version: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Size, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.Size: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.HorizPre, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.HorizPre: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.VertPre, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.VertPre: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Latitude, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.Latitude: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Longitude, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.Longitude: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Altitude, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LOC.Altitude: %w", err)
 	}
 	return off, nil
 }
@@ -1933,14 +1935,14 @@ func (rr *LP) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LP.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Fqdn, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("LP.Fqdn: %w", err)
 	}
 	return off, nil
 }
@@ -1951,7 +1953,7 @@ func (rr *MB) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Mb, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MB.Mb: %w", err)
 	}
 	return off, nil
 }
@@ -1962,7 +1964,7 @@ func (rr *MD) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Md, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MD.Md: %w", err)
 	}
 	return off, nil
 }
@@ -1973,7 +1975,7 @@ func (rr *MF) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Mf, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MF.Mf: %w", err)
 	}
 	return off, nil
 }
@@ -1984,7 +1986,7 @@ func (rr *MG) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Mg, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MG.Mg: %w", err)
 	}
 	return off, nil
 }
@@ -1995,14 +1997,14 @@ func (rr *MINFO) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Rmail, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MINFO.Rmail: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Email, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MINFO.Email: %w", err)
 	}
 	return off, nil
 }
@@ -2013,7 +2015,7 @@ func (rr *MR) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Mr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MR.Mr: %w", err)
 	}
 	return off, nil
 }
@@ -2024,14 +2026,14 @@ func (rr *MX) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MX.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Mx, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("MX.Mx: %w", err)
 	}
 	return off, nil
 }
@@ -2042,42 +2044,42 @@ func (rr *NAPTR) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Order, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NAPTR.Order: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NAPTR.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Flags, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NAPTR.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Service, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NAPTR.Service: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Regexp, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NAPTR.Regexp: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Replacement, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NAPTR.Replacement: %w", err)
 	}
 	return off, nil
 }
@@ -2088,14 +2090,14 @@ func (rr *NID) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NID.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.NodeID, off, err = unpackUint64(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NID.NodeID: %w", err)
 	}
 	return off, nil
 }
@@ -2106,7 +2108,7 @@ func (rr *NIMLOC) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Locator, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NIMLOC.Locator: %w", err)
 	}
 	return off, nil
 }
@@ -2117,7 +2119,7 @@ func (rr *NINFO) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.ZSData, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NINFO.ZSData: %w", err)
 	}
 	return off, nil
 }
@@ -2128,7 +2130,7 @@ func (rr *NS) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Ns, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NS.Ns: %w", err)
 	}
 	return off, nil
 }
@@ -2139,7 +2141,7 @@ func (rr *NSAPPTR) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Ptr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSAPPTR.Ptr: %w", err)
 	}
 	return off, nil
 }
@@ -2150,14 +2152,14 @@ func (rr *NSEC) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.NextDomain, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC.NextDomain: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC.TypeBitMap: %w", err)
 	}
 	return off, nil
 }
@@ -2168,28 +2170,28 @@ func (rr *NSEC3) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3.Hash: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Flags, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Iterations, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3.Iterations: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.SaltLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3.SaltLength: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2200,7 +2202,7 @@ func (rr *NSEC3) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.HashLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3.HashLength: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2211,7 +2213,7 @@ func (rr *NSEC3) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3.TypeBitMap: %w", err)
 	}
 	return off, nil
 }
@@ -2222,28 +2224,28 @@ func (rr *NSEC3PARAM) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3PARAM.Hash: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Flags, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3PARAM.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Iterations, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3PARAM.Iterations: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.SaltLength, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NSEC3PARAM.SaltLength: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2261,7 +2263,7 @@ func (rr *NULL) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Data, off, err = unpackStringAny(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NULL.Data: %w", err)
 	}
 	return off, nil
 }
@@ -2272,14 +2274,14 @@ func (rr *NXT) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.NextDomain, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NXT.NextDomain: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.TypeBitMap, off, err = unpackDataNsec(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("NXT.TypeBitMap: %w", err)
 	}
 	return off, nil
 }
@@ -2290,7 +2292,7 @@ func (rr *OPENPGPKEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("OPENPGPKEY.PublicKey: %w", err)
 	}
 	return off, nil
 }
@@ -2301,7 +2303,7 @@ func (rr *OPT) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Option, off, err = unpackDataOpt(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("OPT.Option: %w", err)
 	}
 	return off, nil
 }
@@ -2312,7 +2314,7 @@ func (rr *PTR) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Ptr, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("PTR.Ptr: %w", err)
 	}
 	return off, nil
 }
@@ -2323,21 +2325,21 @@ func (rr *PX) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("PX.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Map822, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("PX.Map822: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Mapx400, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("PX.Mapx400: %w", err)
 	}
 	return off, nil
 }
@@ -2348,7 +2350,7 @@ func (rr *RFC3597) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Rdata, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RFC3597.Rdata: %w", err)
 	}
 	return off, nil
 }
@@ -2359,28 +2361,28 @@ func (rr *RKEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Flags, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RKEY.Flags: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Protocol, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RKEY.Protocol: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RKEY.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.PublicKey, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RKEY.PublicKey: %w", err)
 	}
 	return off, nil
 }
@@ -2391,14 +2393,14 @@ func (rr *RP) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Mbox, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RP.Mbox: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Txt, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RP.Txt: %w", err)
 	}
 	return off, nil
 }
@@ -2409,63 +2411,63 @@ func (rr *RRSIG) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.TypeCovered, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.TypeCovered: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Labels, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.Labels: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.OrigTtl, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.OrigTtl: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Expiration, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.Expiration: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Inception, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.Inception: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.SignerName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.SignerName: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Signature, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RRSIG.Signature: %w", err)
 	}
 	return off, nil
 }
@@ -2476,14 +2478,14 @@ func (rr *RT) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Preference, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RT.Preference: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Host, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("RT.Host: %w", err)
 	}
 	return off, nil
 }
@@ -2494,63 +2496,63 @@ func (rr *SIG) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.TypeCovered, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.TypeCovered: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Labels, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.Labels: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.OrigTtl, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.OrigTtl: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Expiration, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.Expiration: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Inception, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.Inception: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.SignerName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.SignerName: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Signature, off, err = unpackStringBase64(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SIG.Signature: %w", err)
 	}
 	return off, nil
 }
@@ -2561,28 +2563,28 @@ func (rr *SMIMEA) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Usage, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SMIMEA.Usage: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Selector, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SMIMEA.Selector: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.MatchingType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SMIMEA.MatchingType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Certificate, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SMIMEA.Certificate: %w", err)
 	}
 	return off, nil
 }
@@ -2593,49 +2595,49 @@ func (rr *SOA) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Ns, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Ns: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Mbox, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Mbox: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Serial, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Serial: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Refresh, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Refresh: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Retry, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Retry: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Expire, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Expire: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Minttl, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SOA.Minttl: %w", err)
 	}
 	return off, nil
 }
@@ -2646,7 +2648,7 @@ func (rr *SPF) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SPF.Txt: %w", err)
 	}
 	return off, nil
 }
@@ -2657,28 +2659,28 @@ func (rr *SRV) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SRV.Priority: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Weight, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SRV.Weight: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Port, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SRV.Port: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SRV.Target: %w", err)
 	}
 	return off, nil
 }
@@ -2689,21 +2691,21 @@ func (rr *SSHFP) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SSHFP.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Type, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SSHFP.Type: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.FingerPrint, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SSHFP.FingerPrint: %w", err)
 	}
 	return off, nil
 }
@@ -2714,21 +2716,21 @@ func (rr *SVCB) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SVCB.Priority: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Target, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SVCB.Target: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Value, off, err = unpackDataSVCB(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("SVCB.Value: %w", err)
 	}
 	return off, nil
 }
@@ -2739,28 +2741,28 @@ func (rr *TA) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.KeyTag, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TA.KeyTag: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Algorithm, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TA.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.DigestType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TA.DigestType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TA.Digest: %w", err)
 	}
 	return off, nil
 }
@@ -2771,14 +2773,14 @@ func (rr *TALINK) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.PreviousName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TALINK.PreviousName: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.NextName, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TALINK.NextName: %w", err)
 	}
 	return off, nil
 }
@@ -2789,42 +2791,42 @@ func (rr *TKEY) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Algorithm, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Inception, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.Inception: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Expiration, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.Expiration: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Mode, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.Mode: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Error, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.Error: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.KeySize, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.KeySize: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2835,7 +2837,7 @@ func (rr *TKEY) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.OtherLen, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TKEY.OtherLen: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2853,28 +2855,28 @@ func (rr *TLSA) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Usage, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TLSA.Usage: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Selector, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TLSA.Selector: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.MatchingType, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TLSA.MatchingType: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Certificate, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TLSA.Certificate: %w", err)
 	}
 	return off, nil
 }
@@ -2885,28 +2887,28 @@ func (rr *TSIG) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Algorithm, off, err = UnpackDomainName(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.Algorithm: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.TimeSigned, off, err = unpackUint48(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.TimeSigned: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Fudge, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.Fudge: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.MACSize, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.MACSize: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2917,21 +2919,21 @@ func (rr *TSIG) unpack(msg []byte, off int) (off1 int, err error) {
 	}
 	rr.OrigId, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.OrigId: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Error, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.Error: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.OtherLen, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TSIG.OtherLen: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
@@ -2949,7 +2951,7 @@ func (rr *TXT) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("TXT.Txt: %w", err)
 	}
 	return off, nil
 }
@@ -2960,7 +2962,7 @@ func (rr *UID) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Uid, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("UID.Uid: %w", err)
 	}
 	return off, nil
 }
@@ -2971,7 +2973,7 @@ func (rr *UINFO) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Uinfo, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("UINFO.Uinfo: %w", err)
 	}
 	return off, nil
 }
@@ -2982,21 +2984,21 @@ func (rr *URI) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Priority, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("URI.Priority: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Weight, off, err = unpackUint16(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("URI.Weight: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Target, off, err = unpackStringOctet(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("URI.Target: %w", err)
 	}
 	return off, nil
 }
@@ -3007,7 +3009,7 @@ func (rr *X25) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.PSDNAddress, off, err = unpackString(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("X25.PSDNAddress: %w", err)
 	}
 	return off, nil
 }
@@ -3018,28 +3020,28 @@ func (rr *ZONEMD) unpack(msg []byte, off int) (off1 int, err error) {
 
 	rr.Serial, off, err = unpackUint32(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("ZONEMD.Serial: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Scheme, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("ZONEMD.Scheme: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Hash, off, err = unpackUint8(msg, off)
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("ZONEMD.Hash: %w", err)
 	}
 	if off == len(msg) {
 		return off, nil
 	}
 	rr.Digest, off, err = unpackStringHex(msg, off, rdStart+int(rr.Hdr.Rdlength))
 	if err != nil {
-		return off, err
+		return off, fmt.Errorf("ZONEMD.Digest: %w", err)
 	}
 	return off, nil
 }


### PR DESCRIPTION
Here's a first stab at the code for #1576 

This commit adds annotations to the error message when an error occurs during unpacking of a DNS message, the annotation will give detiail on where in the DNS message the unpacking error occured at. This helps to improve the debugability of such errors.
