### PR TITLE
Don't cache IdleTimeout for TCP connections

### DIFF
--- a/server.go
+++ b/server.go
@@ -572,11 +572,6 @@ func (srv *Server) serveTCPConn(wg *sync.WaitGroup, rw net.Conn) {
 		reader = srv.DecorateReader(reader)
 	}
 
-	idleTimeout := tcpIdleTimeout
-	if srv.IdleTimeout != nil {
-		idleTimeout = srv.IdleTimeout()
-	}
-
 	timeout := srv.getReadTimeout()
 
 	limit := srv.MaxTCPQueries
@@ -599,7 +594,10 @@ func (srv *Server) serveTCPConn(wg *sync.WaitGroup, rw net.Conn) {
 		}
 		// The first read uses the read timeout, the rest use the
 		// idle timeout.
-		timeout = idleTimeout
+		timeout = tcpIdleTimeout
+		if srv.IdleTimeout != nil {
+			timeout = srv.IdleTimeout()
+		}
 	}
 
 	if !w.hijacked {


### PR DESCRIPTION
In DNS Stateful Operations, after a session is established, timeout is a dynamic value negotiated between the server and client.

Thanks for you pull request, do note the following:

* If your PR introduces backward incompatible changes it will very likely not be merged.

* We support the last two major Go versions, if your PR uses features from a too new Go version, it
    will not be merged.
