### PR TITLE
Add RESINFO rr

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Example programs can be found in the `github.com/miekg/exdns` repository.
 * 9461 - Service Binding Mapping for DNS Servers
 * 9462 - Discovery of Designated Resolvers
 * 9460 - SVCB and HTTPS Records
+* 9606 - DNS Resolver Information
 * Draft - Compact Denial of Existence in DNSSEC
 
 ## Loosely Based Upon

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1620,6 +1620,16 @@ func (rr *NINFO) parse(c *zlexer, o string) *ParseError {
 	return nil
 }
 
+// Uses the same format as TXT
+func (rr *RESINFO) parse(c *zlexer, o string) *ParseError {
+	s, e := endingToTxtSlice(c, "bad RESINFO ")
+	if e != nil {
+		return e
+	}
+	rr.Txt = s
+	return nil
+}
+
 func (rr *URI) parse(c *zlexer, o string) *ParseError {
 	l, _ := c.Next()
 	i, e := strconv.ParseUint(l.token, 10, 16)

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -1622,7 +1622,7 @@ func (rr *NINFO) parse(c *zlexer, o string) *ParseError {
 
 // Uses the same format as TXT
 func (rr *RESINFO) parse(c *zlexer, o string) *ParseError {
-	s, e := endingToTxtSlice(c, "bad RESINFO ")
+	s, e := endingToTxtSlice(c, "bad RESINFO Resinfo")
 	if e != nil {
 		return e
 	}

--- a/types.go
+++ b/types.go
@@ -101,6 +101,7 @@ const (
 	TypeCAA        uint16 = 257
 	TypeAVC        uint16 = 258
 	TypeAMTRELAY   uint16 = 260
+	TypeRESINFO    uint16 = 261
 
 	TypeTKEY uint16 = 249
 	TypeTSIG uint16 = 250
@@ -1507,6 +1508,15 @@ func (rr *ZONEMD) String() string {
 		" " + strconv.Itoa(int(rr.Hash)) +
 		" " + rr.Digest
 }
+
+// RESINFO RR. See RFC 9606.
+
+type RESINFO struct {
+	Hdr RR_Header
+	Txt []string `dns:"txt"`
+}
+
+func (rr *RESINFO) String() string { return rr.Hdr.String() + sprintTxt(rr.Txt) }
 
 // APL RR. See RFC 3123.
 type APL struct {

--- a/zduplicate.go
+++ b/zduplicate.go
@@ -957,6 +957,23 @@ func (r1 *PX) isDuplicate(_r2 RR) bool {
 	return true
 }
 
+func (r1 *RESINFO) isDuplicate(_r2 RR) bool {
+	r2, ok := _r2.(*RESINFO)
+	if !ok {
+		return false
+	}
+	_ = r2
+	if len(r1.Txt) != len(r2.Txt) {
+		return false
+	}
+	for i := 0; i < len(r1.Txt); i++ {
+		if r1.Txt[i] != r2.Txt[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func (r1 *RFC3597) isDuplicate(_r2 RR) bool {
 	r2, ok := _r2.(*RFC3597)
 	if !ok {

--- a/zmsg.go
+++ b/zmsg.go
@@ -762,6 +762,14 @@ func (rr *PX) pack(msg []byte, off int, compression compressionMap, compress boo
 	return off, nil
 }
 
+func (rr *RESINFO) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packStringTxt(rr.Txt, msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
 func (rr *RFC3597) pack(msg []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
 	off, err = packStringHex(rr.Rdata, msg, off)
 	if err != nil {
@@ -2347,6 +2355,17 @@ func (rr *PX) unpack(msg []byte, off int) (off1 int, err error) {
 		return off, nil
 	}
 	rr.Mapx400, off, err = UnpackDomainName(msg, off)
+	if err != nil {
+		return off, err
+	}
+	return off, nil
+}
+
+func (rr *RESINFO) unpack(msg []byte, off int) (off1 int, err error) {
+	rdStart := off
+	_ = rdStart
+
+	rr.Txt, off, err = unpackStringTxt(msg, off)
 	if err != nil {
 		return off, err
 	}

--- a/ztypes.go
+++ b/ztypes.go
@@ -66,6 +66,7 @@ var TypeToRR = map[uint16]func() RR{
 	TypeOPT:        func() RR { return new(OPT) },
 	TypePTR:        func() RR { return new(PTR) },
 	TypePX:         func() RR { return new(PX) },
+	TypeRESINFO:    func() RR { return new(RESINFO) },
 	TypeRKEY:       func() RR { return new(RKEY) },
 	TypeRP:         func() RR { return new(RP) },
 	TypeRRSIG:      func() RR { return new(RRSIG) },
@@ -154,6 +155,7 @@ var TypeToString = map[uint16]string{
 	TypeOPT:        "OPT",
 	TypePTR:        "PTR",
 	TypePX:         "PX",
+	TypeRESINFO:    "RESINFO",
 	TypeRKEY:       "RKEY",
 	TypeRP:         "RP",
 	TypeRRSIG:      "RRSIG",
@@ -238,6 +240,7 @@ func (rr *OPENPGPKEY) Header() *RR_Header { return &rr.Hdr }
 func (rr *OPT) Header() *RR_Header        { return &rr.Hdr }
 func (rr *PTR) Header() *RR_Header        { return &rr.Hdr }
 func (rr *PX) Header() *RR_Header         { return &rr.Hdr }
+func (rr *RESINFO) Header() *RR_Header    { return &rr.Hdr }
 func (rr *RFC3597) Header() *RR_Header    { return &rr.Hdr }
 func (rr *RKEY) Header() *RR_Header       { return &rr.Hdr }
 func (rr *RP) Header() *RR_Header         { return &rr.Hdr }
@@ -619,6 +622,14 @@ func (rr *PX) len(off int, compression map[string]struct{}) int {
 	l += 2 // Preference
 	l += domainNameLen(rr.Map822, off+l, compression, false)
 	l += domainNameLen(rr.Mapx400, off+l, compression, false)
+	return l
+}
+
+func (rr *RESINFO) len(off int, compression map[string]struct{}) int {
+	l := rr.Hdr.len(off, compression)
+	for _, x := range rr.Txt {
+		l += len(x) + 1
+	}
 	return l
 }
 
@@ -1146,6 +1157,10 @@ func (rr *PX) copy() RR {
 		rr.Map822,
 		rr.Mapx400,
 	}
+}
+
+func (rr *RESINFO) copy() RR {
+	return &RESINFO{rr.Hdr, cloneSlice(rr.Txt)}
 }
 
 func (rr *RFC3597) copy() RR {


### PR DESCRIPTION
Adds the RESINFO rr type from [RFC 9606](https://www.rfc-editor.org/rfc/rfc9606.html) (DNS Resolver Information).

RESINFO uses the same format as TXT.