### PR TITLE
Fix tsig fqdn misleadig error

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -10,6 +10,11 @@ TSIG, EDNS0, dynamic updates, notifies and DNSSEC validation/signing.
 Note that domain names MUST be fully qualified before sending them, unqualified
 names in a message will result in a packing failure.
 
+Note that domain names, including those used as TSIG key names, MUST be fully qualified before
+sending them. Unqualified names in a message will result in a packing failure.
+To ensure full qualification, the dns.Fqdn() function can be used to normalize domain names
+by appending a trailing dot if one is not already present.
+
 Resource records are native types. They are not stored in wire format. Basic
 usage pattern for creating a new resource record:
 
@@ -164,6 +169,15 @@ The supported algorithms include: HmacSHA1, HmacSHA256 and HmacSHA512.
 Basic use pattern when querying with a TSIG name "axfr." (note that these key names
 must be fully qualified - as they are domain names) and the base64 secret
 "so6ZGir4GPAqINNh9U5c3A==":
+
+It is recommended to use the dns.Fqdn() function to ensure that the TSIG key name
+is fully qualified. This guarantees that the key name is treated correctly by the
+DNS system, avoiding unintended interpretation as a relative name.
+
+For example:
+c.TsigSecret = map[string]string{dns.Fqdn(TSIGKeyName): TSIGSecret}
+This approach not only ensures compliance with DNS standards but also simplifies
+key name management.
 
 If an incoming message contains a TSIG record it MUST be the last record in
 the additional section (RFC2845 3.2).  This means that you should make the

--- a/msg.go
+++ b/msg.go
@@ -48,14 +48,14 @@ const (
 
 // Errors defined in this package.
 var (
-	ErrAlg           error = &Error{err: "bad algorithm"}                                  // ErrAlg indicates an error with the (DNSSEC) algorithm.
-	ErrAuth          error = &Error{err: "bad authentication"}                             // ErrAuth indicates an error in the TSIG authentication.
-	ErrBuf           error = &Error{err: "buffer size too small"}                          // ErrBuf indicates that the buffer used is too small for the message.
-	ErrConnEmpty     error = &Error{err: "conn has no connection"}                         // ErrConnEmpty indicates a connection is being used before it is initialized.
-	ErrExtendedRcode error = &Error{err: "bad extended rcode"}                             // ErrExtendedRcode ...
-	ErrFqdn          error = &Error{err: "domain and/or TSIG key must be fully qualified"} // ErrFqdn indicates that a domain name or TSIG key name does not have a closing dot.
-	ErrId            error = &Error{err: "id mismatch"}                                    // ErrId indicates there is a mismatch with the message's ID.
-	ErrKeyAlg        error = &Error{err: "bad key algorithm"}                              // ErrKeyAlg indicates that the algorithm in the key is not valid.
+	ErrAlg           error = &Error{err: "bad algorithm"}                                       // ErrAlg indicates an error with the (DNSSEC) algorithm.
+	ErrAuth          error = &Error{err: "bad authentication"}                                  // ErrAuth indicates an error in the TSIG authentication.
+	ErrBuf           error = &Error{err: "buffer size too small"}                               // ErrBuf indicates that the buffer used is too small for the message.
+	ErrConnEmpty     error = &Error{err: "conn has no connection"}                              // ErrConnEmpty indicates a connection is being used before it is initialized.
+	ErrExtendedRcode error = &Error{err: "bad extended rcode"}                                  // ErrExtendedRcode ...
+	ErrFqdn          error = &Error{err: "domain and/or TSIG key name must be fully qualified"} // ErrFqdn indicates that a domain name or TSIG key name does not have a closing dot.
+	ErrId            error = &Error{err: "id mismatch"}                                         // ErrId indicates there is a mismatch with the message's ID.
+	ErrKeyAlg        error = &Error{err: "bad key algorithm"}                                   // ErrKeyAlg indicates that the algorithm in the key is not valid.
 	ErrKey           error = &Error{err: "bad key"}
 	ErrKeySize       error = &Error{err: "bad key size"}
 	ErrLongDomain    error = &Error{err: fmt.Sprintf("domain name exceeded %d wire-format octets", maxDomainNameWireOctets)}

--- a/msg.go
+++ b/msg.go
@@ -48,14 +48,14 @@ const (
 
 // Errors defined in this package.
 var (
-	ErrAlg           error = &Error{err: "bad algorithm"}                  // ErrAlg indicates an error with the (DNSSEC) algorithm.
-	ErrAuth          error = &Error{err: "bad authentication"}             // ErrAuth indicates an error in the TSIG authentication.
-	ErrBuf           error = &Error{err: "buffer size too small"}          // ErrBuf indicates that the buffer used is too small for the message.
-	ErrConnEmpty     error = &Error{err: "conn has no connection"}         // ErrConnEmpty indicates a connection is being used before it is initialized.
-	ErrExtendedRcode error = &Error{err: "bad extended rcode"}             // ErrExtendedRcode ...
-	ErrFqdn          error = &Error{err: "domain must be fully qualified"} // ErrFqdn indicates that a domain name does not have a closing dot.
-	ErrId            error = &Error{err: "id mismatch"}                    // ErrId indicates there is a mismatch with the message's ID.
-	ErrKeyAlg        error = &Error{err: "bad key algorithm"}              // ErrKeyAlg indicates that the algorithm in the key is not valid.
+	ErrAlg           error = &Error{err: "bad algorithm"}                                  // ErrAlg indicates an error with the (DNSSEC) algorithm.
+	ErrAuth          error = &Error{err: "bad authentication"}                             // ErrAuth indicates an error in the TSIG authentication.
+	ErrBuf           error = &Error{err: "buffer size too small"}                          // ErrBuf indicates that the buffer used is too small for the message.
+	ErrConnEmpty     error = &Error{err: "conn has no connection"}                         // ErrConnEmpty indicates a connection is being used before it is initialized.
+	ErrExtendedRcode error = &Error{err: "bad extended rcode"}                             // ErrExtendedRcode ...
+	ErrFqdn          error = &Error{err: "domain and/or TSIG key must be fully qualified"} // ErrFqdn indicates that a domain name or TSIG key name does not have a closing dot.
+	ErrId            error = &Error{err: "id mismatch"}                                    // ErrId indicates there is a mismatch with the message's ID.
+	ErrKeyAlg        error = &Error{err: "bad key algorithm"}                              // ErrKeyAlg indicates that the algorithm in the key is not valid.
 	ErrKey           error = &Error{err: "bad key"}
 	ErrKeySize       error = &Error{err: "bad key size"}
 	ErrLongDomain    error = &Error{err: fmt.Sprintf("domain name exceeded %d wire-format octets", maxDomainNameWireOctets)}


### PR DESCRIPTION
This change updates the `ErrFqdn` error message and comment to include a reference to TSIG key names with missing trailing dots, to let the user know that TSIG key names, like domain names, must be fully qualified. This resolves #1661.

<img width="1274" height="970" alt="fix-tsig-fqdn" src="https://github.com/user-attachments/assets/236a08a6-48e3-43f0-b9b5-9d010d420727" />
