### PR TITLE
User Addition: add ZDNS as a user of miekg/dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A not-so-up-to-date-list-that-may-be-actually-current:
 * https://github.com/wintbiit/NineDNS
 * https://linuxcontainers.org/incus/
 * https://ifconfig.es
+* https://github.com/zmap/zdns
 
 
 Send pull request if you want to be listed here.


### PR DESCRIPTION
Hey miekg/dns maintainers!
I help manage the ZDNS fast DNS lookup utility and we use miekg/dns as our underlying dns library. Would love to add our project as a user in the `README.md`. Thanks for all your work!