### PR TITLE
Support RFC 8490 DNS Stateful Operations (DSO) and RFC 8765 DNS Push Notifications

### DIFF
--- a/dso_msg.go
+++ b/dso_msg.go
@@ -1,0 +1,392 @@
+package dns
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+var (
+	ErrDSOMsg  = errors.New("bad DSO message")
+	ErrDSOData = ErrRdata
+
+	ErrDSOState   = errors.New("bad DSO state for the operation")
+	ErrDSOClosed  = fmt.Errorf("%w: closed", ErrDSOState)
+	ErrDSOPending = fmt.Errorf("%w: not established", ErrDSOState)
+)
+
+// DSOMsgHdr represents a DSO header.
+type DSOMsgHdr struct {
+	Id       uint16 // Message Id
+	Response bool
+	Opcode   int
+	Zero     uint16
+	Rcode    int
+}
+
+// DSOMsg represents a DSO message with its header.
+type DSOMsg struct {
+	DSOMsgHdr
+	// If true, the message will be compressed when converted to wire format.
+	Compress bool
+	Values   []DSOValue
+}
+
+// pack converts DSOMsgHdr to a wire format.
+func (h *DSOMsgHdr) pack(buf []byte, off int) (off1 int, err error) {
+	off, err = packUint16(h.Id, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	bits := uint16(h.Opcode)<<11 | uint16(h.Rcode&0xF) | (h.Zero&0x7F)<<4
+	if h.Response {
+		bits |= _QR
+	}
+	off, err = packUint16(bits, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	off, err = packUint64(0, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// String converts DSOMsgHdr to a string with dig-like headers:
+//
+// ;; opcode: STATEFUL, status: NOERROR, id: 48404
+//
+// ;; flags: qr;
+func (h *DSOMsgHdr) String() string {
+	if h == nil {
+		return "<nil> DSOMsgHdr"
+	}
+
+	s := ";; opcode: " + OpcodeToString[h.Opcode]
+	s += ", status: " + RcodeToString[h.Rcode]
+	s += ", id: " + strconv.Itoa(int(h.Id)) + "\n"
+
+	s += ";; flags:"
+	if h.Response {
+		s += " qr"
+	}
+
+	s += ";"
+	return s
+}
+
+// IsRequest returns true if DSOMsg is a request message.
+func (dso *DSOMsg) IsRequest() bool {
+	return !dso.Response && dso.Id != 0
+}
+
+// IsRequest returns true if DSOMsg is a unidirectional message.
+func (dso *DSOMsg) IsUnidirectional() bool {
+	return !dso.Response && dso.Id == 0
+}
+
+// IsRequest returns true if DSOMsg is a response message.
+func (dso *DSOMsg) IsResponse() bool {
+	return dso.Response && dso.Id != 0
+}
+
+// String converts DSOMsg to a string with dig-like output.
+func (dso *DSOMsg) String() string {
+	if dso == nil {
+		return "<nil> DSOMsgHdr"
+	}
+	s := dso.DSOMsgHdr.String() + " "
+	s += "TLV: " + strconv.Itoa(len(dso.Values)) + "\n"
+	if len(dso.Values) > 0 {
+		s += "\n;; TLV SECTION:\n"
+		for _, v := range dso.Values {
+			s += fmt.Sprintf("%s: %s\n", v.DSOType(), v.String())
+		}
+	}
+	return s
+}
+
+// isCompressible returns true if DSOMsg may be compressible.
+func (dso *DSOMsg) isCompressible() bool {
+	if len(dso.Values) == 0 {
+		return false
+	}
+	switch dso.Values[0].DSOType() {
+	case DSOType8765Push:
+		fallthrough
+	case DSOType8765Reconfirm:
+		return true
+	default:
+		return false
+	}
+}
+
+// Len calculates and returns DSOMsg length in an (un)compressed wire format.
+// If dso.Compress is true compression is taken into account.
+//
+// Len() is provided to be a faster way to get the size of the resulting packet, than packing
+// it, measuring the size and discarding the buffer.
+func (dso *DSOMsg) Len() int {
+	if dso.Compress && dso.isCompressible() {
+		compression := make(map[string]struct{})
+		return dso.lenWithCompressionMap(compression)
+	}
+	return dso.lenWithCompressionMap(nil)
+}
+
+func (dso *DSOMsg) lenWithCompressionMap(compression map[string]struct{}) int {
+	l := headerSize
+	for _, tlv := range dso.Values {
+		if tlv == nil {
+			continue
+		}
+		l += 2 // tlv type
+		l += 2 // tlv length
+		l += tlv.len(l, compression)
+	}
+	return l
+}
+
+// Pack converts DSOMsg to a wire format.
+func (dso *DSOMsg) Pack() ([]byte, error) {
+	return dso.PackBuffer(nil)
+}
+
+// PackBuffer converts DSOMsg to a wire format using the buffer.
+// If the buffer is too small a new buffer is allocated.
+func (dso *DSOMsg) PackBuffer(buf []byte) ([]byte, error) {
+	if dso.Rcode != OpcodeStateful {
+		return nil, ErrOpcode
+	}
+
+	compression, compress := compressionMap{}, false
+	if dso.Compress && dso.isCompressible() {
+		compression, compress = compressionMap{int: make(map[string]uint16)}, true
+	}
+
+	uncompressedLen := dso.lenWithCompressionMap(nil)
+	if packLen := uncompressedLen + 1; len(buf) < packLen {
+		buf = make([]byte, packLen)
+	}
+
+	off := 0
+	off, err := dso.DSOMsgHdr.pack(buf, off)
+	if err != nil {
+		return nil, err
+	}
+	for _, tlv := range dso.Values {
+		off, err = packDSOValue(tlv, buf, off, compression, compress)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return buf[:off], nil
+}
+
+// Unpack sets DSOMsg according to the wire format.
+func (dso *DSOMsg) Unpack(buf []byte) error {
+	dh, off, err := unpackMsgHdr(buf, 0)
+	if err != nil {
+		return err
+	}
+
+	// RFC 8490, Section 5.4: If ... any of the count fields are not zero, then a FORMERR MUST be returned.
+	if dh.Ancount != 0 || dh.Arcount != 0 || dh.Nscount != 0 || dh.Qdcount != 0 {
+		return ErrDSOData
+	}
+
+	dso.setHdr(dh)
+	if dso.Opcode != OpcodeStateful {
+		return ErrOpcode
+	}
+
+	return dso.unpack(dh, buf, off)
+}
+
+// unpack sets TLVs of DSOMsg according to the wire format.
+func (dso *DSOMsg) unpack(dh Header, buf []byte, off int) (err error) {
+	var tlv DSOValue
+	for off < len(buf) {
+		tlv, off, err = unpackDSOValue(buf, off)
+		if err != nil {
+			break
+		}
+		dso.Values = append(dso.Values, tlv)
+	}
+	return err
+}
+
+// Copy creates a deep-copy of DSOMsg.
+func (dso *DSOMsg) Copy() *DSOMsg { return dso.CopyTo(new(DSOMsg)) }
+
+// CopyTo deep-copies DSOMsg to the message and returns it.
+func (dso *DSOMsg) CopyTo(r1 *DSOMsg) *DSOMsg {
+	r1.DSOMsgHdr = dso.DSOMsgHdr
+	r1.Values = make([]DSOValue, len(dso.Values))
+	for i, tlv := range dso.Values {
+		r1.Values[i] = tlv.copy()
+	}
+	return r1
+}
+
+// Validate checks DSOMsg, including its TLVs, to be valid when composed on server (server = true)
+// or client (server = false)
+//
+// TLV specification may require that it's used only in messages of certain types,
+// only by a server or client, only at a certain index, exclusively or not, or any
+// combination of these. See RFC 8490, Section 8
+//
+//
+// Optionally, the request message can be passed to verify that DSOMsg is a valid response.
+//
+// Validation errors are fatal and must be followed up by forcibly closing the connection.
+func (dso *DSOMsg) Validate(server bool, req *DSOMsg) error {
+	// RFC 8490, Section 5.4.1: If a DSO response message (QR=1) is received where the
+	// MESSAGE ID is zero, this is a fatal error
+	if dso.Response && dso.Id == 0 {
+		return ErrId
+	}
+
+	if req != nil {
+		if !dso.Response {
+			return ErrResponse
+		}
+		if dso.Id != req.Id {
+			return ErrId
+		}
+	}
+
+	// RFC 8490, Section 5.4.2: A DSO request message or DSO unidirectional message
+	// MUST contain at least one TLV.
+	if !dso.Response && len(dso.Values) == 0 {
+		return fmt.Errorf("%w: missing primary tlv", ErrDSOData)
+	}
+
+	// RFC 8490, Section 3: in a DSO response, any TLVs with the same DSO-TYPE as
+	// the Primary TLV from the corresponding DSO request message. If present,
+	// any Response Primary TLV(s) MUST appear first in the DSO response message,
+	// before any Response Additional TLVs.
+	respPrimary := req != nil && len(dso.Values) > 0 && dso.Values[0].DSOType() == req.Values[0].DSOType()
+	for i, tlv := range dso.Values {
+		if respPrimary && i > 0 {
+			respPrimary = tlv.DSOType() == dso.Values[i-1].DSOType()
+		}
+		err := tlv.validate(server, dso, i, i == 0, respPrimary)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// setHdr sets DSOMsg header using data in dh.
+func (dso *DSOMsg) setHdr(dh Header) {
+	dso.Id = dh.Id
+	dso.Response = dh.Bits&_QR != 0
+	dso.Opcode = int(dh.Bits>>11) & 0xF
+	dso.Zero = dh.Bits & 0x7F0
+	dso.Rcode = int(dh.Bits & 0xF)
+}
+
+// SetUnidirectional sets DSOMsg to a unidirectional message.
+func (dso *DSOMsg) SetUnidirectional() *DSOMsg {
+	dso.Id = 0
+	dso.Response = false
+	dso.Opcode = OpcodeStateful
+	dso.Rcode = RcodeSuccess
+	return dso
+}
+
+// SetRequest sets DSOMsg to a request message with the ID.
+func (dso *DSOMsg) SetRequest(id uint16) *DSOMsg {
+	dso.Id = id
+	dso.Response = false
+	dso.Opcode = OpcodeStateful
+	dso.Rcode = RcodeSuccess
+	return dso
+}
+
+// SetResponse sets DSOMsg to a response message for the request.
+func (dso *DSOMsg) SetResponse(request *DSOMsg, rcode int) *DSOMsg {
+	dso.Id = request.Id
+	dso.Response = true
+	dso.Opcode = OpcodeStateful
+	dso.Rcode = RcodeSuccess
+	return dso
+}
+
+// SetClose sets DSOMsg to a graceful close unidirectional message.
+func (dso *DSOMsg) SetClose(retryDelay time.Duration, rcode int) *DSOMsg {
+	dso.SetUnidirectional()
+	dso.Rcode = rcode
+	dso.Values = []DSOValue{&DSORetryDelay{uint32(retryDelay.Milliseconds())}}
+	return dso
+}
+
+// packDSOValue creates wite format from the DSOValue.
+func packDSOValue(tlv DSOValue, buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	if tlv == nil {
+		return len(buf), fmt.Errorf("%w: nil tlv")
+	}
+
+	off, err = packUint16(uint16(tlv.DSOType()), buf, off)
+	if err != nil {
+		return off, ErrBuf
+	}
+
+	off, err = packUint16(0, buf, off)
+	if err != nil {
+		return off, ErrBuf
+	}
+	headerEnd := off
+
+	off, err = tlv.pack(buf, off, compression, compress)
+	if err != nil {
+		return off, err
+	}
+
+	vlength := off - headerEnd
+	if int(uint16(vlength)) != vlength { // overflow
+		return len(buf), ErrDSOData
+	}
+
+	// Set the DSO length field once wire length is known.
+	binary.BigEndian.PutUint16(buf[headerEnd-2:], uint16(vlength))
+	return off, nil
+}
+
+// unpackDSOValue creates DSOValue from the wire format.
+func unpackDSOValue(buf []byte, off int) (tlv DSOValue, off1 int, err error) {
+	vtype, off, err := unpackUint16(buf, off)
+	if err != nil {
+		return nil, len(buf), ErrBuf
+	}
+
+	vlen, off, err := unpackUint16(buf, off)
+	if err != nil {
+		return nil, len(buf), ErrBuf
+	}
+	end := off + int(vlen)
+	if end > len(buf) {
+		return nil, len(buf), fmt.Errorf("%w: bad DSO data length", ErrDSOData)
+	}
+
+	tlv = makeDSOValue(DSOType(vtype))
+	if tlv == nil {
+		return nil, end, fmt.Errorf("%w: bad DSO type %d", ErrDSOData, vtype)
+	}
+	if off, err = tlv.unpack(buf[:end], off); err != nil {
+		return nil, end, err
+	}
+	if off != end {
+		return nil, end, fmt.Errorf("%w: bad DSO data length", ErrDSOData)
+	}
+
+	return tlv, off, nil
+}

--- a/dso_server.go
+++ b/dso_server.go
@@ -1,0 +1,464 @@
+package dns
+
+/*
+Caveats:
+  - The requirement to abort when unexpected Primary TLV is included in a DSO message sent via
+    Early Data is not implemented because crypto/tls does allow to discern it from a regular read.
+*/
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// DSOHandler responds to a DSO message.
+type DSOHandler interface {
+	// Serve a DSO message.
+	// See RFC 8490 Sections 5.4 (specifically 5.4.5) and 5.5.
+	//
+	// DSOHandler.ServeDSO may write a response and, if appropriate, spawn a long lived operation.
+	// This call is blocking and the implementation should return as soon as possible. However,
+	// DSOResponseWriter can be retained for future unidirectional and request messages.
+	//
+	// Cancelation of the passed context signals that the handler should stop its long-lived operations.
+	ServeDSO(ctx context.Context, w DSOResponseWriter, m *DSOMsg)
+}
+
+// The DSOHandlerFunc type is an adapter to allow the use of ordinary functions
+// as DSO handlers. If f is a function with the appropriate signature, DSOHandlerFunc(f)
+// is a DSOHandler object that calls f.
+type DSOHandlerFunc func(context.Context, DSOResponseWriter, *DSOMsg)
+
+// ServeDSO implements DSOHandler.ServeDSO and calls f(ctx, w, r)
+func (f DSOHandlerFunc) ServeDSO(ctx context.Context, w DSOResponseWriter, m *DSOMsg) {
+	f(ctx, w, m)
+}
+
+// DSOSessionState is the list of states a DSOResponseWriter can take.
+type DSOSessionState uint32
+
+const (
+	// Waiting for a request to establish a session.
+	dsoSessionWaiting DSOSessionState = 0
+	// Received a request that may establish a session.
+	dsoSessionRequested DSOSessionState = 1 << iota
+	// In process of communicating result of the session establishment.
+	dsoSessionPending
+	// The session is successfully established.
+	DSOSessionEstablished
+	// CloseDSO was called and the server is waiting for the client to gracefully
+	// close the connection. New messages are not accepted.
+	// dsoSessionClosing
+	// The session is closed and not longer accepts new messages.
+	DSOSessionClosed
+)
+
+// DSOResponseWriter is an "upgraded" ResponseWriter that accepts DSO messages.
+type DSOResponseWriter interface {
+	ResponseWriter
+
+	// WaitDSOSession waits until the DSO session is either established or closed.
+	//
+	// A context may be passed to limit how long to wait for the session to reach the state.
+	// When cancelled, WaitDSOSession returns the context's error and the state value should
+	// be disregarded.
+	WaitDSOSession(ctx context.Context) (DSOSessionState, error)
+	// WriteDSOMsg writes a DSO message to the client.
+	//
+	// Before a DSO session is established only the DSO response message with Id that
+	// matches client's initial DSO request message is allowed.
+	//
+	// Returned ErrDSOMsg and ErrDSOState indicate that passed message is malformed or it's not valid
+	// for the current DSO state. Other values indicate a writing error.
+	WriteDSOMsg(m *DSOMsg) error
+	// CancelDSOMsg asks the client to cancel long-lived operation which it previously requested.
+	//
+	// See RFC 8490, Section 5.6
+	CancelDSOMsg(reqId uint16, rcode int) error
+	// CloseDSO asks the client to close the DSO session gracefully.
+	//
+	// See RFC 8490, Sections 6.6 and 7.2 for circumstances to call this method
+	// as well as for acceptable values of retryDelay.
+	CloseDSO(retryDelay time.Duration, rcode int) error
+	// AbortDSO forcibly closes the connection.
+	//
+	// Search RFC 8490 for "forcibly abort" for circumstances to call this method.
+	AbortDSO() error
+}
+
+type dsoSession struct {
+	sync.RWMutex
+	state DSOSessionState
+	// ctx is cancelled when the session is closed.
+	ctx    context.Context
+	cancel context.CancelFunc
+	// pendingCond is broadcasted on to signal that the session changed state from Pending.
+	pendingCond *sync.Cond
+	// establishedChan is closed to signal that the session is Established.
+	establishedChan chan struct{}
+	// DSO message id of the initial request to establish DSO session
+	initReqId uint16
+}
+
+// dsoresponse is an "upgraded" response that implements DSOResponseWriter.
+type dsoresponse struct {
+	*response
+
+	dso *dsoSession
+}
+
+var _ DSOResponseWriter = &dsoresponse{}
+
+func newDSOSession() *dsoSession {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &dsoSession{
+		ctx:             ctx,
+		cancel:          cancel,
+		establishedChan: make(chan struct{}),
+	}
+	s.pendingCond = sync.NewCond(s.RLocker())
+	return s
+}
+
+func newDSOResponse(w *response) *dsoresponse {
+	dsow := &dsoresponse{
+		response: w,
+		dso:      newDSOSession(),
+	}
+	return dsow
+}
+
+// WaitDSOSession implements the DSOResponseWriter.WaitDSOSession method.
+func (dsow *dsoresponse) WaitDSOSession(ctx context.Context) (DSOSessionState, error) {
+	select {
+	case <-dsow.dso.establishedChan:
+	case <-dsow.dso.ctx.Done():
+	case <-ctx.Done():
+		return dsow.dso.state, context.Cause(ctx)
+	}
+
+	dsow.dso.RLock()
+	defer dsow.dso.RUnlock()
+	switch dsow.dso.state {
+	case DSOSessionEstablished:
+		return DSOSessionEstablished, nil
+	case DSOSessionClosed:
+		return DSOSessionClosed, nil
+	default:
+		panic("dns: internal error: unexpected DSO state")
+	}
+}
+
+// WriteDSOMsg implements the DSOResponseWriter.WriteDSOMsg method.
+func (dsow *dsoresponse) WriteDSOMsg(m *DSOMsg) error {
+	buf, err := m.Pack()
+	if err != nil {
+		return errors.Join(ErrDSOMsg, err)
+	}
+
+	// We allow graceful close messages in states where any other message would be disallowed
+	// because we follow intent to close DSO session, rather than explicit desire to write bytes
+	// to the socket.
+	isCloseMsg := m.IsUnidirectional() && len(m.Values) > 0 && m.Values[0].DSOType() == DSOTypeRetryDelay
+
+	dsow.dso.Lock()
+	unlockOnce := sync.OnceFunc(dsow.dso.Unlock)
+	defer unlockOnce()
+	switch dsow.dso.state {
+	case dsoSessionWaiting:
+		if isCloseMsg {
+			dsow.closeSession()
+			return nil
+		}
+		return fmt.Errorf("%w: WriteDSOMsg is called before client requested session", ErrDSOPending)
+	case dsoSessionRequested:
+		// RFC 8490, Section 5.1.1
+		// - User wants to close DSO before it had a chance to establish and thus the RetryDelay
+		// unidirectional couldn't be sent. The client will eventually abort and either retry DSO
+		// or mark the server as not supporting DSO.
+		if isCloseMsg {
+			dsow.closeSession()
+			return nil
+		}
+
+		// RFC 8490, Section 5.1: a server MUST NOT initiate DSO request messages or DSO unidirectional
+		// messages until a DSO Session has been mutually established by at least one successful DSO
+		// request/response exchange initiated by the client.
+		if !m.IsResponse() {
+			return errors.Join(ErrDSOMsg, ErrResponse)
+		}
+
+		// RFC 8490, Section 5.1: A DSO Session is established over a connection by the client ...
+		// receiving a response with a matching MESSAGE ID ...
+		if  m.Id != dsow.dso.initReqId {
+			return errors.Join(ErrDSOMsg, ErrId)
+		}
+
+		dsow.pendingSession()
+	case dsoSessionPending:
+		return fmt.Errorf("%w: concurrent WriteDSOMsg before session is established", ErrDSOPending)
+	case DSOSessionEstablished:
+		// RFC 8490, Section 6.6.1.1: At the instant a server chooses to initiate a DSO Retry Delay
+		// message, there may be DNS requests already in flight from client to server on this
+		// DSO Session, which will arrive at the server after its DSO Retry Delay message has
+		// been sent.  The server MUST silently ignore such incoming requests and MUST NOT
+		// generate any response messages for them.
+		if isCloseMsg {
+			dsow.closeSession()
+		}
+	case DSOSessionClosed:
+		return ErrDSOClosed
+	default:
+		panic("dns: internal error: unknown DSO state")
+	}
+	unlockOnce()
+
+	_, err = dsow.writer.Write(buf)
+
+	dsow.dso.Lock()
+	unlockOnce = sync.OnceFunc(dsow.dso.Unlock)
+	defer unlockOnce()
+	switch dsow.dso.state {
+	case dsoSessionWaiting:
+		panic("dns: internal error: unexpected DSO state")
+	case dsoSessionRequested:
+		panic("dns: internal error: unexpected DSO state")
+	case dsoSessionPending:
+		defer dsow.dso.pendingCond.Broadcast()
+		switch m.Rcode {
+		// RFC 8490, Section 5.1.2: When the server receives a DSO request message from a client, and
+		// transmits a successful NOERROR response to that request, the server considers the DSO Session
+		// established.
+		case RcodeSuccess:
+			dsow.establishSession()
+
+		// RFC 8490, Section 5.1.1: If the server returns DSOTYPENI, then a DSO Session is not considered
+		// established. The client is, however, permitted to continue sending DNS messages on the connection,
+		// including other DSO messages such as the DSO Keepalive, which may result in a successful NOERROR
+		// response, yielding the establishment of a DSO Session.
+		case RcodeStatefulTypeNotImplemented:
+			dsow.resetSession()
+
+		// RFC 8490, Section 5.1.1: If the response RCODE is set to NOTIMP (4), or in practice any value other
+		// than NOERROR (0) or DSOTYPENI (defined below), then the client MUST assume that the server does not
+		// implement DSO at all. In this case, the client is permitted to continue sending DNS messages on that
+		// connection but MUST NOT issue further DSO messages on that connection.
+		default:
+			dsow.closeSession()
+		}
+		return err
+	case DSOSessionEstablished:
+		switch {
+		case errors.Is(err, syscall.EPIPE) || errors.Is(err, net.ErrClosed):
+			dsow.closeSession()
+			return errors.Join(ErrDSOClosed, err)
+		default:
+			return err
+		}
+	case DSOSessionClosed:
+		return errors.Join(ErrDSOClosed, err)
+	default:
+		panic("dns: internal error: unknown DSO state")
+	}
+}
+
+// CancelDSOMsg implements the DSOResponseWriter.CancelDSOMsg method.
+func (dsow *dsoresponse) CancelDSOMsg(reqId uint16, rcode int) error {
+	// RFC 8490, Section 5.6: The responder performs this selective cancellation by sending a new
+	// DSO response message ... with nonzero RCODE ...
+	if rcode == RcodeSuccess {
+		return errors.Join(ErrDSOMsg, ErrRcode)
+	}
+
+	resp := new(DSOMsg)
+	resp.Id = reqId
+	resp.Response = true
+	resp.Opcode = OpcodeStateful
+	resp.Rcode = rcode
+	return dsow.WriteDSOMsg(resp)
+}
+
+// CloseDSO implements the DSOResponseWriter.CloseDSO method.
+func (dsow *dsoresponse) CloseDSO(retryDelay time.Duration, rcode int) error {
+	uni := new(DSOMsg)
+	uni.SetClose(retryDelay, rcode)
+	err := dsow.WriteDSOMsg(uni)
+	if errors.Is(err, ErrDSOClosed) {
+		return nil
+	}
+	return err
+}
+
+// AbortDSO implements the DSOResponseWriter.AbortDSO method.
+func (dsow *dsoresponse) AbortDSO() error {
+	// RFC 8490, Section 5.3: Where this specification says "forcibly abort",
+	// it means sending a TCP RST
+	// RFC 8765, Section 1.2: Where this specification says "forcibly abort",
+	// it means sending a TCP RST to terminate the TCP connection and the TLS
+	// session running over that TCP connection.
+	setLinger(dsow.tcp, 0)
+	return dsow.Close()
+}
+
+func (dsow *dsoresponse) requestSession(id uint16) {
+	if dsow.dso.state&(dsoSessionWaiting|dsoSessionPending) == 0 {
+		panic("dns: internal error: unexpected DSO state")
+	}
+	dsow.dso.initReqId = id
+	dsow.dso.state = dsoSessionRequested
+}
+
+func (dsow *dsoresponse) pendingSession() {
+	if dsow.dso.state != dsoSessionRequested {
+		panic("dns: internal error: unexpected DSO state")
+	}
+	dsow.dso.state = dsoSessionPending
+}
+
+func (dsow *dsoresponse) resetSession() {
+	if dsow.dso.state != dsoSessionPending {
+		panic("dns: internal error: unexpected DSO state")
+	}
+	dsow.dso.initReqId = 0
+	dsow.dso.state = dsoSessionWaiting
+}
+
+func (dsow *dsoresponse) establishSession() {
+	if dsow.dso.state != dsoSessionPending {
+		panic("dns: internal error: unexpected DSO state")
+	}
+	dsow.dso.state = DSOSessionEstablished
+	close(dsow.dso.establishedChan)
+}
+
+func (dsow *dsoresponse) closeSession() {
+	if dsow.dso.state == dsoSessionPending {
+		defer dsow.dso.pendingCond.Broadcast()
+	}
+	dsow.dso.state = DSOSessionClosed
+	dsow.dso.cancel()
+}
+
+func (dsow *dsoresponse) abortSession(locker sync.Locker) {
+	if locker != nil {
+		locker.Lock()
+	}
+	dsow.closeSession()
+	if locker != nil {
+		locker.Unlock()
+	}
+	if !dsow.hijacked {
+		// RFC 8490, Section 5.3: Where this specification says "forcibly abort",
+		// it means sending a TCP RST
+		setLinger(dsow.tcp, 0)
+		dsow.Close()
+	}
+}
+
+func (srv *Server) serveDSOWithHeader(dh Header, buf []byte, off int, dsow *dsoresponse) {
+	// This is a quick check and doesn't have to be reliable.
+	if dsow.dso.state == DSOSessionClosed {
+		return
+	}
+
+	msg := new(DSOMsg)
+	msg.setHdr(dh)
+
+	switch action := srv.MsgAcceptFunc(dh); action {
+	case MsgAccept:
+		err := msg.unpack(dh, buf, off)
+		if err == nil {
+			break
+		}
+		err = msg.Validate(false, nil)
+		if err != nil {
+			srv.MsgInvalidFunc(buf, err)
+			dsow.abortSession(sync.Locker(dsow.dso))
+			return
+		}
+
+		srv.MsgInvalidFunc(buf, err)
+		fallthrough
+	case MsgReject, MsgRejectNotImplemented:
+		msg.SetResponse(msg, RcodeFormatError)
+		if action == MsgRejectNotImplemented {
+			msg.Rcode = RcodeNotImplemented
+		}
+		msg.Values = nil
+		msg.Zero = 0
+		buf, _ := msg.Pack()
+		dsow.writer.Write(buf)
+		fallthrough
+	case MsgIgnore:
+		return
+	case MsgAbort:
+		dsow.abortSession(sync.Locker(dsow.dso))
+		return
+	}
+
+	dsow.dso.RLock()
+	rUnlockOnce := sync.OnceFunc(dsow.dso.RUnlock)
+	defer rUnlockOnce()
+
+	for dsow.dso.state == dsoSessionPending {
+		dsow.dso.pendingCond.Wait()
+	}
+
+	// RFC 8490, Section 6.6.1.1: At the instant a server chooses to initiate a DSO Retry Delay
+	// message, there may be DNS requests already in flight from client to server on this
+	// DSO Session, which will arrive at the server after its DSO Retry Delay message has
+	// been sent.  The server MUST silently ignore such incoming requests and MUST NOT generate
+	// any response messages for them.
+	if dsow.dso.state == DSOSessionClosed {
+		return
+	}
+
+	isResponse := dh.Bits&_QR != 0 && dh.Id != 0
+	isRequest := dh.Bits&_QR == 0 && dh.Id != 0
+	isUnidirectional := dh.Bits&_QR == 0 && dh.Id == 0
+
+	// RFC 8490, Section 5.5.2: If a client or server receives a response (QR=1) where
+	// the MESSAGE ID ... is any other value that does not match the MESSAGE ID of any of
+	// its outstanding operations, this is a fatal error and the recipient MUST forcibly abort
+	// the connection immediately.
+	// - in this case client replied to a request that couldn't be sent.
+	if isResponse && dsow.dso.state != DSOSessionEstablished {
+		rUnlockOnce()
+		dsow.abortSession(sync.Locker(dsow.dso))
+		return
+	}
+
+	// RFC 8490, Section 5.1: Until a DSO Session has been implicitly or explicitly established, a
+	// client MUST NOT initiate DSO unidirectional messages.
+	if isUnidirectional && dsow.dso.state != DSOSessionEstablished {
+		rUnlockOnce()
+		dsow.abortSession(sync.Locker(dsow.dso))
+		return
+	}
+
+	maybeState := dsow.dso.state
+	rUnlockOnce()
+
+	// Only serveDSO can advance Waiting to a non-Closed state and it is called strictly sequentially.
+	if isRequest && maybeState == dsoSessionWaiting {
+		dsow.dso.Lock()
+		switch dsow.dso.state {
+		case dsoSessionWaiting:
+			dsow.requestSession(msg.Id)
+			dsow.dso.Unlock()
+		case DSOSessionClosed:
+			dsow.dso.Unlock()
+			return
+		default:
+			dsow.dso.Unlock()
+			panic("dns: internal error: unexpected DSO state")
+		}
+	}
+
+	srv.DSOHandler.ServeDSO(dsow.dso.ctx, dsow, msg)
+}

--- a/dso_types.go
+++ b/dso_types.go
@@ -1,0 +1,820 @@
+package dns
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// DSOType is the type of a DSO TLV.
+type DSOType uint16
+
+const (
+	// DSO types defined in RFC 8490, Section 10.3
+	DSOTypeReserved          = DSOType(StatefulTypeReserved)
+	DSOTypeKeepAlive         = DSOType(StatefulTypeKeepAlive)
+	DSOTypeRetryDelay        = DSOType(StatefulTypeRetryDelay)
+	DSOTypeEncryptionPadding = DSOType(StatefulTypeEncryptionPadding)
+
+	// DSO types defined in RFC 8765, Section 8
+	DSOType8765Subscribe   = DSOType(StatefulType8765Subscribe)
+	DSOType8765Push        = DSOType(StatefulType8765Push)
+	DSOType8765Unsubscribe = DSOType(StatefulType8765Unsubscribe)
+	DSOType8765Reconfirm   = DSOType(StatefulType8765Reconfirm)
+)
+
+// String converts DSOType to a readable value.
+// Accepts unassigned as well as experimental/local types.
+func (t DSOType) String() string {
+	str, ok := StatefulTypeToString[uint16(t)]
+	if !ok {
+		str = fmt.Sprintf("type%04X", uint16(t))
+	}
+	return str
+}
+
+// makeDSOValue creates DSOValue from the type.
+func makeDSOValue(t DSOType) DSOValue {
+	// All the DSOType.* constants above need to be in this switch.
+	switch t {
+	case DSOTypeKeepAlive:
+		return new(DSOKeepAlive)
+	case DSOTypeRetryDelay:
+		return new(DSORetryDelay)
+	case DSOTypeEncryptionPadding:
+		return new(DSOEncryptionPadding)
+	case DSOType8765Subscribe:
+		return new(DSO8765Subscribe)
+	case DSOType8765Push:
+		return new(DSO8765Push)
+	case DSOType8765Unsubscribe:
+		return new(DSO8765Unsubscribe)
+	case DSOType8765Reconfirm:
+		return new(DSO8765Reconfirm)
+	case DSOTypeReserved:
+		return nil
+	default:
+		tlv := new(DSOLocal)
+		tlv.dsotype = t
+		return tlv
+	}
+}
+
+// DSOValue is a generic DSO TLV.
+type DSOValue interface {
+	// DSOType returns the numerical TLV type.
+	DSOType() DSOType
+	// String converts TLV to a readable string.
+	String() string
+	// validate checks that the TLV can appear in msg.
+	validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error
+	// len calculates and returns TLV length in an (un)compressed wire format.
+	//
+	// If compression is nil, the uncompressed size will be returned, otherwise the compressed
+	// size will be returned and domain names will be added to the map for future compression.
+	len(off int, compression map[string]struct{}) int
+	// pack converts TLV to a wire format.
+	pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error)
+	// unpack sets TLV according to the wire format.
+	unpack(buf []byte, off int) (int, error)
+	// copy creates a deep-copy of TLV.
+	copy() DSOValue
+}
+
+// All values are in milliseconds.
+const (
+	// RFC 8490, Section 6.2: On a new DSO Session, if no explicit DSO Keepalive message exchange
+    // has taken place, the default value for both timeouts is 15 seconds.
+	DSOInactivityTimeoutDefault    = 15 * 1000
+	DSOKeepAliveIntervalDefault    = 15 * 1000
+	// RFC 8490, Section 6.5.2: By default, it is RECOMMENDED that clients request, and servers
+    // grant, a keepalive interval of 60 minutes.
+	DSOKeepAliveIntervalRecommened = 60 * 60 * 1000
+	// RFC 8490, Section 7.1: The keepalive interval MUST NOT be less than ten seconds.
+	DSOKeepAliveIntervalMin        = 10 * 1000
+	// RFC 8490, Section 6.5.2: A keepalive interval value of 0xFFFFFFFF represents "infinity"
+	// and informs the client that it should generate no DSO keepalive traffic.
+	DSOKeepAliveIntervalNever      = 0xFFFFFFFF
+	// RFC 8490, Section 6.4.2: An inactivity timeout of 0xFFFFFFFF represents "infinity"
+	// and informs the client that it may keep an idle connection open as long as it wishes.
+	DSOInactivityTimeoutNever	   = 0xFFFFFFFF
+)
+
+// Section 7.1: Keepalive TLV
+type DSOKeepAlive struct {
+	InactivityTimeout uint32
+	KeepAliveInterval uint32
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSOKeepAlive) DSOType() DSOType {
+	return DSOTypeKeepAlive
+}
+
+// String implements DSOValue.Len
+func (tlv *DSOKeepAlive) String() string {
+	return fmt.Sprintf("timeout %dms, interval %dms", tlv.InactivityTimeout, tlv.KeepAliveInterval)
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSOKeepAlive) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		// valid
+	case usage.c_u():
+		return fmt.Errorf("%w: bad keepalive primary tlv", ErrDSOData)
+	case usage.c_a():
+		return fmt.Errorf("%w: bad keepalive additional tlv", ErrDSOData)
+	case usage.crp():
+		// valid
+	case usage.cra():
+		return fmt.Errorf("%w: bad keepalive response additional tlv", ErrDSOData)
+	case usage.s_p():
+		return fmt.Errorf("%w: bad keepalive primary tlv", ErrDSOData)
+	case usage.s_u():
+		// valid
+	case usage.s_a():
+		return fmt.Errorf("%w: bad keepalive additional tlv", ErrDSOData)
+	case usage.srp():
+		fallthrough
+	case usage.sra():
+		return fmt.Errorf("%w: bad keepalive response tlv", ErrDSOData)
+	}
+
+	if server && tlv.KeepAliveInterval < DSOKeepAliveIntervalMin {
+		return fmt.Errorf("%w: bad keepalive interval", ErrDSOData)
+	}
+
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSOKeepAlive) len(off int, compression map[string]struct{}) int {
+	return 8
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSOKeepAlive) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packUint32(tlv.InactivityTimeout, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	off, err = packUint32(tlv.KeepAliveInterval, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSOKeepAlive) unpack(buf []byte, off int) (off1 int, err error) {
+	tlv.InactivityTimeout, off, err = unpackUint32(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	tlv.KeepAliveInterval, off, err = unpackUint32(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSOKeepAlive) copy() DSOValue {
+	return &DSOKeepAlive{tlv.InactivityTimeout, tlv.KeepAliveInterval}
+}
+
+// RFC 8490, Section 7.2: Retry Delay TLV
+type DSORetryDelay struct {
+	RetryDelay uint32
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSORetryDelay) DSOType() DSOType {
+	return DSOTypeRetryDelay
+}
+
+// String implements DSOValue.String
+func (tlv *DSORetryDelay) String() string {
+	return (time.Duration(tlv.RetryDelay) * time.Millisecond).String()
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSORetryDelay) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		fallthrough
+	case usage.c_u():
+		return fmt.Errorf("%w: bad retry delay primary tlv", ErrDSOData)
+	case usage.c_a():
+		return fmt.Errorf("%w: bad retry delay additional tlv", ErrDSOData)
+	case usage.crp():
+		return fmt.Errorf("%w: bad retry delay response primary tlv", ErrDSOData)
+	case usage.cra():
+		// valid
+	case usage.s_p():
+		return fmt.Errorf("%w: bad retry delay primary tlv", ErrDSOData)
+	case usage.s_u():
+		// valid
+	case usage.s_a():
+		return fmt.Errorf("%w: bad retry delay additional tlv", ErrDSOData)
+	case usage.srp():
+		return fmt.Errorf("%w: bad retry delay response primary tlv", ErrDSOData)
+	case usage.sra():
+		// valid
+	}
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSORetryDelay) len(off int, compression map[string]struct{}) int {
+	return 4
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSORetryDelay) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packUint32(tlv.RetryDelay, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSORetryDelay) unpack(buf []byte, off int) (off1 int, err error) {
+	tlv.RetryDelay, off, err = unpackUint32(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSORetryDelay) copy() DSOValue {
+	return &DSORetryDelay{tlv.RetryDelay}
+}
+
+// RFC 8490, Section 7.3: Encryption Padding TLV
+type DSOEncryptionPadding struct {
+	Padding []byte
+}
+
+// DSOType implements the DSOValue.DSOType
+func (tlv *DSOEncryptionPadding) DSOType() DSOType {
+	return DSOTypeEncryptionPadding
+}
+
+// String implements DSOValue.String
+func (tlv *DSOEncryptionPadding) String() string {
+	return fmt.Sprintf("%0X", tlv.Padding)
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSOEncryptionPadding) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		fallthrough
+	case usage.c_u():
+		return fmt.Errorf("%w: bad encryption padding primary tlv", ErrDSOData)
+	case usage.c_a():
+		// valid
+	case usage.crp():
+		return fmt.Errorf("%w: bad encryption padding response primary tlv", ErrDSOData)
+	case usage.cra():
+		// valid
+	case usage.s_p():
+		fallthrough
+	case usage.s_u():
+		return fmt.Errorf("%w: bad encryption padding primary tlv", ErrDSOData)
+	case usage.s_a():
+		// valid
+	case usage.srp():
+		return fmt.Errorf("%w: bad encryption padding response primary tlv", ErrDSOData)
+	case usage.sra():
+		// valid
+	}
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSOEncryptionPadding) len(off int, compression map[string]struct{}) int {
+	return len(tlv.Padding)
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSOEncryptionPadding) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	packLen := len(tlv.Padding)
+	if len(buf)-off < packLen {
+		return len(buf), ErrBuf
+	}
+	copy(buf[off:], tlv.Padding)
+	off += packLen
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSOEncryptionPadding) unpack(buf []byte, off int) (int, error) {
+	tlv.Padding = cloneSlice(buf[off:])
+	return len(buf), nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSOEncryptionPadding) copy() DSOValue {
+	return &DSOEncryptionPadding{cloneSlice(tlv.Padding)}
+}
+
+// DSOLocal is intended for experimental/private use as well as for unrecognized TLVs.
+type DSOLocal struct {
+	dsotype DSOType
+	Data    []byte
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSOLocal) DSOType() DSOType {
+	return tlv.dsotype
+}
+
+// String implements DSOValue.String
+func (tlv *DSOLocal) String() string {
+	return fmt.Sprintf("%0X", tlv.Data)
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSOLocal) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSOLocal) len(off int, compression map[string]struct{}) int {
+	return len(tlv.Data)
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSOLocal) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	packLen := len(tlv.Data)
+	if len(buf)-off < packLen {
+		return len(buf), ErrBuf
+	}
+	copy(buf[off:], tlv.Data)
+	off += packLen
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSOLocal) unpack(buf []byte, off int) (int, error) {
+	tlv.Data = cloneSlice(buf[off:])
+	return len(buf), nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSOLocal) copy() DSOValue {
+	return &DSOLocal{tlv.dsotype, cloneSlice(tlv.Data)}
+}
+
+// RFC 8765, Section 6.2: DNS Push Notification SUBSCRIBE
+type DSO8765Subscribe struct {
+	Name   string
+	Rrtype uint16
+	Class  uint16
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSO8765Subscribe) DSOType() DSOType {
+	return DSOType8765Subscribe
+}
+
+// String implements DSOValue.String
+func (tlv *DSO8765Subscribe) String() (s string) {
+	s = ";" + sprintName(tlv.Name) + "\t"
+	s += Class(tlv.Class).String() + "\t"
+	s += " " + Type(tlv.Rrtype).String()
+	return s
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSO8765Subscribe) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		// valid
+	case usage.c_u():
+		return fmt.Errorf("%w: bad rfc8765 subscribe primary tlv", ErrDSOData)
+	case usage.c_a():
+		return fmt.Errorf("%w: bad rfc8765 subscribe additional tlv", ErrDSOData)
+	case usage.crp():
+		fallthrough
+	case usage.cra():
+		// RFC 8765, Section 6.2.2: A SUBSCRIBE response message MUST NOT include
+		// a SUBSCRIBE TLV.If a client receives a SUBSCRIBE response message containing
+		// a SUBSCRIBE TLV, then the response message is processed but the SUBSCRIBE TLV
+		// MUST be silently ignored.
+	case usage.s_p():
+		fallthrough
+	case usage.s_u():
+		return fmt.Errorf("%w: bad rfc8765 subscribe primary tlv", ErrDSOData)
+	case usage.s_a():
+		return fmt.Errorf("%w: bad rfc8765 subscribe additional tlv", ErrDSOData)
+	case usage.srp():
+		fallthrough
+	case usage.sra():
+		return fmt.Errorf("%w: bad rfc8765 subscribe response tlv", ErrDSOData)
+	}
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSO8765Subscribe) len(off int, compression map[string]struct{}) int {
+	l := domainNameLen(tlv.Name, off, compression, true)
+	l += 2 + 2
+	return l
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSO8765Subscribe) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packDomainName(tlv.Name, buf, off, compression, compress)
+	if err != nil {
+		return len(buf), err
+	}
+
+	off, err = packUint16(tlv.Rrtype, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	off, err = packUint16(tlv.Class, buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSO8765Subscribe) unpack(buf []byte, off int) (off1 int, err error) {
+	tlv.Name, off, err = UnpackDomainName(buf, off)
+	if err != nil {
+		return len(buf), err
+	}
+
+	tlv.Rrtype, off, err = unpackUint16(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+
+	tlv.Class, off, err = unpackUint16(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSO8765Subscribe) copy() DSOValue {
+	return &DSO8765Subscribe{tlv.Name, tlv.Rrtype, tlv.Class}
+}
+
+// RFC 8765, Section 6.3: DNS Push Notification Updates
+type DSO8765Push struct {
+	Change []RR
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSO8765Push) DSOType() DSOType {
+	return DSOType8765Push
+}
+
+// String implements DSOValue.String
+func (tlv *DSO8765Push) String() string {
+	switch {
+	case len(tlv.Change) == 0:
+		return "<nil>"
+	case len(tlv.Change) == 1:
+		return tlv.Change[0].String()
+	default:
+		s := fmt.Sprintf("\t%s", tlv.Change[0])
+		for _, r := range tlv.Change[1:] {
+			s += fmt.Sprintf("\n\t%s", r)
+		}
+		return s
+	}
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSO8765Push) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		fallthrough
+	case usage.c_u():
+		return fmt.Errorf("%w: bad rfc8765 push primary tlv", ErrDSOData)
+	case usage.c_a():
+		return fmt.Errorf("%w: bad rfc8765 push additional tlv", ErrDSOData)
+	case usage.crp():
+		fallthrough
+	case usage.cra():
+		return fmt.Errorf("%w: bad rfc8765 push response tlv", ErrDSOData)
+	case usage.s_p():
+		return fmt.Errorf("%w: bad rfc8765 push primary tlv", ErrDSOData)
+	case usage.s_u():
+		// valid
+	case usage.s_a():
+		return fmt.Errorf("%w: bad rfc8765 push additional tlv", ErrDSOData)
+	case usage.srp():
+		fallthrough
+	case usage.sra():
+		return fmt.Errorf("%w: bad rfc8765 push response tlv", ErrDSOData)
+	}
+
+	// RFC 8765, Section 6.3.1: A PUSH Message MUST contain at least one change notification.
+	if len(tlv.Change) == 0 {
+		return fmt.Errorf("%w: empty rfc8765 push tlv", ErrDSOData)
+	}
+
+	for _, r := range tlv.Change {
+		h := r.Header()
+		switch {
+		// RFC 8765, Section 6.3.1: If the TTL is in the range ... 0x7FFFFFFF then a new DNS
+		// Resource Record with the given name, type, class, and RDATA is added. Type and class
+		// MUST NOT be 255 (ANY).
+		case h.Ttl <= 0x7FFFFFFF && (h.Class == ClassANY || h.Rrtype == TypeANY):
+			fallthrough
+		// RFC 8765, Section 6.3.1: If the TTL has the value 0xFFFFFFFF, then the DNS Resource
+		// Record with the given name, type, class, and RDATA is removed. Type and class
+		// MUST NOT be 255 (ANY)
+		case h.Ttl == 0xFFFFFFFF && (h.Class == ClassANY || h.Rrtype == TypeANY):
+			return fmt.Errorf("%w: bad class / type in rfc8765 push tlv", ErrDSOData)
+		// RFC 8765, Section 6.3.1: If the TTL has the value 0xFFFFFFFE, then this is a
+		// 'collective' remove notification. For collective remove notifications,
+		// RDLEN MUST be zero
+		case h.Ttl == 0xFFFFFFFE && h.Rdlength != 0:
+			return fmt.Errorf("%w: non-empty collective removal in rfc8765 push tlv", ErrDSOData)
+		// RFC 8765, Section 6.3.1: If the TTL is any value other than 0xFFFFFFFF, 0xFFFFFFFE,
+		// or a value in the range 0 to 0x7FFFFFFF, then the receiver SHOULD silently ignore
+		// this particular change notification record.
+		default:
+		}
+	}
+
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSO8765Push) len(off int, compression map[string]struct{}) int {
+	l := off
+	for _, r := range tlv.Change {
+		l += r.len(l, compression)
+	}
+	return l - off
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSO8765Push) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	for _, r := range tlv.Change {
+		_, off, err = packRR(r, buf, off, compression, compress)
+		if err != nil {
+			return len(buf), err
+		}
+	}
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSO8765Push) unpack(buf []byte, off int) (off1 int, err error) {
+	var r RR
+	for off < len(buf) {
+		off1 := off
+		r, off, err = UnpackRR(buf, off)
+		if err != nil {
+			return len(buf), err
+		}
+		if off1 == off {
+			break
+		}
+		tlv.Change = append(tlv.Change, r)
+	}
+	return off, nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSO8765Push) copy() DSOValue {
+	tlv1 := DSO8765Push{}
+	tlv1.Change = make([]RR, len(tlv.Change))
+	for i, r := range tlv.Change {
+		tlv1.Change[i] = r.copy()
+	}
+	return &tlv1
+}
+
+// RFC 8765, Section 6.4: DNS Push Notification UNSUBSCRIBE
+type DSO8765Unsubscribe struct {
+	SubscribeId uint16
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSO8765Unsubscribe) DSOType() DSOType {
+	return DSOType8765Unsubscribe
+}
+
+// String implements DSOValue.String
+func (tlv *DSO8765Unsubscribe) String() (s string) {
+	return strconv.Itoa(int(tlv.SubscribeId))
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSO8765Unsubscribe) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		return fmt.Errorf("%w: bad rfc8765 unsubscribe primary tlv", ErrDSOData)
+	case usage.c_u():
+		// valid
+	case usage.c_a():
+		return fmt.Errorf("%w: bad rfc8765 unsubscribe additional tlv", ErrDSOData)
+	case usage.crp():
+		fallthrough
+	case usage.cra():
+		return fmt.Errorf("%w: bad rfc8765 unsubscribe response tlv", ErrDSOData)
+	case usage.s_p():
+		fallthrough
+	case usage.s_u():
+		return fmt.Errorf("%w: bad rfc8765 unsubscribe primary tlv", ErrDSOData)
+	case usage.s_a():
+		return fmt.Errorf("%w: bad rfc8765 unsubscribe additional tlv", ErrDSOData)
+	case usage.srp():
+		fallthrough
+	case usage.sra():
+		return fmt.Errorf("%w: bad rfc8765 unsubscribe response tlv", ErrDSOData)
+	}
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSO8765Unsubscribe) len(off int, compression map[string]struct{}) int {
+	return 2
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSO8765Unsubscribe) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	off, err = packUint16(uint16(tlv.SubscribeId), buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSO8765Unsubscribe) unpack(buf []byte, off int) (off1 int, err error) {
+	tlv.SubscribeId, off, err = unpackUint16(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	return off, nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSO8765Unsubscribe) copy() DSOValue {
+	return &DSO8765Unsubscribe{tlv.SubscribeId}
+}
+
+// RFC 8765, Section 6.5: DNS Push Notification RECONFIRM
+type DSO8765Reconfirm struct {
+	Rr RR
+}
+
+// DSOType implements DSOValue.DSOType
+func (tlv *DSO8765Reconfirm) DSOType() DSOType {
+	return DSOType8765Reconfirm
+}
+
+// String implements DSOValue.String
+func (tlv *DSO8765Reconfirm) String() (s string) {
+	return tlv.Rr.String()
+}
+
+// validate implements DSOValue.validate
+func (tlv *DSO8765Reconfirm) validate(server bool, msg *DSOMsg, i int, primary bool, respPrimary bool) error {
+	usage := tlvUsage{server, primary, respPrimary, msg}
+	switch {
+	case usage.c_p():
+		return fmt.Errorf("%w: bad rfc8765 reconfirm primary tlv", ErrDSOData)
+	case usage.c_u():
+		// valid
+	case usage.c_a():
+		return fmt.Errorf("%w: bad rfc8765 reconfirm additional tlv", ErrDSOData)
+	case usage.crp():
+		fallthrough
+	case usage.cra():
+		return fmt.Errorf("%w: bad rfc8765 reconfirm response tlv", ErrDSOData)
+	case usage.s_p():
+		fallthrough
+	case usage.s_u():
+		return fmt.Errorf("%w: bad rfc8765 reconfirm primary tlv", ErrDSOData)
+	case usage.s_a():
+		return fmt.Errorf("%w: bad rfc8765 reconfirm additional tlv", ErrDSOData)
+	case usage.srp():
+		fallthrough
+	case usage.sra():
+		return fmt.Errorf("%w: bad rfc8765 reconfirm response tlv", ErrDSOData)
+	}
+
+	if h := tlv.Rr.Header(); h.Class == ClassANY || h.Rrtype == TypeANY {
+		return fmt.Errorf("%w: bad class / type in rfc8765 reconfirm tlv", ErrDSOData)
+	}
+
+	return nil
+}
+
+// len implements DSOValue.len
+func (tlv *DSO8765Reconfirm) len(off int, compression map[string]struct{}) int {
+	l := tlv.Rr.len(off, compression) - 4 - 2 // Ttl and Rdlength are not packed
+	return l
+}
+
+// pack implements DSOValue.pack
+func (tlv *DSO8765Reconfirm) pack(buf []byte, off int, compression compressionMap, compress bool) (off1 int, err error) {
+	h := tlv.Rr.Header()
+
+	// RR Header w/o Ttl and Rdlength
+	off, err = packDomainName(h.Name, buf, off, compression, compress)
+	if err != nil {
+		return len(buf), err
+	}
+	off, err = packUint16(h.Rrtype, buf, off)
+	if err != nil {
+		return len(buf), err
+	}
+	off, err = packUint16(h.Class, buf, off)
+	if err != nil {
+		return len(buf), err
+	}
+
+	// Actual RR data
+	off, err = tlv.Rr.pack(buf, off, compression, compress)
+	if err != nil {
+		return len(buf), err
+	}
+
+	return off, nil
+}
+
+// unpack implements DSOValue.unpack
+func (tlv *DSO8765Reconfirm) unpack(buf []byte, off int) (off1 int, err error) {
+	var h RR_Header
+
+	// RR Header
+	h.Name, off, err = UnpackDomainName(buf, off)
+	if err != nil {
+		return len(buf), err
+	}
+	h.Rrtype, off, err = unpackUint16(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	h.Class, off, err = unpackUint16(buf, off)
+	if err != nil {
+		return len(buf), ErrBuf
+	}
+	headerEnd := off
+
+	rdlength := len(buf) - headerEnd
+	if int(uint16(rdlength)) != rdlength {
+		return len(buf), ErrDSOData
+	}
+	h.Rdlength = uint16(rdlength)
+
+	// Actual RR data
+	tlv.Rr, off, err = UnpackRRWithHeader(h, buf, off)
+	if err != nil {
+		return len(buf), err
+	}
+	return off, nil
+}
+
+// copy implements DSOValue.copy
+func (tlv *DSO8765Reconfirm) copy() DSOValue {
+	return &DSO8765Reconfirm{tlv.Rr.copy()}
+}
+
+// RFC 8490, Section 8.2 TLV usage matrix.
+type tlvUsage struct {
+	server      bool
+	primary     bool
+	respPrimary bool
+	msg         *DSOMsg
+}
+
+func (u *tlvUsage) c_p() bool { return !u.server && u.msg.IsRequest() && u.primary }
+func (u *tlvUsage) c_u() bool { return !u.server && u.msg.IsUnidirectional() && u.primary }
+func (u *tlvUsage) c_a() bool { return !u.server && !u.msg.IsResponse() && !u.primary }
+func (u *tlvUsage) crp() bool { return u.server && u.msg.IsResponse() && u.respPrimary }
+func (u *tlvUsage) cra() bool { return u.server && u.msg.IsResponse() && !u.respPrimary }
+func (u *tlvUsage) s_p() bool { return u.server && u.msg.IsRequest() && u.primary }
+func (u *tlvUsage) s_u() bool { return u.server && u.msg.IsUnidirectional() && u.primary }
+func (u *tlvUsage) s_a() bool { return u.server && !u.msg.IsResponse() && !u.primary }
+func (u *tlvUsage) srp() bool { return !u.server && u.msg.IsResponse() && u.respPrimary }
+func (u *tlvUsage) sra() bool { return !u.server && u.msg.IsResponse() && !u.respPrimary }

--- a/edns.go
+++ b/edns.go
@@ -694,6 +694,9 @@ func (e *EDNS0_LOCAL) unpack(b []byte) error {
 
 // EDNS0_TCP_KEEPALIVE is an EDNS0 option that instructs the server to keep
 // the TCP connection alive. See RFC 7828.
+//
+// The receiver must forcibly abort the connection if this option is present within
+// an active DSO session. See RFC 8490, Section 7.1.2
 type EDNS0_TCP_KEEPALIVE struct {
 	Code uint16 // always EDNSTCPKEEPALIVE
 

--- a/types.go
+++ b/types.go
@@ -183,15 +183,29 @@ const (
 
 // Stateful types as defined in RFC 8490.
 const (
-	StatefulTypeKeepAlive uint16 = iota + 1
+	StatefulTypeReserved uint16 = iota
+
+	StatefulTypeKeepAlive
 	StatefulTypeRetryDelay
 	StatefulTypeEncryptionPadding
+
+	StatefulType8765Subscribe uint16 = iota + 0x0040
+	StatefulType8765Push
+	StatefulType8765Unsubscribe
+	StatefulType8765Reconfirm
 )
 
 var StatefulTypeToString = map[uint16]string{
+	StatefulTypeReserved:          "<nil>",
+
 	StatefulTypeKeepAlive:         "KeepAlive",
 	StatefulTypeRetryDelay:        "RetryDelay",
 	StatefulTypeEncryptionPadding: "EncryptionPadding",
+
+	StatefulType8765Subscribe:     "RFC8765 Subscribe",
+	StatefulType8765Push:          "RFC8765 Push",
+	StatefulType8765Unsubscribe:   "RFC8765 Unsubscribe",
+	StatefulType8765Reconfirm:     "RFC8765 Reconfirm",
 }
 
 // Header is the wire format for the DNS packet header.


### PR DESCRIPTION
Preliminary placeholder PR in light of [@miekg's work on the dnsv2 package](url).

---

This PR adds support for RFC 8490 DNS Stateful Operations and RFC 8765 DNS Push Notifications.

The changes are fully backward compatible and do not affect existing code. Enabling DSO requires an explicit opt-in by setting `Server.DSOHandler`.

Changes to the existing codebase:
- `MsgAcceptAction` is extended with `MsgAbort`. Default action is to set socket's linger to 0 and close.
- `Msg` errors early during packing and unpacking non-empty messages when opcode is Stateful. This is backward compatible because it couldn't represent non-empty DSO messages anyway.
- Indirection was added to `Server` to route OpcodeStateful messages through the DSO dispatcher.

---

1. I anticipate that DSO traffic is going to be low volume, so I used sync.RWMutex to synchronize access to DSO state. But it's feasible to rewrite this with atomics / trylocks.
2. Perhaps it's better to substitute the `DSOHandler` field with a runtime check of whether `Handler` implements `DSOResponseWriter`.
3. Since DSOHandler is opt-in, I'd prefer to change `serveDSOWithHeader(...)` to `go serveDSOWithHeader(...)` with a caveat that the user must ensure that their `DecorateWriter`, if any,  is safe to be called concurrently. It's my understanding that both Go's `TCPConn` and `TLSConn` can properly handle concurrent writes. Perhaps the only change needed for `response` is to make `closed` and, possibly, `hijacked` into `atomic.Bool`.