### PR TITLE
add decorate reader warning

### DIFF
--- a/server.go
+++ b/server.go
@@ -226,6 +226,7 @@ type Server struct {
 	// If NotifyStartedFunc is set it is called once the server has started listening.
 	NotifyStartedFunc func()
 	// DecorateReader is optional, allows customization of the process that reads raw DNS messages.
+	// The decorated reader must not mutate the data read from the conn.
 	DecorateReader DecorateReader
 	// DecorateWriter is optional, allows customization of the process that writes raw DNS messages.
 	DecorateWriter DecorateWriter


### PR DESCRIPTION
The bytes read from the reader are returned to a pool and
must not be changed by the decorated reader.

Fixes #1578