### PR TITLE
Fix logic in xfr ReadMsg + add test

### DIFF
--- a/xfr.go
+++ b/xfr.go
@@ -251,10 +251,13 @@ func (t *Transfer) ReadMsg() (*Msg, error) {
 	if err := m.Unpack(p); err != nil {
 		return nil, err
 	}
-	if ts, tp := m.IsTsig(), t.tsigProvider(); ts != nil && tp != nil {
+
+	if tp := t.tsigProvider(); tp != nil {
 		// Need to work on the original message p, as that was used to calculate the tsig.
 		err = TsigVerifyWithProvider(p, tp, t.tsigRequestMAC, t.tsigTimersOnly)
-		t.tsigRequestMAC = ts.MAC
+		if ts := m.IsTsig(); ts != nil {
+			t.tsigRequestMAC = ts.MAC
+		}
 	}
 	return m, err
 }


### PR DESCRIPTION
Hi! 

This fixes a possible bug where a xfr client can skip tsig validation if the server doesn't respond with a tsig. 

Say I setup an xfr client with a tsig provider. If it connects to a server which doesn't implement tsig, but that server can perform a transfer without adding the tsig to the response then the current logic will skip validation. 

`m.IsTsig() && t.tsigProvider()` is going to look for the tsig in the message, see none and consider the transfer valid, but I think the client should be checking the signature since the tsig provider is configured on the client.