### PR TITLE
Allow providing invalid counts to message

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -92,17 +92,18 @@ func id() uint16 {
 
 // MsgHdr is a a manually-unpacked version of (id, bits).
 type MsgHdr struct {
-	Id                 uint16
-	Response           bool
-	Opcode             int
-	Authoritative      bool
-	Truncated          bool
-	RecursionDesired   bool
-	RecursionAvailable bool
-	Zero               bool
-	AuthenticatedData  bool
-	CheckingDisabled   bool
-	Rcode              int
+	Id                                 uint16
+	Response                           bool
+	Opcode                             int
+	Authoritative                      bool
+	Truncated                          bool
+	RecursionDesired                   bool
+	RecursionAvailable                 bool
+	Zero                               bool
+	AuthenticatedData                  bool
+	CheckingDisabled                   bool
+	Rcode                              int
+	Qdcount, Ancount, Nscount, Arcount *uint16 `json:"-"` // Optional counts, may deviate from actual array lengths.
 }
 
 // Msg contains the layout of a DNS message.
@@ -777,10 +778,26 @@ func (dns *Msg) packBufferWithCompressionMap(buf []byte, compression compression
 		dh.Bits |= _CD
 	}
 
-	dh.Qdcount = uint16(len(dns.Question))
-	dh.Ancount = uint16(len(dns.Answer))
-	dh.Nscount = uint16(len(dns.Ns))
-	dh.Arcount = uint16(len(dns.Extra))
+	if dns.Qdcount != nil {
+		dh.Qdcount = *dns.Qdcount
+	} else {
+		dh.Qdcount = uint16(len(dns.Question))
+	}
+	if dns.Ancount != nil {
+		dh.Ancount = *dns.Ancount
+	} else {
+		dh.Ancount = uint16(len(dns.Answer))
+	}
+	if dns.Nscount != nil {
+		dh.Nscount = *dns.Nscount
+	} else {
+		dh.Nscount = uint16(len(dns.Ns))
+	}
+	if dns.Arcount != nil {
+		dh.Arcount = *dns.Arcount
+	} else {
+		dh.Arcount = uint16(len(dns.Extra))
+	}
 
 	// We need the uncompressed length here, because we first pack it and then compress it.
 	msg = buf


### PR DESCRIPTION
Hi! We're working on a protocol testing tool, and figured it would be good to allow providing invalid data in messages to verify that servers are behaving sanely in such situations. Most fields in the header can already be set to an incorrect value, but the RR counts are automatically determined, and can't be "faked" currently.

Let me know if this is something you'd consider merging! It should be fully backwards compatible as far as I can tell, and doesn't change default behaviour.