### PR TITLE
Revert "Remove use of deprecated net.Error.Temporary (#1589)"

### DIFF
--- a/server.go
+++ b/server.go
@@ -476,6 +476,9 @@ func (srv *Server) serveTCP(l net.Listener) error {
 			if !srv.isStarted() {
 				return nil
 			}
+			if neterr, ok := err.(net.Error); ok && neterr.Temporary() {
+				continue
+			}
 			return err
 		}
 		srv.lock.Lock()
@@ -531,6 +534,9 @@ func (srv *Server) serveUDP(l net.PacketConn) error {
 		if err != nil {
 			if !srv.isStarted() {
 				return nil
+			}
+			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+				continue
 			}
 			return err
 		}


### PR DESCRIPTION
This reverts commit ef7392e4ff2ef86bea51ee4f32fc60eaf1c2a88a.

See:
https://github.com/miekg/dns/pull/1589#issuecomment-2276738695

breaks udp serving

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
