### PR TITLE
Avoid sendmsg control messages on darwin

### DIFF
--- a/udp.go
+++ b/udp.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !darwin
+// +build !windows,!darwin
 
 package dns
 

--- a/udp_no_control.go
+++ b/udp_no_control.go
@@ -1,8 +1,10 @@
-//go:build windows
-// +build windows
+//go:build windows || darwin
+// +build windows darwin
 
 // TODO(tmthrgd): Remove this Windows-specific code if go.dev/issue/7175 and
 //   go.dev/issue/7174 are ever fixed.
+
+// NOTICE(stek29): darwin supports PKTINFO in sendmsg, but it unbinds sockets, see https://github.com/miekg/dns/issues/724
 
 package dns
 


### PR DESCRIPTION
sendmsg with PKTINFO is broken on darwin, so don't use it

udp_windows is renamed to udp_no_control since it's no longer exlusive to windows, and is used on darwin too

fixes #724 and #941