### PR TITLE
Return error for empty CNAME target

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -185,6 +185,8 @@ func IsDomainName(s string) (labels int, ok bool) {
 
 	const lenmsg = 256
 
+	s = strings.TrimSpace(s)
+
 	if len(s) == 0 { // Ok, for instance when dealing with update RR without any rdata.
 		return 0, false
 	}

--- a/labels_test.go
+++ b/labels_test.go
@@ -176,6 +176,7 @@ func TestIsDomainName(t *testing.T) {
 		lab int
 	}
 	names := map[string]*ret{
+		"\n":                     {false, 0},
 		".":                      {true, 1},
 		"..":                     {false, 0},
 		"double-dot..test":       {false, 1},

--- a/scan_test.go
+++ b/scan_test.go
@@ -226,6 +226,19 @@ func TestZoneParserAddressAAAA(t *testing.T) {
 	}
 }
 
+func TestZoneParserCnameBad(t *testing.T) {
+	records := []string{
+		"1.bad.example.org. CNAME    ; bad cname",
+	}
+
+	for _, record := range records {
+		const expect = "bad CNAME"
+		if got, err := NewRR(record); err == nil || !strings.Contains(err.Error(), expect) {
+			t.Errorf("NewRR(%v) = %v, want err to contain %q", record, got, expect)
+		}
+	}
+}
+
 func TestZoneParserAddressBad(t *testing.T) {
 	records := []string{
 		"1.bad.example.org. 600 IN A ::1",


### PR DESCRIPTION
The current version will parse the target of `1.bad.example.org. CNAME    ; bad cname` as `\010.1.bad.example.org.`



