### PR TITLE
Add support for Compact Answers OK flag in EDNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 9461 - Service Binding Mapping for DNS Servers
 * 9462 - Discovery of Designated Resolvers
 * 9460 - SVCB and HTTPS Records
+* Draft - Compact Denial of Existence in DNSSEC
 
 ## Loosely Based Upon
 

--- a/edns_test.go
+++ b/edns_test.go
@@ -56,6 +56,39 @@ func TestOPTTtl(t *testing.T) {
 		t.Errorf("DO bit should be non-zero")
 	}
 
+	// CO (Compact ANswers OK) flag tests follow the same pattern as DO tests
+	// verify that invoking SetCo() sets CO=1
+	e.SetCo()
+	if !e.Co() {
+		t.Errorf("CO bit should be non-zero")
+	}
+
+	// verify that using SetCo(true) works when CO=1
+	e.SetCo(true)
+	if !e.Co() {
+		t.Errorf("CO bit should still be non-zero")
+	}
+	// verify that we can use SetCo(false) to set CO=0
+	e.SetCo(false)
+	if e.Co() {
+		t.Errorf("CO bit should be zero")
+	}
+	// verify that if we call SetCo(false) when CO=0 that it is unchanged
+	e.SetCo(false)
+	if e.Co() {
+		t.Errorf("CO bit should still be zero")
+	}
+	// verify that using SetCo(true) works for CO=0
+	e.SetCo(true)
+	if !e.Co() {
+		t.Errorf("CO bit should be non-zero")
+	}
+	// verify that using SetCo() works for CO=1
+	e.SetCo()
+	if !e.Co() {
+		t.Errorf("CO bit should be non-zero")
+	}
+
 	if e.Version() != 0 {
 		t.Errorf("version should be non-zero")
 	}
@@ -141,6 +174,7 @@ func TestZ(t *testing.T) {
 	e.Hdr.Rrtype = TypeOPT
 	e.SetVersion(8)
 	e.SetDo()
+	e.SetCo()
 	if e.Z() != 0 {
 		t.Errorf("expected Z of 0, got %d", e.Z())
 	}
@@ -149,8 +183,8 @@ func TestZ(t *testing.T) {
 		t.Errorf("expected Z of 5, got %d", e.Z())
 	}
 	e.SetZ(0xFFFF)
-	if e.Z() != 0x7FFF {
-		t.Errorf("expected Z of 0x7FFFF, got %d", e.Z())
+	if e.Z() != 0x3FFF {
+		t.Errorf("expected Z of 0x3FFFF, got %d", e.Z())
 	}
 	if e.Version() != 8 {
 		t.Errorf("expected version to still be 8, got %d", e.Version())


### PR DESCRIPTION
Compact Answers OK flag is a signal that a queryer or server understand and can validate Compact Denial of Existance answers allowing RCODE NXDOMAIN restoration with single NSEC/NSEC3.
Flag is allocated by IANA: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-13 Compact Denial of Existance: https://www.iana.org/go/draft-ietf-dnsop-compact-denial-of-existence-07

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
