### PR TITLE
Fix string formatting issues

### DIFF
--- a/svcb_test.go
+++ b/svcb_test.go
@@ -57,7 +57,7 @@ func TestSVCB(t *testing.T) {
 			continue
 		}
 		if str := kv.String(); str != o.data {
-			t.Errorf("`%s' should be equal to\n`%s', but is     `%s'", o.key, o.data, str)
+			t.Errorf("`%s` should be equal to\n`%s`, but is     `%s`", o.key, o.data, str)
 		}
 	}
 }


### PR DESCRIPTION
There are some problems with the output of strings at present, for example:


```go
package main

import "fmt"

func main() {


	fmt.Printf("`%s' should be equal to\n`%s', but is     `%s'", "hello", "gopher", "golang")

	fmt.Println()
	fmt.Println()

	fmt.Printf("`%s` should be equal to\n`%s`, but is     `%s`", "hello", "gopher", "golang")

}
```

The output:

```
（The old：）
`hello' should be equal to
`gopher', but is     `golang'

（The new：）
`hello` should be equal to
`gopher`, but is     `golang`
```


The code in play.golang.org: https://go.dev/play/p/wmJ-8ZuHhSh