### PR TITLE
Fix Msg.Len calculation when an RR contains a padded base64 string

### DIFF
--- a/length_test.go
+++ b/length_test.go
@@ -33,9 +33,12 @@ func TestMsgCompressLength(t *testing.T) {
 	name1 := "12345678901234567890123456789012345.12345678.123."
 	rrA := testRR(name1 + " 3600 IN A 192.0.2.1")
 	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
+	rrSig := testRR(name1 + " 3600 IN RRSIG A 13 3 3600 20151021000000 20151020000000 12345 12345678.123. 6AF6rwhRrx9cPGptdWkkCZLWwpff+WQ2HvHw8ahhkcyagHD4udi5WQrmOsCg28sAtbd2brTUyOwsrlGjpLHJGA==")
 	tests := []*Msg{
 		makeMsg(name1, []RR{rrA}, nil, nil),
-		makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)}
+		makeMsg(name1, []RR{rrMx, rrMx}, nil, nil),
+		makeMsg(name1, []RR{rrA, rrSig}, nil, nil),
+	}
 
 	for _, msg := range tests {
 		predicted := msg.Len()
@@ -43,7 +46,7 @@ func TestMsgCompressLength(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if predicted < len(buf) {
+		if predicted != len(buf) {
 			t.Errorf("predicted compressed length is wrong: predicted %s (len=%d) %d, actual %d",
 				msg.Question[0].Name, len(msg.Answer), predicted, len(buf))
 		}
@@ -53,7 +56,6 @@ func TestMsgCompressLength(t *testing.T) {
 func TestMsgLength(t *testing.T) {
 	makeMsg := func(question string, ans, ns, e []RR) *Msg {
 		msg := new(Msg)
-		msg.Compress = true
 		msg.SetQuestion(Fqdn(question), TypeANY)
 		msg.Answer = append(msg.Answer, ans...)
 		msg.Ns = append(msg.Ns, ns...)
@@ -64,9 +66,12 @@ func TestMsgLength(t *testing.T) {
 	name1 := "12345678901234567890123456789012345.12345678.123."
 	rrA := testRR(name1 + " 3600 IN A 192.0.2.1")
 	rrMx := testRR(name1 + " 3600 IN MX 10 " + name1)
+	rrSig := testRR(name1 + " 3600 IN RRSIG A 13 3 3600 20151021000000 20151020000000 12345 12345678.123. 6AF6rwhRrx9cPGptdWkkCZLWwpff+WQ2HvHw8ahhkcyagHD4udi5WQrmOsCg28sAtbd2brTUyOwsrlGjpLHJGA==")
 	tests := []*Msg{
 		makeMsg(name1, []RR{rrA}, nil, nil),
-		makeMsg(name1, []RR{rrMx, rrMx}, nil, nil)}
+		makeMsg(name1, []RR{rrMx, rrMx}, nil, nil),
+		makeMsg(name1, []RR{rrA, rrSig}, nil, nil),
+	}
 
 	for _, msg := range tests {
 		predicted := msg.Len()
@@ -74,9 +79,9 @@ func TestMsgLength(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		if predicted < len(buf) {
-			t.Errorf("predicted length is wrong: predicted %s (len=%d), actual %d",
-				msg.Question[0].Name, predicted, len(buf))
+		if predicted != len(buf) {
+			t.Errorf("predicted length is wrong: predicted %s (len=%d) %d, actual %d",
+				msg.Question[0].Name, len(msg.Answer), predicted, len(buf))
 		}
 	}
 }

--- a/msg_helpers.go
+++ b/msg_helpers.go
@@ -168,6 +168,16 @@ func fromBase64(s []byte) (buf []byte, err error) {
 
 func toBase64(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
 
+// base64StringDecodedLen returns the exact length in bytes of the decoded data
+// represented by the base64 string s.
+func base64StringDecodedLen(s string) int {
+	n := len(s)
+	for n > 0 && s[n-1] == '=' {
+		n--
+	}
+	return n * 3 / 4
+}
+
 // dynamicUpdate returns true if the Rdlength is zero.
 func noRdata(h RR_Header) bool { return h.Rdlength == 0 }
 

--- a/types_generate.go
+++ b/types_generate.go
@@ -34,7 +34,6 @@ var packageHdr = `
 package dns
 
 import (
-	"encoding/base64"
 	"net"
 )
 
@@ -205,7 +204,7 @@ func main() {
 			case strings.HasPrefix(st.Tag(i), `dns:"size-base64`):
 				fallthrough
 			case st.Tag(i) == `dns:"base64"`:
-				o("l += base64.StdEncoding.DecodedLen(len(rr.%s))\n")
+				o("l += base64StringDecodedLen(rr.%s)\n")
 			case strings.HasPrefix(st.Tag(i), `dns:"size-hex:`): // this has an extra field where the length is stored
 				o("l += len(rr.%s)/2\n")
 			case st.Tag(i) == `dns:"hex"`:

--- a/ztypes.go
+++ b/ztypes.go
@@ -3,7 +3,6 @@
 package dns
 
 import (
-	"encoding/base64"
 	"net"
 )
 
@@ -338,7 +337,7 @@ func (rr *CERT) len(off int, compression map[string]struct{}) int {
 	l += 2 // Type
 	l += 2 // KeyTag
 	l++    // Algorithm
-	l += base64.StdEncoding.DecodedLen(len(rr.Certificate))
+	l += base64StringDecodedLen(rr.Certificate)
 	return l
 }
 
@@ -350,7 +349,7 @@ func (rr *CNAME) len(off int, compression map[string]struct{}) int {
 
 func (rr *DHCID) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += base64.StdEncoding.DecodedLen(len(rr.Digest))
+	l += base64StringDecodedLen(rr.Digest)
 	return l
 }
 
@@ -365,7 +364,7 @@ func (rr *DNSKEY) len(off int, compression map[string]struct{}) int {
 	l += 2 // Flags
 	l++    // Protocol
 	l++    // Algorithm
-	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
+	l += base64StringDecodedLen(rr.PublicKey)
 	return l
 }
 
@@ -423,7 +422,7 @@ func (rr *HIP) len(off int, compression map[string]struct{}) int {
 	l++    // PublicKeyAlgorithm
 	l += 2 // PublicKeyLength
 	l += len(rr.Hit) / 2
-	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
+	l += base64StringDecodedLen(rr.PublicKey)
 	for _, x := range rr.RendezvousServers {
 		l += domainNameLen(x, off+l, compression, false)
 	}
@@ -443,7 +442,7 @@ func (rr *IPSECKEY) len(off int, compression map[string]struct{}) int {
 	case IPSECGatewayHost:
 		l += len(rr.GatewayHost) + 1
 	}
-	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
+	l += base64StringDecodedLen(rr.PublicKey)
 	return l
 }
 
@@ -607,7 +606,7 @@ func (rr *NXNAME) len(off int, compression map[string]struct{}) int {
 
 func (rr *OPENPGPKEY) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
-	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
+	l += base64StringDecodedLen(rr.PublicKey)
 	return l
 }
 
@@ -644,7 +643,7 @@ func (rr *RKEY) len(off int, compression map[string]struct{}) int {
 	l += 2 // Flags
 	l++    // Protocol
 	l++    // Algorithm
-	l += base64.StdEncoding.DecodedLen(len(rr.PublicKey))
+	l += base64StringDecodedLen(rr.PublicKey)
 	return l
 }
 
@@ -665,7 +664,7 @@ func (rr *RRSIG) len(off int, compression map[string]struct{}) int {
 	l += 4 // Inception
 	l += 2 // KeyTag
 	l += domainNameLen(rr.SignerName, off+l, compression, false)
-	l += base64.StdEncoding.DecodedLen(len(rr.Signature))
+	l += base64StringDecodedLen(rr.Signature)
 	return l
 }
 


### PR DESCRIPTION
The `RR.len` functions use `base64.StdEncoding.DecodedLen` to obtain the length of a base64 string field.

Per `base64.StdEncoding.DecodedLen`'s documentation:
> DecodedLen returns the maximum length in bytes of the decoded data

Unfortunately, that function does not account for padding characters.

This PR replaces the use of that function with one that calculates the exact length of the decoded data, and adds some tests to prove that.