### PR TITLE
Golangci fixes

### DIFF
--- a/labels.go
+++ b/labels.go
@@ -66,10 +66,7 @@ func CompareDomainName(s1, s2 string) (n int) {
 	} else {
 		return
 	}
-	for {
-		if i1 < 0 || i2 < 0 {
-			break
-		}
+	for i1 < 0 || i2 < 0 {
 		if equal(s1[l1[i1]:l1[j1]], s2[l2[i2]:l2[j2]]) {
 			n++
 		} else {

--- a/scan_rr.go
+++ b/scan_rr.go
@@ -519,15 +519,16 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 		return &ParseError{err: "bad NAPTR Flags", lex: l}
 	}
 	l, _ = c.Next() // Either String or Quote
-	if l.value == zString {
+	switch l.value {
+	case zString:
 		rr.Flags = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
 			return &ParseError{err: "bad NAPTR Flags", lex: l}
 		}
-	} else if l.value == zQuote {
+	case zQuote:
 		rr.Flags = ""
-	} else {
+	default:
 		return &ParseError{err: "bad NAPTR Flags", lex: l}
 	}
 
@@ -538,15 +539,16 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 		return &ParseError{err: "bad NAPTR Service", lex: l}
 	}
 	l, _ = c.Next() // Either String or Quote
-	if l.value == zString {
+	switch l.value {
+	case zString:
 		rr.Service = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
 			return &ParseError{err: "bad NAPTR Service", lex: l}
 		}
-	} else if l.value == zQuote {
+	case zQuote:
 		rr.Service = ""
-	} else {
+	default:
 		return &ParseError{err: "bad NAPTR Service", lex: l}
 	}
 
@@ -557,15 +559,16 @@ func (rr *NAPTR) parse(c *zlexer, o string) *ParseError {
 		return &ParseError{err: "bad NAPTR Regexp", lex: l}
 	}
 	l, _ = c.Next() // Either String or Quote
-	if l.value == zString {
+	switch l.value {
+	case zString:
 		rr.Regexp = l.token
 		l, _ = c.Next() // _QUOTE
 		if l.value != zQuote {
 			return &ParseError{err: "bad NAPTR Regexp", lex: l}
 		}
-	} else if l.value == zQuote {
+	case zQuote:
 		rr.Regexp = ""
-	} else {
+	default:
 		return &ParseError{err: "bad NAPTR Regexp", lex: l}
 	}
 
@@ -1303,7 +1306,7 @@ func (rr *AMTRELAY) parse(c *zlexer, o string) *ParseError {
 	c.Next() // zBlank
 
 	l, _ = c.Next()
-	if l.err || !(l.token == "0" || l.token == "1") {
+	if l.err || (l.token != "0" && l.token != "1") {
 		return &ParseError{err: "bad discovery value", lex: l}
 	}
 	if l.token == "1" {

--- a/server.go
+++ b/server.go
@@ -480,7 +480,7 @@ func (srv *Server) serveTCP(l net.Listener) error {
 			if !srv.isStarted() {
 				return nil
 			}
-			if neterr, ok := err.(net.Error); ok && neterr.Temporary() {
+			if neterr, ok := err.(net.Error); ok && neterr.Timeout() {
 				continue
 			}
 			return err
@@ -539,7 +539,7 @@ func (srv *Server) serveUDP(l net.PacketConn) error {
 			if !srv.isStarted() {
 				return nil
 			}
-			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 				continue
 			}
 			return err

--- a/server.go
+++ b/server.go
@@ -719,7 +719,7 @@ func (srv *Server) readUDP(conn *net.UDPConn, timeout time.Duration) ([]byte, *S
 	m := srv.udpPool.Get().([]byte)
 	n, s, err := ReadFromSessionUDP(conn, m)
 	if err != nil {
-		srv.udpPool.Put(m)
+		srv.udpPool.Put(&m)
 		return nil, nil, err
 	}
 	m = m[:n]
@@ -737,7 +737,7 @@ func (srv *Server) readPacketConn(conn net.PacketConn, timeout time.Duration) ([
 	m := srv.udpPool.Get().([]byte)
 	n, addr, err := conn.ReadFrom(m)
 	if err != nil {
-		srv.udpPool.Put(m)
+		srv.udpPool.Put(&m)
 		return nil, nil, err
 	}
 	m = m[:n]


### PR DESCRIPTION
* Minor golanci code improvements
 
    Tidy up the following.
 
        labels.go:70:3: QF1006: could lift into loop condition (staticcheck)
        scan_rr.go:522:2: QF1003: could use tagged switch on l.value (staticcheck)
        scan_rr.go:541:2: QF1003: could use tagged switch on l.value (staticcheck)
        scan_rr.go:560:2: QF1003: could use tagged switch on l.value (staticcheck)
        scan_rr.go:1306:14: QF1001: could apply De Morgan's law (staticcheck)
 
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>

* Avoid couple allocations when reading packages
    
    Inspired by golangci-lint that gives few 'SA6002: argument should be
    pointer-like to avoid allocations' outputs. Remaining warnings are about
    slices used via indexes, and such things cannot be addressed via pointer.
    
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>

* Avoid using deprecated socket error check
    
    Advised by golangci-lint:
    
        SA1019: neterr.Temporary has been deprecated since Go 1.18 because
        it shouldn't be used: Temporary errors are not well-defined. Most
        "temporary" errors are timeouts, and the few exceptions are
        surprising. Do not use this method.
    
    Signed-off-by: Sami Kerola <kerolasa@cloudflare.com>
