### PR TITLE
Add Msg.MarshalJSON, Msg.UnmarshalJSON and tests with full coverage

### DIFF
--- a/json.go
+++ b/json.go
@@ -12,11 +12,11 @@ var _ json.Marshaler = &Msg{}
 var _ json.Unmarshaler = &Msg{}
 
 var (
-	ErrEmptyInput         = errors.New("dnsjson: empty input")
-	ErrInvalidJSON        = errors.New("dnsjson: invalid JSON")
-	ErrInvalidMessage     = errors.New("dnsjson: invalid message")
-	ErrQuestionQType      = errors.New("dnsjson: question qtype")
-	ErrQuestionQClass     = errors.New("dnsjson: question qclass")
+	ErrEmptyInput         = errors.New("empty input")
+	ErrInvalidJSON        = errors.New("invalid JSON")
+	ErrInvalidMessage     = errors.New("invalid message")
+	ErrQuestionQType      = errors.New("question qtype")
+	ErrQuestionQClass     = errors.New("question qclass")
 	ErrAnswerSection      = errors.New("answer")
 	ErrNsSection          = errors.New("ns")
 	ErrExtraSection       = errors.New("extra")

--- a/json.go
+++ b/json.go
@@ -1,8 +1,11 @@
 package dns
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"math"
+	"net"
 	"net/netip"
 	"strconv"
 	"strings"
@@ -12,17 +15,27 @@ var _ json.Marshaler = &Msg{}
 var _ json.Unmarshaler = &Msg{}
 
 var (
-	ErrEmptyInput         = errors.New("empty input")
-	ErrInvalidJSON        = errors.New("invalid JSON")
-	ErrInvalidMessage     = errors.New("invalid message")
-	ErrQuestionQType      = errors.New("question qtype")
-	ErrQuestionQClass     = errors.New("question qclass")
-	ErrAnswerSection      = errors.New("answer")
-	ErrNsSection          = errors.New("ns")
-	ErrExtraSection       = errors.New("extra")
-	ErrUnknownType        = errors.New("unknown type")
-	ErrUnknownClass       = errors.New("unknown class")
-	ErrInvalidStringSlice = errors.New("invalid string slice")
+	ErrEmptyInput          = errors.New("empty input")
+	ErrInvalidJSON         = errors.New("invalid JSON")
+	ErrInvalidMessage      = errors.New("invalid message")
+	ErrQuestionQType       = errors.New("question qtype")
+	ErrQuestionQClass      = errors.New("question qclass")
+	ErrAnswerSection       = errors.New("answer")
+	ErrNsSection           = errors.New("ns")
+	ErrExtraSection        = errors.New("extra")
+	ErrUnknownType         = errors.New("unknown type")
+	ErrUnknownClass        = errors.New("unknown class")
+	ErrInvalidStringSlice  = errors.New("invalid string slice")
+	ErrEDNSOptionEntry     = errors.New("edns option entry type")
+	ErrEDNSOption          = errors.New("edns option")
+	ErrEDNSOptionsNotArray = errors.New("opt options must be array")
+	ErrEDNSOptionNoCode    = errors.New("opt option missing code")
+	ErrUint8SliceType      = errors.New("uint8 slice type")
+	ErrUint8SliceElement   = errors.New("uint8 slice element")
+	ErrUint8SliceRange     = errors.New("uint8 slice range")
+	ErrNegativeValue       = errors.New("negative value")
+	ErrInvalidNumber       = errors.New("invalid number")
+	ErrInvalidNumberType   = errors.New("invalid number type")
 )
 
 // MessageJSON is the top-level JSON shape for Msg.
@@ -63,7 +76,7 @@ type RRJSON struct {
 	Data  map[string]any `json:"data"`
 }
 
-// MarshalJSON generates JSON using an explicit, human-readable JSON schema.
+// MarshalJSON provides JSON marshalling for *Msg using an explicit, human-readable JSON schema.
 //
 // Schema overview (stable keys; rdata keys per RR type listed below):
 //
@@ -84,29 +97,30 @@ type RRJSON struct {
 //	  "data": { "a":"93.184.216.34" }
 //	}
 //
-//	AAAA: {"aaaa":"2001:db8::1"}
-//	CNAME: {"target":"alias.example."}
-//	NS: {"ns":"ns1.example."}
-//	PTR: {"ptr":"host.example."}
-//	TXT: {"txt":["chunk1","chunk2"]}
-//	MX: {"preference":10, "mx":"mail.example."}
-//	SRV: {"priority":0, "weight":5, "port":443, "target":"svc.example."}
-//	SOA: {"ns":"ns1.", "mbox":"hostmaster.", "serial":1, "refresh":7200, "retry":900, "expire":1209600, "minttl":300}
-//	CAA: {"flag":0, "tag":"issue", "value":"letsencrypt.org"}
-//	NAPTR: {"order":100, "preference":50, "flags":"s", "services":"SIP+D2U", "regexp":"", "replacement":"_sip._udp.example."}
-//	DS: {"key_tag":12345, "algorithm":8, "digest_type":2, "digest":"...hex..."}
-//	DNSKEY: {"flags":257, "protocol":3, "algorithm":8, "public_key":"base64..."}
-//	TLSA: {"usage":3, "selector":1, "matching_type":1, "cert_data":"hex or base64"}
-//	RRSIG: {
-//		"type_covered":"A", "algorithm":8, "labels":2, "original_ttl":300,
-//		"expiration": 1735689600, "inception": 1733097600, "key_tag":12345,
-//		"signer_name":"example.", "signature":"base64..."}
+// AAAA: {"aaaa":"2001:db8::1"}
+// CNAME: {"target":"alias.example."}
+// NS: {"ns":"ns1.example."}
+// PTR: {"ptr":"host.example."}
+// TXT: {"txt":["chunk1","chunk2"]}
+// MX: {"preference":10, "mx":"mail.example."}
+// SRV: {"priority":0, "weight":5, "port":443, "target":"svc.example."}
+// SOA: {"ns":"ns1.", "mbox":"hostmaster.", "serial":1, "refresh":7200, "retry":900, "expire":1209600, "minttl":300}
+// CAA: {"flag":0, "tag":"issue", "value":"letsencrypt.org"}
+// NAPTR: {"order":100, "preference":50, "flags":"s", "services":"SIP+D2U", "regexp":"", "replacement":"_sip._udp.example."}
+// DS: {"key_tag":12345, "algorithm":8, "digest_type":2, "digest":"...hex..."}
+// DNSKEY: {"flags":257, "protocol":3, "algorithm":8, "public_key":"base64..."}
+// RRSIG: {"type_covered":"A", "algorithm":8, "labels":2, "original_ttl":300,
+//
+//	"expiration": 1735689600, "inception": 1733097600, "key_tag":12345,
+//	"signer_name":"example.", "signature":"base64..."}
+//
+// TLSA: {"usage":3, "selector":1, "matching_type":1, "cert_data":"hex or base64"}
 //
 // Notes
 //   - Type/class use standard mnemonics (e.g., "A", "AAAA", "IN").
 //   - Unknown/less-common RR types are round-tripped via a best-effort map in "data"; if a
 //     type is not implemented below, Marshal will include {"raw": "<presentation>"} and
-//     Unmarshal will parse it using NewRR.
+//     Unmarshal will parse it using NewRR on a synthesized presentation string.
 //   - Times in RRSIG use UNIX seconds per miekg/dns conventions.
 func (m *Msg) MarshalJSON() (b []byte, err error) {
 	b = []byte("null")
@@ -287,6 +301,20 @@ func rrToJSON(rr RR) RRJSON {
 		j.Data["selector"] = v.Selector
 		j.Data["matching_type"] = v.MatchingType
 		j.Data["cert_data"] = v.Certificate
+	case *OPT:
+		j.Data["udp_size"] = v.UDPSize()
+		j.Data["extended_rcode"] = uint16(v.ExtendedRcode()) // #nosec G115
+		j.Data["version"] = v.Version()
+		j.Data["do"] = v.Do()
+		j.Data["co"] = v.Co()
+		j.Data["z"] = v.Z()
+		if len(v.Option) > 0 {
+			opts := make([]map[string]any, 0, len(v.Option))
+			for _, opt := range v.Option {
+				opts = append(opts, ednsOptionToJSON(opt))
+			}
+			j.Data["options"] = opts
+		}
 	default:
 		// Fallback to presentation for unknown types to maintain coverage without wire format.
 		j.Data["raw"] = rr.String()
@@ -425,6 +453,45 @@ func rrFromJSON(j RRJSON) (rr RR, err error) {
 					MatchingType: getUint8(j.Data, "matching_type"),
 					Certificate:  getString(j.Data, "cert_data"),
 				}
+			case TypeOPT:
+				opt := &OPT{Hdr: rrHdr(j, typeCode, classCode)}
+				udp_size := classCode
+				if _, ok := j.Data["udp_size"]; ok {
+					udp_size = getUint16(j.Data, "udp_size")
+				}
+				opt.SetUDPSize(udp_size)
+				if _, ok := j.Data["extended_rcode"]; ok {
+					opt.SetExtendedRcode(getUint16(j.Data, "extended_rcode"))
+				}
+				if _, ok := j.Data["version"]; ok {
+					opt.SetVersion(getUint8(j.Data, "version"))
+				}
+				if do, ok := getBool(j.Data, "do"); ok {
+					opt.SetDo(do)
+				}
+				if co, ok := getBool(j.Data, "co"); ok {
+					opt.SetCo(co)
+				}
+				if _, ok := j.Data["z"]; ok {
+					opt.SetZ(getUint16(j.Data, "z"))
+				}
+				if raw, ok := j.Data["options"]; ok {
+					err = ErrEDNSOptionsNotArray
+					if arr, ok := raw.([]any); ok {
+						err = nil
+						for idx, entry := range arr {
+							var option EDNS0
+							if option, err = ednsOptionFromJSON(entry); err == nil {
+								opt.Option = append(opt.Option, option)
+							} else {
+								err = errors.Join(err, &optOptionEntryError{index: idx})
+							}
+						}
+					}
+				}
+				if err == nil {
+					rr = opt
+				}
 			default:
 				// Best-effort fallback using presentation format stored in data.raw
 				if rr, err = NewRR(strings.TrimSpace(getString(j.Data, "raw"))); err == nil {
@@ -435,6 +502,146 @@ func rrFromJSON(j RRJSON) (rr RR, err error) {
 						h.Rrtype = typeCode
 						h.Ttl = j.TTL
 					}
+				}
+			}
+		}
+	}
+	return
+}
+
+func ednsOptionToJSON(opt EDNS0) map[string]any {
+	m := map[string]any{
+		"code": optionCodeToString(opt.Option()),
+	}
+	switch o := opt.(type) {
+	case *EDNS0_NSID:
+		m["nsid"] = strings.ToLower(o.Nsid)
+	case *EDNS0_SUBNET:
+		m["family"] = o.Family
+		m["source_netmask"] = o.SourceNetmask
+		m["source_scope"] = o.SourceScope
+		if o.Address != nil {
+			m["address"] = o.Address.String()
+		}
+	case *EDNS0_COOKIE:
+		m["cookie"] = strings.ToLower(o.Cookie)
+	case *EDNS0_UL:
+		m["lease"] = o.Lease
+		m["key_lease"] = o.KeyLease
+	case *EDNS0_LLQ:
+		m["version"] = o.Version
+		m["opcode"] = o.Opcode
+		m["error"] = o.Error
+		m["id"] = o.Id
+		m["lease_life"] = o.LeaseLife
+	case *EDNS0_DAU:
+		m["alg_codes"] = uint8SliceToIntSlice(o.AlgCode)
+	case *EDNS0_DHU:
+		m["alg_codes"] = uint8SliceToIntSlice(o.AlgCode)
+	case *EDNS0_N3U:
+		m["alg_codes"] = uint8SliceToIntSlice(o.AlgCode)
+	case *EDNS0_EXPIRE:
+		m["expire"] = o.Expire
+		if o.Empty {
+			m["empty"] = true
+		}
+	case *EDNS0_LOCAL:
+		m["data"] = strings.ToLower(hex.EncodeToString(o.Data))
+	case *EDNS0_TCP_KEEPALIVE:
+		m["timeout"] = o.Timeout
+	case *EDNS0_PADDING:
+		m["padding"] = strings.ToLower(hex.EncodeToString(o.Padding))
+	case *EDNS0_EDE:
+		m["info_code"] = o.InfoCode
+		m["extra_text"] = o.ExtraText
+	case *EDNS0_ESU:
+		m["uri"] = o.Uri
+	}
+	return m
+}
+
+func ednsOptionFromJSON(in any) (rr EDNS0, err error) {
+	err = ErrEDNSOptionNoCode
+	if m, ok := in.(map[string]any); ok {
+		if codeStr := getString(m, "code"); codeStr != "" {
+			var code uint16
+			if code, err = stringToOptionCode(codeStr); err == nil {
+				switch code {
+				case EDNS0NSID:
+					rr = &EDNS0_NSID{Code: code, Nsid: strings.ToLower(getString(m, "nsid"))}
+				case EDNS0SUBNET:
+					var address net.IP
+					if addr := getString(m, "address"); addr != "" {
+						var ip netip.Addr
+						if ip, err = netip.ParseAddr(addr); err == nil {
+							address = ip.AsSlice()
+						}
+					}
+					if err == nil {
+						rr = &EDNS0_SUBNET{
+							Code:          code,
+							Family:        getUint16(m, "family"),
+							SourceNetmask: getUint8(m, "source_netmask"),
+							SourceScope:   getUint8(m, "source_scope"),
+							Address:       address,
+						}
+					}
+				case EDNS0COOKIE:
+					rr = &EDNS0_COOKIE{Code: code, Cookie: strings.ToLower(getString(m, "cookie"))}
+				case EDNS0UL:
+					rr = &EDNS0_UL{Code: code, Lease: getUint32(m, "lease"), KeyLease: getUint32(m, "key_lease")}
+				case EDNS0LLQ:
+					var id uint64
+					if raw, ok := m["id"]; ok {
+						id, err = anyToUint64(raw)
+					}
+					if err == nil {
+						rr = &EDNS0_LLQ{
+							Id:        id,
+							Code:      code,
+							Version:   getUint16(m, "version"),
+							Opcode:    getUint16(m, "opcode"),
+							Error:     getUint16(m, "error"),
+							LeaseLife: getUint32(m, "lease_life"),
+						}
+					}
+				case EDNS0DAU:
+					var algs []uint8
+					if algs, err = getUint8Slice(m, "alg_codes"); err == nil {
+						rr = &EDNS0_DAU{Code: code, AlgCode: algs}
+					}
+				case EDNS0DHU:
+					var algs []uint8
+					if algs, err = getUint8Slice(m, "alg_codes"); err == nil {
+						rr = &EDNS0_DHU{Code: code, AlgCode: algs}
+					}
+				case EDNS0N3U:
+					var algs []uint8
+					if algs, err = getUint8Slice(m, "alg_codes"); err == nil {
+						rr = &EDNS0_N3U{Code: code, AlgCode: algs}
+					}
+				case EDNS0EXPIRE:
+					empty, _ := getBool(m, "empty")
+					rr = &EDNS0_EXPIRE{Code: code, Expire: getUint32(m, "expire"), Empty: empty}
+				case EDNS0TCPKEEPALIVE:
+					rr = &EDNS0_TCP_KEEPALIVE{Code: code, Timeout: getUint16(m, "timeout")}
+				case EDNS0PADDING:
+					var padding []byte
+					if padding, err = hex.DecodeString(getString(m, "padding")); err == nil {
+						rr = &EDNS0_PADDING{Padding: padding}
+					}
+				case EDNS0EDE:
+					rr = &EDNS0_EDE{InfoCode: getUint16(m, "info_code"), ExtraText: getString(m, "extra_text")}
+				case EDNS0ESU:
+					rr = &EDNS0_ESU{Code: code, Uri: getString(m, "uri")}
+				default:
+					var data []byte
+					if data, err = hex.DecodeString(getString(m, "data")); err == nil {
+						rr = &EDNS0_LOCAL{Code: code, Data: data}
+					}
+				}
+				if err != nil {
+					err = &optOptionCodeError{code: codeStr, err: err}
 				}
 			}
 		}
@@ -485,6 +692,52 @@ func stringToClass(s string) (cls uint16, err error) {
 			cls = uint16(n)
 		} else {
 			err = &unknownClassError{value: s}
+		}
+	}
+	return
+}
+
+var optionCodeToName = map[uint16]string{
+	EDNS0LLQ:          "LLQ",
+	EDNS0UL:           "UL",
+	EDNS0NSID:         "NSID",
+	EDNS0DAU:          "DAU",
+	EDNS0DHU:          "DHU",
+	EDNS0N3U:          "N3U",
+	EDNS0SUBNET:       "SUBNET",
+	EDNS0EXPIRE:       "EXPIRE",
+	EDNS0COOKIE:       "COOKIE",
+	EDNS0TCPKEEPALIVE: "TCPKEEPALIVE",
+	EDNS0PADDING:      "PADDING",
+	EDNS0EDE:          "EDE",
+	EDNS0ESU:          "ESU",
+}
+
+var optionNameToCode = func() map[string]uint16 {
+	out := make(map[string]uint16, len(optionCodeToName)+1)
+	for code, name := range optionCodeToName {
+		out[strings.ToUpper(name)] = code
+	}
+	out["TCP_KEEPALIVE"] = EDNS0TCPKEEPALIVE
+	return out
+}()
+
+func optionCodeToString(code uint16) (s string) {
+	var ok bool
+	if s, ok = optionCodeToName[code]; !ok {
+		s = strconv.FormatUint(uint64(code), 10)
+	}
+	return
+}
+
+func stringToOptionCode(s string) (code uint16, err error) {
+	var ok bool
+	if code, ok = optionNameToCode[strings.ToUpper(s)]; !ok {
+		var n uint64
+		if n, err = strconv.ParseUint(s, 10, 16); err == nil {
+			code = uint16(n)
+		} else {
+			err = &unknownOptionError{value: s}
 		}
 	}
 	return
@@ -564,6 +817,102 @@ func getStringSlice(m map[string]any, key string) (out []string, err error) {
 	return
 }
 
+func getBool(m map[string]any, key string) (bool, bool) {
+	if m != nil {
+		if v, ok := m[key]; ok {
+			switch t := v.(type) {
+			case bool:
+				return t, true
+			case string:
+				if b, err := strconv.ParseBool(t); err == nil {
+					return b, true
+				}
+			case float64:
+				return t != 0, true
+			case json.Number:
+				if n, err := t.Int64(); err == nil {
+					return n != 0, true
+				}
+			}
+		}
+	}
+	return false, false
+}
+
+func getUint8Slice(m map[string]any, key string) (out []uint8, err error) {
+	if m != nil {
+		if raw, ok := m[key]; ok {
+			arr, ok := raw.([]any)
+			if !ok {
+				return nil, &keyArrayError{key: key}
+			}
+			for idx, v := range arr {
+				val, e := anyToUint64(v)
+				if e != nil {
+					return nil, &keyIndexError{key: key, index: idx, err: e}
+				}
+				if val > math.MaxUint8 {
+					return nil, &keyIndexRangeError{key: key, index: idx}
+				}
+				out = append(out, uint8(val))
+			}
+		}
+	}
+	return
+}
+
+func anyToUint64(v any) (n uint64, err error) {
+	switch t := v.(type) {
+	case float64:
+		if t < 0 {
+			return 0, ErrNegativeValue
+		}
+		n = uint64(t)
+	case json.Number:
+		var val int64
+		if val, err = t.Int64(); err == nil {
+			if val < 0 {
+				err = ErrNegativeValue
+			} else {
+				n = uint64(val)
+			}
+		}
+	case string:
+		if t != "" {
+			n, err = strconv.ParseUint(t, 10, 64)
+		}
+	case int:
+		if t < 0 {
+			return 0, ErrNegativeValue
+		}
+		n = uint64(t)
+	case int64:
+		if t < 0 {
+			return 0, ErrNegativeValue
+		}
+		n = uint64(t)
+	case uint8:
+		n = uint64(t)
+	case uint16:
+		n = uint64(t)
+	case uint32:
+		n = uint64(t)
+	case uint64:
+		n = t
+	default:
+		err = ErrInvalidNumberType
+	}
+	return
+}
+
+func uint8SliceToIntSlice(in []uint8) []int {
+	out := make([]int, 0, len(in))
+	for _, v := range in {
+		out = append(out, int(v))
+	}
+	return out
+}
+
 type wrappedError struct {
 	sentinel error
 	err      error
@@ -612,6 +961,14 @@ func (e *unknownClassError) Is(target error) bool {
 	return target == ErrUnknownClass
 }
 
+type unknownOptionError struct {
+	value string
+}
+
+func (e *unknownOptionError) Error() string {
+	return "unknown option code " + strconv.Quote(e.value)
+}
+
 type stringSliceError struct {
 	key string
 }
@@ -622,4 +979,82 @@ func (e *stringSliceError) Error() string {
 
 func (e *stringSliceError) Is(target error) bool {
 	return target == ErrInvalidStringSlice
+}
+
+type optOptionEntryError struct {
+	index int
+}
+
+func (e *optOptionEntryError) Error() string {
+	return "opt options[" + strconv.Itoa(e.index) + "] must be object"
+}
+
+func (e *optOptionEntryError) Is(target error) bool {
+	return target == ErrEDNSOptionEntry
+}
+
+type optOptionCodeError struct {
+	code string
+	err  error
+}
+
+func (e *optOptionCodeError) Error() string {
+	if e.err == nil {
+		return "opt option " + e.code
+	}
+	return "opt option " + e.code + ": " + e.err.Error()
+}
+
+func (e *optOptionCodeError) Unwrap() error {
+	return e.err
+}
+
+func (e *optOptionCodeError) Is(target error) bool {
+	return target == ErrEDNSOption || errors.Is(e.err, target)
+}
+
+type keyArrayError struct {
+	key string
+}
+
+func (e *keyArrayError) Error() string {
+	return e.key + " must be array"
+}
+
+func (e *keyArrayError) Is(target error) bool {
+	return target == ErrUint8SliceType
+}
+
+type keyIndexError struct {
+	key   string
+	index int
+	err   error
+}
+
+func (e *keyIndexError) Error() string {
+	if e.err == nil {
+		return e.key + "[" + strconv.Itoa(e.index) + "]"
+	}
+	return e.key + "[" + strconv.Itoa(e.index) + "]: " + e.err.Error()
+}
+
+func (e *keyIndexError) Unwrap() error {
+	return e.err
+}
+
+func (e *keyIndexError) Is(target error) bool {
+	return target == ErrUint8SliceElement || errors.Is(e.err, target)
+}
+
+type keyIndexRangeError struct {
+	key   string
+	index int
+}
+
+func (e *keyIndexRangeError) Error() string {
+	return e.key + "[" + strconv.Itoa(e.index) + "]: value out of range"
+}
+
+func (e *keyIndexRangeError) Is(target error) bool {
+	return target == ErrUint8SliceRange
 }

--- a/json.go
+++ b/json.go
@@ -84,24 +84,23 @@ type RRJSON struct {
 //	  "data": { "a":"93.184.216.34" }
 //	}
 //
-// AAAA: {"aaaa":"2001:db8::1"}
-// CNAME: {"target":"alias.example."}
-// NS: {"ns":"ns1.example."}
-// PTR: {"ptr":"host.example."}
-// TXT: {"txt":["chunk1","chunk2"]}
-// MX: {"preference":10, "mx":"mail.example."}
-// SRV: {"priority":0, "weight":5, "port":443, "target":"svc.example."}
-// SOA: {"ns":"ns1.", "mbox":"hostmaster.", "serial":1, "refresh":7200, "retry":900, "expire":1209600, "minttl":300}
-// CAA: {"flag":0, "tag":"issue", "value":"letsencrypt.org"}
-// NAPTR: {"order":100, "preference":50, "flags":"s", "services":"SIP+D2U", "regexp":"", "replacement":"_sip._udp.example."}
-// DS: {"key_tag":12345, "algorithm":8, "digest_type":2, "digest":"...hex..."}
-// DNSKEY: {"flags":257, "protocol":3, "algorithm":8, "public_key":"base64..."}
-// RRSIG: {"type_covered":"A", "algorithm":8, "labels":2, "original_ttl":300,
-//
-//	"expiration": 1735689600, "inception": 1733097600, "key_tag":12345,
-//	"signer_name":"example.", "signature":"base64..."}
-//
-// TLSA: {"usage":3, "selector":1, "matching_type":1, "cert_data":"hex or base64"}
+//	AAAA: {"aaaa":"2001:db8::1"}
+//	CNAME: {"target":"alias.example."}
+//	NS: {"ns":"ns1.example."}
+//	PTR: {"ptr":"host.example."}
+//	TXT: {"txt":["chunk1","chunk2"]}
+//	MX: {"preference":10, "mx":"mail.example."}
+//	SRV: {"priority":0, "weight":5, "port":443, "target":"svc.example."}
+//	SOA: {"ns":"ns1.", "mbox":"hostmaster.", "serial":1, "refresh":7200, "retry":900, "expire":1209600, "minttl":300}
+//	CAA: {"flag":0, "tag":"issue", "value":"letsencrypt.org"}
+//	NAPTR: {"order":100, "preference":50, "flags":"s", "services":"SIP+D2U", "regexp":"", "replacement":"_sip._udp.example."}
+//	DS: {"key_tag":12345, "algorithm":8, "digest_type":2, "digest":"...hex..."}
+//	DNSKEY: {"flags":257, "protocol":3, "algorithm":8, "public_key":"base64..."}
+//	TLSA: {"usage":3, "selector":1, "matching_type":1, "cert_data":"hex or base64"}
+//	RRSIG: {
+//		"type_covered":"A", "algorithm":8, "labels":2, "original_ttl":300,
+//		"expiration": 1735689600, "inception": 1733097600, "key_tag":12345,
+//		"signer_name":"example.", "signature":"base64..."}
 //
 // Notes
 //   - Type/class use standard mnemonics (e.g., "A", "AAAA", "IN").

--- a/json.go
+++ b/json.go
@@ -1,0 +1,626 @@
+package dns
+
+import (
+	"encoding/json"
+	"errors"
+	"net/netip"
+	"strconv"
+	"strings"
+)
+
+var _ json.Marshaler = &Msg{}
+var _ json.Unmarshaler = &Msg{}
+
+var (
+	ErrEmptyInput         = errors.New("dnsjson: empty input")
+	ErrInvalidJSON        = errors.New("dnsjson: invalid JSON")
+	ErrInvalidMessage     = errors.New("dnsjson: invalid message")
+	ErrQuestionQType      = errors.New("dnsjson: question qtype")
+	ErrQuestionQClass     = errors.New("dnsjson: question qclass")
+	ErrAnswerSection      = errors.New("answer")
+	ErrNsSection          = errors.New("ns")
+	ErrExtraSection       = errors.New("extra")
+	ErrUnknownType        = errors.New("unknown type")
+	ErrUnknownClass       = errors.New("unknown class")
+	ErrInvalidStringSlice = errors.New("invalid string slice")
+)
+
+// MessageJSON is the top-level JSON shape for Msg.
+type MessageJSON struct {
+	ID       uint16         `json:"id"`
+	MsgHdr   MsgHdrJSON     `json:"msgHdr"`
+	Question []QuestionJSON `json:"question"`
+	Answer   []RRJSON       `json:"answer,omitempty"`
+	Ns       []RRJSON       `json:"ns,omitempty"`
+	Extra    []RRJSON       `json:"extra,omitempty"`
+}
+
+type MsgHdrJSON struct {
+	QR     bool   `json:"qr,omitempty"`
+	Opcode string `json:"opcode"`
+	AA     bool   `json:"aa,omitempty"`
+	TC     bool   `json:"tc,omitempty"`
+	RD     bool   `json:"rd,omitempty"`
+	RA     bool   `json:"ra,omitempty"`
+	Z      bool   `json:"z,omitempty"`
+	AD     bool   `json:"ad,omitempty"`
+	CD     bool   `json:"cd,omitempty"`
+	Rcode  string `json:"rcode"`
+}
+
+type QuestionJSON struct {
+	Name   string `json:"name"`
+	Qtype  string `json:"qtype"`
+	Qclass string `json:"qclass"`
+}
+
+// RRJSON contains common RR header fields plus a per-type data map.
+type RRJSON struct {
+	Name  string         `json:"name"`
+	Type  string         `json:"type"`
+	Class string         `json:"class"`
+	TTL   uint32         `json:"ttl"`
+	Data  map[string]any `json:"data"`
+}
+
+// MarshalJSON generates JSON using an explicit, human-readable JSON schema.
+//
+// Schema overview (stable keys; rdata keys per RR type listed below):
+//
+//	{
+//	  "id": 1234,
+//	  "msgHdr": {"qr":true, "opcode":"QUERY", "aa":false, "tc":false, "rd":true,
+//	              "ra":true, "z":0, "ad":false, "cd":false, "rcode":"NOERROR"},
+//	  "question": [{"name":"example.com.", "qtype":"A", "qclass":"IN"}],
+//	  "answer":  [ RRJSON, ... ],
+//	  "ns":      [ RRJSON, ... ],
+//	  "extra":   [ RRJSON, ... ]
+//	}
+//
+// RRJSON (common fields) + per-type data (examples):
+//
+//	{
+//	  "name":"example.com.", "type":"A", "class":"IN", "ttl":300,
+//	  "data": { "a":"93.184.216.34" }
+//	}
+//
+// AAAA: {"aaaa":"2001:db8::1"}
+// CNAME: {"target":"alias.example."}
+// NS: {"ns":"ns1.example."}
+// PTR: {"ptr":"host.example."}
+// TXT: {"txt":["chunk1","chunk2"]}
+// MX: {"preference":10, "mx":"mail.example."}
+// SRV: {"priority":0, "weight":5, "port":443, "target":"svc.example."}
+// SOA: {"ns":"ns1.", "mbox":"hostmaster.", "serial":1, "refresh":7200, "retry":900, "expire":1209600, "minttl":300}
+// CAA: {"flag":0, "tag":"issue", "value":"letsencrypt.org"}
+// NAPTR: {"order":100, "preference":50, "flags":"s", "services":"SIP+D2U", "regexp":"", "replacement":"_sip._udp.example."}
+// DS: {"key_tag":12345, "algorithm":8, "digest_type":2, "digest":"...hex..."}
+// DNSKEY: {"flags":257, "protocol":3, "algorithm":8, "public_key":"base64..."}
+// RRSIG: {"type_covered":"A", "algorithm":8, "labels":2, "original_ttl":300,
+//
+//	"expiration": 1735689600, "inception": 1733097600, "key_tag":12345,
+//	"signer_name":"example.", "signature":"base64..."}
+//
+// TLSA: {"usage":3, "selector":1, "matching_type":1, "cert_data":"hex or base64"}
+//
+// Notes
+//   - Type/class use standard mnemonics (e.g., "A", "AAAA", "IN").
+//   - Unknown/less-common RR types are round-tripped via a best-effort map in "data"; if a
+//     type is not implemented below, Marshal will include {"raw": "<presentation>"} and
+//     Unmarshal will parse it using NewRR.
+//   - Times in RRSIG use UNIX seconds per miekg/dns conventions.
+func (m *Msg) MarshalJSON() (b []byte, err error) {
+	b = []byte("null")
+	if m != nil {
+		j := MessageJSON{
+			ID:     m.Id,
+			MsgHdr: hdrToJSON(m.MsgHdr),
+			Answer: rrsToJSON(m.Answer),
+			Ns:     rrsToJSON(m.Ns),
+			Extra:  rrsToJSON(m.Extra),
+		}
+		// Questions
+		for _, q := range m.Question {
+			j.Question = append(j.Question, QuestionJSON{
+				Name:   q.Name,
+				Qtype:  typeToString(q.Qtype),
+				Qclass: classToString(q.Qclass),
+			})
+		}
+		b, err = json.Marshal(j)
+	}
+	return
+}
+
+func (msg *Msg) UnmarshalJSON(data []byte) (err error) {
+	err = ErrEmptyInput
+	if len(data) > 0 {
+		var raw json.RawMessage
+		if err = wrapError(ErrInvalidJSON, json.Unmarshal(data, &raw)); err == nil {
+			if string(raw) != "null" {
+				var j MessageJSON
+				if err = wrapError(ErrInvalidMessage, json.Unmarshal(raw, &j)); err == nil {
+					msg.MsgHdr = hdrFromJSON(j.MsgHdr)
+					msg.Id = j.ID
+					// Questions
+					for _, qj := range j.Question {
+						qt, e := stringToType(qj.Qtype)
+						err = errors.Join(err, wrapError(ErrQuestionQType, e))
+						qc, e := stringToClass(qj.Qclass)
+						err = errors.Join(err, wrapError(ErrQuestionQClass, e))
+						msg.Question = append(msg.Question, Question{Name: qj.Name, Qtype: qt, Qclass: qc})
+					}
+					// Sections
+					var e error
+					msg.Answer, e = rrsFromJSON(j.Answer)
+					err = errors.Join(err, wrapError(ErrAnswerSection, e))
+					msg.Ns, e = rrsFromJSON(j.Ns)
+					err = errors.Join(err, wrapError(ErrNsSection, e))
+					msg.Extra, e = rrsFromJSON(j.Extra)
+					err = errors.Join(err, wrapError(ErrExtraSection, e))
+				}
+			}
+		}
+	}
+	return
+}
+
+// --- helpers ---
+
+func hdrToJSON(h MsgHdr) MsgHdrJSON {
+	return MsgHdrJSON{
+		QR:     h.Response,
+		Opcode: OpcodeToString[h.Opcode],
+		AA:     h.Authoritative,
+		TC:     h.Truncated,
+		RD:     h.RecursionDesired,
+		RA:     h.RecursionAvailable,
+		Z:      h.Zero,
+		AD:     h.AuthenticatedData,
+		CD:     h.CheckingDisabled,
+		Rcode:  RcodeToString[h.Rcode],
+	}
+}
+
+func hdrFromJSON(j MsgHdrJSON) (mh MsgHdr) {
+	mh.Response = j.QR
+	mh.Opcode = stringToOpcode(j.Opcode)
+	mh.Authoritative = j.AA
+	mh.Truncated = j.TC
+	mh.RecursionDesired = j.RD
+	mh.RecursionAvailable = j.RA
+	mh.Zero = j.Z
+	mh.AuthenticatedData = j.AD
+	mh.CheckingDisabled = j.CD
+	mh.Rcode = stringToRcode(j.Rcode)
+	return
+}
+
+func rrsToJSON(rrs []RR) (out []RRJSON) {
+	for _, rr := range rrs {
+		out = append(out, rrToJSON(rr))
+	}
+	return
+}
+
+func rrsFromJSON(rrjs []RRJSON) (out []RR, err error) {
+	for _, j := range rrjs {
+		if rr, e := rrFromJSON(j); e == nil {
+			out = append(out, rr)
+		} else {
+			err = errors.Join(err, e)
+		}
+	}
+	return
+}
+
+func rrToJSON(rr RR) RRJSON {
+	h := rr.Header()
+	j := RRJSON{
+		Name:  h.Name,
+		Type:  typeToString(h.Rrtype),
+		Class: classToString(h.Class),
+		TTL:   h.Ttl,
+		Data:  map[string]any{},
+	}
+	switch v := rr.(type) {
+	case *A:
+		j.Data["a"] = v.A.String()
+	case *AAAA:
+		j.Data["aaaa"] = v.AAAA.String()
+	case *CNAME:
+		j.Data["target"] = v.Target
+	case *NS:
+		j.Data["ns"] = v.Ns
+	case *PTR:
+		j.Data["ptr"] = v.Ptr
+	case *TXT:
+		j.Data["txt"] = append([]string(nil), v.Txt...)
+	case *MX:
+		j.Data["preference"] = v.Preference
+		j.Data["mx"] = v.Mx
+	case *SRV:
+		j.Data["priority"] = v.Priority
+		j.Data["weight"] = v.Weight
+		j.Data["port"] = v.Port
+		j.Data["target"] = v.Target
+	case *SOA:
+		j.Data["ns"] = v.Ns
+		j.Data["mbox"] = v.Mbox
+		j.Data["serial"] = v.Serial
+		j.Data["refresh"] = v.Refresh
+		j.Data["retry"] = v.Retry
+		j.Data["expire"] = v.Expire
+		j.Data["minttl"] = v.Minttl
+	case *CAA:
+		j.Data["flag"] = v.Flag
+		j.Data["tag"] = v.Tag
+		j.Data["value"] = v.Value
+	case *NAPTR:
+		j.Data["order"] = v.Order
+		j.Data["preference"] = v.Preference
+		j.Data["flags"] = v.Flags
+		j.Data["service"] = v.Service
+		j.Data["regexp"] = v.Regexp
+		j.Data["replacement"] = v.Replacement
+	case *DS:
+		j.Data["key_tag"] = v.KeyTag
+		j.Data["algorithm"] = v.Algorithm
+		j.Data["digest_type"] = v.DigestType
+		j.Data["digest"] = strings.ToLower(v.Digest)
+	case *DNSKEY:
+		j.Data["flags"] = v.Flags
+		j.Data["protocol"] = v.Protocol
+		j.Data["algorithm"] = v.Algorithm
+		j.Data["public_key"] = v.PublicKey
+	case *RRSIG:
+		j.Data["type_covered"] = typeToString(v.TypeCovered)
+		j.Data["algorithm"] = v.Algorithm
+		j.Data["labels"] = v.Labels
+		j.Data["original_ttl"] = v.OrigTtl
+		j.Data["expiration"] = v.Expiration
+		j.Data["inception"] = v.Inception
+		j.Data["key_tag"] = v.KeyTag
+		j.Data["signer_name"] = v.SignerName
+		j.Data["signature"] = v.Signature
+	case *TLSA:
+		j.Data["usage"] = v.Usage
+		j.Data["selector"] = v.Selector
+		j.Data["matching_type"] = v.MatchingType
+		j.Data["cert_data"] = v.Certificate
+	default:
+		// Fallback to presentation for unknown types to maintain coverage without wire format.
+		j.Data["raw"] = rr.String()
+	}
+	return j
+}
+
+func rrFromJSON(j RRJSON) (rr RR, err error) {
+	var typeCode, classCode uint16
+	if typeCode, err = stringToType(j.Type); err == nil {
+		if classCode, err = stringToClass(j.Class); err == nil {
+			// Choose concrete by type
+			switch typeCode {
+			case TypeA:
+				var ip netip.Addr
+				if ip, err = netip.ParseAddr(getString(j.Data, "a")); err == nil {
+					if ip.Is4() {
+						rr = &A{
+							Hdr: rrHdr(j, typeCode, classCode),
+							A:   ip.AsSlice(),
+						}
+					}
+				}
+			case TypeAAAA:
+				var ip netip.Addr
+				if ip, err = netip.ParseAddr(getString(j.Data, "aaaa")); err == nil {
+					if ip.Is6() {
+						rr = &AAAA{
+							Hdr:  rrHdr(j, typeCode, classCode),
+							AAAA: ip.AsSlice(),
+						}
+					}
+				}
+			case TypeCNAME:
+				rr = &CNAME{
+					Hdr:    rrHdr(j, typeCode, classCode),
+					Target: getString(j.Data, "target"),
+				}
+			case TypeNS:
+				rr = &NS{
+					Hdr: rrHdr(j, typeCode, classCode),
+					Ns:  getString(j.Data, "ns"),
+				}
+			case TypePTR:
+				rr = &PTR{
+					Hdr: rrHdr(j, typeCode, classCode),
+					Ptr: getString(j.Data, "ptr"),
+				}
+			case TypeTXT:
+				var arr []string
+				if arr, err = getStringSlice(j.Data, "txt"); err == nil {
+					rr = &TXT{
+						Hdr: rrHdr(j, typeCode, classCode),
+						Txt: arr,
+					}
+				}
+			case TypeMX:
+				rr = &MX{
+					Hdr:        rrHdr(j, typeCode, classCode),
+					Preference: getUint16(j.Data, "preference"),
+					Mx:         getString(j.Data, "mx"),
+				}
+			case TypeSRV:
+				rr = &SRV{
+					Hdr:      rrHdr(j, typeCode, classCode),
+					Priority: getUint16(j.Data, "priority"),
+					Weight:   getUint16(j.Data, "weight"),
+					Port:     getUint16(j.Data, "port"),
+					Target:   getString(j.Data, "target"),
+				}
+			case TypeSOA:
+				rr = &SOA{
+					Hdr:     rrHdr(j, typeCode, classCode),
+					Ns:      getString(j.Data, "ns"),
+					Mbox:    getString(j.Data, "mbox"),
+					Serial:  getUint32(j.Data, "serial"),
+					Refresh: getUint32(j.Data, "refresh"),
+					Retry:   getUint32(j.Data, "retry"),
+					Expire:  getUint32(j.Data, "expire"),
+					Minttl:  getUint32(j.Data, "minttl"),
+				}
+			case TypeCAA:
+				rr = &CAA{
+					Hdr:   rrHdr(j, typeCode, classCode),
+					Flag:  getUint8(j.Data, "flag"),
+					Tag:   getString(j.Data, "tag"),
+					Value: getString(j.Data, "value"),
+				}
+			case TypeNAPTR:
+				rr = &NAPTR{
+					Hdr:         rrHdr(j, typeCode, classCode),
+					Order:       getUint16(j.Data, "order"),
+					Preference:  getUint16(j.Data, "preference"),
+					Flags:       getString(j.Data, "flags"),
+					Service:     getString(j.Data, "service"),
+					Regexp:      getString(j.Data, "regexp"),
+					Replacement: getString(j.Data, "replacement"),
+				}
+			case TypeDS:
+				rr = &DS{
+					Hdr:        rrHdr(j, typeCode, classCode),
+					KeyTag:     getUint16(j.Data, "key_tag"),
+					Algorithm:  getUint8(j.Data, "algorithm"),
+					DigestType: getUint8(j.Data, "digest_type"),
+					Digest:     strings.ToUpper(getString(j.Data, "digest")),
+				}
+			case TypeDNSKEY:
+				rr = &DNSKEY{
+					Hdr:       rrHdr(j, typeCode, classCode),
+					Flags:     getUint16(j.Data, "flags"),
+					Protocol:  getUint8(j.Data, "protocol"),
+					Algorithm: getUint8(j.Data, "algorithm"),
+					PublicKey: getString(j.Data, "public_key"),
+				}
+			case TypeRRSIG:
+				var cov uint16
+				if cov, err = stringToType(getString(j.Data, "type_covered")); err == nil {
+					rr = &RRSIG{
+						Hdr:         rrHdr(j, typeCode, classCode),
+						TypeCovered: cov,
+						Algorithm:   getUint8(j.Data, "algorithm"),
+						Labels:      getUint8(j.Data, "labels"),
+						OrigTtl:     getUint32(j.Data, "original_ttl"),
+						Expiration:  getUint32(j.Data, "expiration"),
+						Inception:   getUint32(j.Data, "inception"),
+						KeyTag:      getUint16(j.Data, "key_tag"),
+						SignerName:  getString(j.Data, "signer_name"),
+						Signature:   getString(j.Data, "signature"),
+					}
+				}
+			case TypeTLSA:
+				rr = &TLSA{
+					Hdr:          rrHdr(j, typeCode, classCode),
+					Usage:        getUint8(j.Data, "usage"),
+					Selector:     getUint8(j.Data, "selector"),
+					MatchingType: getUint8(j.Data, "matching_type"),
+					Certificate:  getString(j.Data, "cert_data"),
+				}
+			default:
+				// Best-effort fallback using presentation format stored in data.raw
+				if rr, err = NewRR(strings.TrimSpace(getString(j.Data, "raw"))); err == nil {
+					// NewRR does not preserve TTL/class/name from header in raw string if omitted; ensure header set
+					if h := rr.Header(); h != nil {
+						h.Name = j.Name
+						h.Class = classCode
+						h.Rrtype = typeCode
+						h.Ttl = j.TTL
+					}
+				}
+			}
+		}
+	}
+	return
+}
+
+func rrHdr(j RRJSON, t uint16, c uint16) RR_Header {
+	return RR_Header{Name: j.Name, Rrtype: t, Class: c, Ttl: j.TTL}
+}
+
+// --- mapping helpers ---
+
+func typeToString(t uint16) (s string) {
+	var ok bool
+	if s, ok = TypeToString[t]; !ok {
+		s = strconv.FormatUint(uint64(t), 10)
+	}
+	return
+}
+
+func stringToType(s string) (typ uint16, err error) {
+	var ok bool
+	if typ, ok = StringToType[strings.ToUpper(s)]; !ok {
+		var n uint64
+		if n, err = strconv.ParseUint(s, 10, 16); err == nil {
+			typ = uint16(n)
+		} else {
+			err = &unknownTypeError{value: s}
+		}
+	}
+	return
+}
+
+func classToString(c uint16) (s string) {
+	var ok bool
+	if s, ok = ClassToString[c]; !ok {
+		s = strconv.FormatUint(uint64(c), 10)
+	}
+	return
+}
+
+func stringToClass(s string) (cls uint16, err error) {
+	var ok bool
+	if cls, ok = StringToClass[strings.ToUpper(s)]; !ok {
+		var n uint64
+		if n, err = strconv.ParseUint(s, 10, 16); err == nil {
+			cls = uint16(n)
+		} else {
+			err = &unknownClassError{value: s}
+		}
+	}
+	return
+}
+
+func stringToOpcode(s string) (opcode int) {
+	opcode = OpcodeQuery
+	if op, ok := StringToOpcode[strings.ToUpper(s)]; ok {
+		opcode = op
+	}
+	return
+}
+
+func stringToRcode(s string) (rcode int) {
+	rcode = RcodeSuccess
+	if rc, ok := StringToRcode[strings.ToUpper(s)]; ok {
+		rcode = rc
+	}
+	return
+}
+
+// --- small JSON helpers ---
+
+func getString(m map[string]any, key string) (s string) {
+	if m != nil {
+		if v, ok := m[key]; ok {
+			s, _ = v.(string)
+		}
+	}
+	return
+}
+
+func getUint8(m map[string]any, key string) uint8 {
+	return uint8(getInt(m, key)) // #nosec G115
+}
+func getUint16(m map[string]any, key string) uint16 {
+	return uint16(getInt(m, key)) // #nosec G115
+}
+func getUint32(m map[string]any, key string) uint32 {
+	return uint32(getInt(m, key)) // #nosec G115
+}
+
+func getInt(m map[string]any, key string) (n int64) {
+	if m != nil {
+		if v, ok := m[key]; ok {
+			switch t := v.(type) {
+			case float64:
+				n = int64(t)
+			case int:
+				n = int64(t)
+			case int64:
+				n = t
+			case json.Number:
+				n, _ = t.Int64()
+			case string:
+				n, _ = strconv.ParseInt(t, 10, 64)
+			}
+		}
+	}
+	return
+}
+
+func getStringSlice(m map[string]any, key string) (out []string, err error) {
+	if v, ok := m[key]; ok {
+		a, ok := v.([]any)
+		if !ok {
+			return nil, &stringSliceError{key: key}
+		}
+		for _, it := range a {
+			s, ok := it.(string)
+			if !ok {
+				return nil, &stringSliceError{key: key}
+			}
+			out = append(out, s)
+		}
+	}
+	return
+}
+
+type wrappedError struct {
+	sentinel error
+	err      error
+}
+
+func wrapError(sentinel, err error) (out error) {
+	if err != nil {
+		out = &wrappedError{sentinel: sentinel, err: err}
+	}
+	return
+}
+
+func (w *wrappedError) Error() string {
+	return w.sentinel.Error() + ": " + w.err.Error()
+}
+
+func (w *wrappedError) Unwrap() error {
+	return w.err
+}
+
+func (w *wrappedError) Is(target error) bool {
+	return target == w.sentinel || errors.Is(w.err, target)
+}
+
+type unknownTypeError struct {
+	value string
+}
+
+func (e *unknownTypeError) Error() string {
+	return "unknown type " + strconv.Quote(e.value)
+}
+
+func (e *unknownTypeError) Is(target error) bool {
+	return target == ErrUnknownType
+}
+
+type unknownClassError struct {
+	value string
+}
+
+func (e *unknownClassError) Error() string {
+	return "unknown class " + strconv.Quote(e.value)
+}
+
+func (e *unknownClassError) Is(target error) bool {
+	return target == ErrUnknownClass
+}
+
+type stringSliceError struct {
+	key string
+}
+
+func (e *stringSliceError) Error() string {
+	return e.key + " must be array of strings"
+}
+
+func (e *stringSliceError) Is(target error) bool {
+	return target == ErrInvalidStringSlice
+}

--- a/json_test.go
+++ b/json_test.go
@@ -1,0 +1,533 @@
+package dns
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+)
+
+const fallbackType = 65280
+
+func TestMsgJSONRoundTrip(t *testing.T) {
+	fixtures := messageFixtures(t)
+
+	expectedTypes := map[uint16]string{
+		TypeA:        "A",
+		TypeAAAA:     "AAAA",
+		TypeCNAME:    "CNAME",
+		TypeNS:       "NS",
+		TypePTR:      "PTR",
+		TypeTXT:      "TXT",
+		TypeMX:       "MX",
+		TypeSRV:      "SRV",
+		TypeSOA:      "SOA",
+		TypeCAA:      "CAA",
+		TypeNAPTR:    "NAPTR",
+		TypeDS:       "DS",
+		TypeDNSKEY:   "DNSKEY",
+		TypeRRSIG:    "RRSIG",
+		TypeTLSA:     "TLSA",
+		fallbackType: "TYPE65280",
+	}
+
+	seenTypes := make(map[uint16]bool)
+
+	for name, want := range fixtures {
+		want := want
+		t.Run(name, func(t *testing.T) {
+			t.Helper()
+
+			data, err := json.Marshal((*Msg)(want))
+			if err != nil {
+				t.Fatalf("Marshal failed: %v", err)
+			}
+
+			var got Msg
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal failed: %v\nJSON: %s", err, data)
+			}
+
+			wantCopy := want.Copy()
+			gotMsg := Msg(got)
+
+			if wantCopy.String() != gotMsg.String() {
+				t.Fatalf("round-trip mismatch\nwant: %s\njson: %s\ngot: %s", wantCopy, data, gotMsg.String())
+			}
+		})
+
+		for _, rr := range want.Answer {
+			seenTypes[rr.Header().Rrtype] = true
+		}
+		for _, rr := range want.Ns {
+			seenTypes[rr.Header().Rrtype] = true
+		}
+		for _, rr := range want.Extra {
+			seenTypes[rr.Header().Rrtype] = true
+		}
+	}
+
+	for typ, label := range expectedTypes {
+		if !seenTypes[typ] {
+			t.Fatalf("test fixtures missing record for type %s", label)
+		}
+	}
+}
+
+func TestMsgMarshalNil(t *testing.T) {
+
+	var m *Msg
+	got, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("Marshal nil failed: %v", err)
+	}
+	if string(got) != "null" {
+		t.Fatalf("unexpected JSON for nil Msg: %s", got)
+	}
+}
+
+func TestMsgUnmarshalNull(t *testing.T) {
+
+	var msg Msg
+	if err := json.Unmarshal([]byte("null"), &msg); err != nil {
+		t.Fatalf("Unmarshal null failed: %v", err)
+	}
+	dnsMsg := Msg(msg)
+	if dnsMsg.Id != 0 || len(dnsMsg.Question) != 0 || len(dnsMsg.Answer) != 0 || len(dnsMsg.Ns) != 0 || len(dnsMsg.Extra) != 0 {
+		t.Fatalf("expected zero-value message after null unmarshal, got %+v", dnsMsg)
+	}
+}
+
+func messageFixtures(t *testing.T) map[string]*Msg {
+	t.Helper()
+
+	const ttl = 600
+
+	header := func(name string, rrtype uint16) RR_Header {
+		return RR_Header{Name: name, Rrtype: rrtype, Class: ClassINET, Ttl: ttl}
+	}
+
+	fallbackRR := mustRR(t, "raw.example. 3600 IN TYPE65280 \\# 4 01020304")
+	fallbackRR.Header().Name = "raw.example."
+	fallbackRR.Header().Class = ClassINET
+	fallbackRR.Header().Rrtype = fallbackType
+	fallbackRR.Header().Ttl = 3600
+
+	full := &Msg{
+		MsgHdr: MsgHdr{
+			Id:                 4242,
+			Response:           true,
+			Opcode:             OpcodeUpdate,
+			Authoritative:      true,
+			Truncated:          true,
+			RecursionDesired:   true,
+			RecursionAvailable: true,
+			Zero:               true,
+			AuthenticatedData:  true,
+			CheckingDisabled:   true,
+			Rcode:              RcodeNameError,
+		},
+		Question: []Question{
+			{Name: "a.example.", Qtype: TypeA, Qclass: ClassINET},
+			{Name: "aaaa.example.", Qtype: TypeAAAA, Qclass: ClassCHAOS},
+		},
+		Answer: []RR{
+			&A{Hdr: header("a.example.", TypeA), A: net.IPv4(192, 0, 2, 1)},
+			&AAAA{Hdr: header("aaaa.example.", TypeAAAA), AAAA: net.ParseIP("2001:db8::1")},
+			&CNAME{Hdr: header("alias.example.", TypeCNAME), Target: "target.example."},
+			&NS{Hdr: header("example.", TypeNS), Ns: "ns1.example."},
+			&PTR{Hdr: header("1.2.0.192.in-addr.arpa.", TypePTR), Ptr: "ptr.example."},
+		},
+		Ns: []RR{
+			&TXT{Hdr: header("txt.example.", TypeTXT), Txt: []string{"chunk1", "chunk2"}},
+			&MX{Hdr: header("example.", TypeMX), Preference: 10, Mx: "mail.example."},
+			&SRV{Hdr: header("_service._tcp.example.", TypeSRV), Priority: 0, Weight: 5, Port: 443, Target: "srv.example."},
+			&SOA{
+				Hdr:     header("example.", TypeSOA),
+				Ns:      "ns1.example.",
+				Mbox:    "hostmaster.example.",
+				Serial:  2023120101,
+				Refresh: 7200,
+				Retry:   900,
+				Expire:  1209600,
+				Minttl:  3600,
+			},
+		},
+		Extra: []RR{
+			&CAA{Hdr: header("example.", TypeCAA), Flag: 0, Tag: "issue", Value: "letsencrypt.org"},
+			&NAPTR{
+				Hdr:         header("example.", TypeNAPTR),
+				Order:       100,
+				Preference:  50,
+				Flags:       "s",
+				Service:     "SIP+D2U",
+				Regexp:      "!^.*$!sip:info@example.com!",
+				Replacement: "_sip._udp.example.",
+			},
+			&DS{
+				Hdr:        header("example.", TypeDS),
+				KeyTag:     12345,
+				Algorithm:  8,
+				DigestType: 2,
+				Digest:     "BEEFCAFE0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123",
+			},
+			&DNSKEY{
+				Hdr:       header("example.", TypeDNSKEY),
+				Flags:     257,
+				Protocol:  3,
+				Algorithm: 8,
+				PublicKey: "AwEAAcR2examplePublicKey==",
+			},
+			&RRSIG{
+				Hdr:         header("example.", TypeRRSIG),
+				TypeCovered: TypeA,
+				Algorithm:   8,
+				Labels:      2,
+				OrigTtl:     600,
+				Expiration:  1735689600,
+				Inception:   1733097600,
+				KeyTag:      12345,
+				SignerName:  "example.",
+				Signature:   "exampleSignatureBase64==",
+			},
+			&TLSA{
+				Hdr:          header("_443._tcp.example.", TypeTLSA),
+				Usage:        3,
+				Selector:     1,
+				MatchingType: 1,
+				Certificate:  "abcdef1234567890",
+			},
+			fallbackRR,
+		},
+	}
+
+	minimal := new(Msg)
+	minimal.SetQuestion("minimal.example.", TypeTXT)
+
+	return map[string]*Msg{
+		"full":    full,
+		"minimal": minimal,
+	}
+}
+
+func mustRR(t *testing.T, s string) RR {
+	t.Helper()
+	rr, err := NewRR(s)
+	if err != nil {
+		t.Fatalf("failed to parse RR %q: %v", s, err)
+	}
+	return rr
+}
+
+func TestStringToType(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "known mnemonic", input: "A", want: TypeA},
+		{name: "case insensitive", input: "a", want: TypeA},
+		{name: "numeric string", input: "15", want: TypeMX},
+		{name: "unknown", input: "definitely-unknown", wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			got, err := stringToType(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("stringToType(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassToString(t *testing.T) {
+
+	tests := []struct {
+		name string
+		in   uint16
+		want string
+	}{
+		{name: "known class", in: ClassINET, want: "IN"},
+		{name: "unknown class", in: 9999, want: "9999"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			if got := classToString(tc.in); got != tc.want {
+				t.Fatalf("classToString(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTypeToString(t *testing.T) {
+
+	tests := []struct {
+		name string
+		in   uint16
+		want string
+	}{
+		{name: "known type", in: TypeAAAA, want: "AAAA"},
+		{name: "unknown type", in: 9999, want: "9999"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			if got := typeToString(tc.in); got != tc.want {
+				t.Fatalf("typeToString(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStringToClass(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "known mnemonic", input: "IN", want: ClassINET},
+		{name: "case insensitive", input: "in", want: ClassINET},
+		{name: "numeric string", input: "254", want: 254},
+		{name: "unknown", input: "definitely-unknown", wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			got, err := stringToClass(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("stringToClass(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetUintHelpers(t *testing.T) {
+
+	m := map[string]any{
+		"u8":    float64(42),
+		"u16":   int(65535),
+		"u32n":  json.Number("123456"),
+		"u32s":  "789",
+		"int64": int64(65535),
+	}
+
+	if got := getUint8(m, "u8"); got != 42 {
+		t.Fatalf("getUint8 = %d, want 42", got)
+	}
+	if got := getUint16(m, "u16"); got != 65535 {
+		t.Fatalf("getUint16 = %d, want 65535", got)
+	}
+	if got := getUint32(m, "u32n"); got != 123456 {
+		t.Fatalf("getUint32(json.Number) = %d, want 123456", got)
+	}
+	if got := getUint32(m, "u32s"); got != 789 {
+		t.Fatalf("getUint32(string) = %d, want 789", got)
+	}
+	if got := getUint16(m, "missing"); got != 0 {
+		t.Fatalf("getUint16 missing key = %d, want 0", got)
+	}
+	if got := getUint32(m, "int64"); got != 65535 {
+		t.Fatalf("getUint32 = %d, want 65535", got)
+	}
+}
+
+func TestGetStringSlice(t *testing.T) {
+
+	m := map[string]any{"txt": []any{"chunk1", "chunk2"}}
+	got, err := getStringSlice(m, "txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"chunk1", "chunk2"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("getStringSlice mismatch at %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+
+	_, err = getStringSlice(map[string]any{"txt": "not-a-slice"}, "txt")
+	if err == nil {
+		t.Fatal("expected error for non-slice input")
+	}
+
+	_, err = getStringSlice(map[string]any{"txt": []any{"ok", 123}}, "txt")
+	if err == nil {
+		t.Fatal("expected error for mixed slice")
+	}
+}
+
+func TestRRFromJSONFallback(t *testing.T) {
+
+	rr, err := rrFromJSON(RRJSON{
+		Name:  "fallback.example.",
+		Type:  "99",
+		Class: "IN",
+		TTL:   123,
+		Data: map[string]any{
+			"raw": "fallback.example. 0 IN TYPE99 \\# 0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rr == nil {
+		t.Fatalf("expected rr, got nil")
+	}
+	hdr := rr.Header()
+	if hdr.Name != "fallback.example." {
+		t.Fatalf("unexpected name: %q", hdr.Name)
+	}
+	if hdr.Ttl != 123 {
+		t.Fatalf("ttl not restored from JSON header: got %d", hdr.Ttl)
+	}
+	if hdr.Class != ClassINET {
+		t.Fatalf("unexpected class: %d", hdr.Class)
+	}
+	if hdr.Rrtype != 99 {
+		t.Fatalf("unexpected type: %d", hdr.Rrtype)
+	}
+}
+
+func TestRRsFromJSONAggregatesErrors(t *testing.T) {
+
+	valid := RRJSON{
+		Name:  "valid.example.",
+		Type:  "A",
+		Class: "IN",
+		TTL:   60,
+		Data:  map[string]any{"a": "192.0.2.1"},
+	}
+	invalid := RRJSON{
+		Name:  "invalid.example.",
+		Type:  "A",
+		Class: "IN",
+		TTL:   60,
+		Data:  map[string]any{"a": "not-an-ip"},
+	}
+
+	got, err := rrsFromJSON([]RRJSON{valid, invalid})
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !strings.Contains(err.Error(), "ParseAddr") {
+		t.Fatalf("unexpected error contents: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one successful RR, got %d", len(got))
+	}
+	if got[0].Header().Name != "valid.example." {
+		t.Fatalf("unexpected RR in output: %v", got[0])
+	}
+}
+
+func TestWrapError(t *testing.T) {
+
+	if got := wrapError(ErrInvalidJSON, nil); got != nil {
+		t.Fatalf("wrapError should return nil when err nil: got %v", got)
+	}
+
+	base := errors.New("boom")
+	err := wrapError(ErrInvalidJSON, base)
+	if !errors.Is(err, ErrInvalidJSON) {
+		t.Fatalf("expected errors.Is to match sentinel: %v", err)
+	}
+	if got := err.Error(); got != "dnsjson: invalid JSON: boom" {
+		t.Errorf("%q != %q", got, "dnsjson: invalid JSON: boom")
+	}
+	if errors.Unwrap(err) != base {
+		t.Fatalf("expected unwrap to yield original error, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestUnknownTypeErrorIs(t *testing.T) {
+
+	_, err := stringToType("definitely-unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+	if !errors.Is(err, ErrUnknownType) {
+		t.Fatalf("expected errors.Is to match ErrUnknownType: %v", err)
+	}
+	if errors.Is(err, ErrUnknownClass) {
+		t.Fatalf("unexpected match against ErrUnknownClass: %v", err)
+	}
+
+	var ute *unknownTypeError
+	if !errors.As(err, &ute) {
+		t.Fatalf("expected unknownTypeError, got %T", err)
+	}
+	if ute.Error() != "unknown type \"definitely-unknown\"" {
+		t.Fatalf("unexpected error string: %q", ute.Error())
+	}
+}
+
+func TestUnknownClassErrorIs(t *testing.T) {
+	_, err := stringToClass("definitely-unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown class")
+	}
+	if !errors.Is(err, ErrUnknownClass) {
+		t.Fatalf("expected errors.Is to match ErrUnknownClass: %v", err)
+	}
+	if errors.Is(err, ErrUnknownType) {
+		t.Fatalf("unexpected match against ErrUnknownType: %v", err)
+	}
+
+	var uce *unknownClassError
+	if !errors.As(err, &uce) {
+		t.Fatalf("expected unknownClassError, got %T", err)
+	}
+	if uce.Error() != "unknown class \"definitely-unknown\"" {
+		t.Fatalf("unexpected error string: %q", uce.Error())
+	}
+}
+
+func TestStringSliceErrorIs(t *testing.T) {
+	_, err := getStringSlice(map[string]any{"txt": "not-a-slice"}, "txt")
+	if err == nil {
+		t.Fatal("expected error for invalid string slice")
+	}
+	if !errors.Is(err, ErrInvalidStringSlice) {
+		t.Fatalf("expected errors.Is to match ErrInvalidStringSlice: %v", err)
+	}
+
+	var sse *stringSliceError
+	if !errors.As(err, &sse) {
+		t.Fatalf("expected stringSliceError, got %T", err)
+	}
+	if sse.Error() != "txt must be array of strings" {
+		t.Fatalf("unexpected error string: %q", sse.Error())
+	}
+}

--- a/json_test.go
+++ b/json_test.go
@@ -8,6 +8,672 @@ import (
 	"testing"
 )
 
+func TestStringToType(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "known mnemonic", input: "A", want: TypeA},
+		{name: "case insensitive", input: "a", want: TypeA},
+		{name: "numeric string", input: "15", want: TypeMX},
+		{name: "unknown", input: "definitely-unknown", wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			got, err := stringToType(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("stringToType(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassToString(t *testing.T) {
+
+	tests := []struct {
+		name string
+		in   uint16
+		want string
+	}{
+		{name: "known class", in: ClassINET, want: "IN"},
+		{name: "unknown class", in: 9999, want: "9999"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			if got := classToString(tc.in); got != tc.want {
+				t.Fatalf("classToString(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTypeToString(t *testing.T) {
+	tests := []struct {
+		name string
+		in   uint16
+		want string
+	}{
+		{name: "known type", in: TypeAAAA, want: "AAAA"},
+		{name: "unknown type", in: 9999, want: "9999"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			if got := typeToString(tc.in); got != tc.want {
+				t.Fatalf("typeToString(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStringToClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "known mnemonic", input: "IN", want: ClassINET},
+		{name: "case insensitive", input: "in", want: ClassINET},
+		{name: "numeric string", input: "254", want: 254},
+		{name: "unknown", input: "definitely-unknown", wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			got, err := stringToClass(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("stringToClass(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetUintHelpers(t *testing.T) {
+	m := map[string]any{
+		"u8":    float64(42),
+		"u16":   int(65535),
+		"u32n":  json.Number("123456"),
+		"u32s":  "789",
+		"int64": int64(65535),
+	}
+
+	if got := getUint8(m, "u8"); got != 42 {
+		t.Fatalf("getUint8 = %d, want 42", got)
+	}
+	if got := getUint16(m, "u16"); got != 65535 {
+		t.Fatalf("getUint16 = %d, want 65535", got)
+	}
+	if got := getUint32(m, "u32n"); got != 123456 {
+		t.Fatalf("getUint32(json.Number) = %d, want 123456", got)
+	}
+	if got := getUint32(m, "u32s"); got != 789 {
+		t.Fatalf("getUint32(string) = %d, want 789", got)
+	}
+	if got := getUint16(m, "missing"); got != 0 {
+		t.Fatalf("getUint16 missing key = %d, want 0", got)
+	}
+	if got := getUint32(m, "int64"); got != 65535 {
+		t.Fatalf("getUint32 = %d, want 65535", got)
+	}
+}
+
+func TestGetStringSlice(t *testing.T) {
+	m := map[string]any{"txt": []any{"chunk1", "chunk2"}}
+	got, err := getStringSlice(m, "txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []string{"chunk1", "chunk2"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("getStringSlice mismatch at %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+
+	_, err = getStringSlice(map[string]any{"txt": "not-a-slice"}, "txt")
+	if err == nil {
+		t.Fatal("expected error for non-slice input")
+	}
+
+	_, err = getStringSlice(map[string]any{"txt": []any{"ok", 123}}, "txt")
+	if err == nil {
+		t.Fatal("expected error for mixed slice")
+	}
+}
+
+func TestGetUint8Slice(t *testing.T) {
+	m := map[string]any{
+		"algs": []any{float64(1), json.Number("2"), uint8(3)},
+	}
+
+	got, err := getUint8Slice(m, "algs")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []uint8{1, 2, 3}
+	if len(got) != len(want) {
+		t.Fatalf("length mismatch: got %d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("value mismatch at %d: got %d want %d", i, got[i], want[i])
+		}
+	}
+
+	if _, err := getUint8Slice(map[string]any{"algs": "not-an-array"}, "algs"); !errors.Is(err, ErrUint8SliceType) {
+		t.Fatalf("expected ErrUint8SliceType, got %v", err)
+	}
+
+	if _, err := getUint8Slice(map[string]any{"algs": []any{true}}, "algs"); !errors.Is(err, ErrInvalidNumberType) {
+		t.Fatalf("expected ErrInvalidNumberType, got %v", err)
+	}
+
+	if _, err := getUint8Slice(map[string]any{"algs": []any{float64(-1)}}, "algs"); !errors.Is(err, ErrNegativeValue) {
+		t.Fatalf("expected ErrNegativeValue, got %v", err)
+	}
+
+	if _, err := getUint8Slice(map[string]any{"algs": []any{float64(300)}}, "algs"); !errors.Is(err, ErrUint8SliceRange) {
+		t.Fatalf("expected ErrUint8SliceRange, got %v", err)
+	}
+}
+
+func TestAnyToUint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    uint64
+		wantErr error
+	}{
+		{name: "float", input: float64(42.5), want: 42},
+		{name: "negative float", input: float64(-1), wantErr: ErrNegativeValue},
+		{name: "json number", input: json.Number("10"), want: 10},
+		{name: "json number string", input: json.Number("-11"), wantErr: ErrNegativeValue},
+		{name: "string", input: "123", want: 123},
+		{name: "int", input: int(1), want: 1},
+		{name: "int64", input: int64(1), want: 1},
+		{name: "uint8", input: uint8(1), want: 1},
+		{name: "uint16", input: uint16(1), want: 1},
+		{name: "uint32", input: uint32(1), want: 1},
+		{name: "uint64", input: uint64(1), want: 1},
+		{name: "negative int", input: int(-5), wantErr: ErrNegativeValue},
+		{name: "negative int64", input: int64(-5), wantErr: ErrNegativeValue},
+		{name: "invalid type", input: true, wantErr: ErrInvalidNumberType},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := anyToUint64(tc.input)
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Fatalf("expected error %v, got nil", tc.wantErr)
+				}
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("anyToUint64(%v) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetBool(t *testing.T) {
+	m := map[string]any{
+		"bool":         true,
+		"string":       "true",
+		"stringBad":    "nope",
+		"floatZero":    float64(0),
+		"float":        float64(2),
+		"jsonZero":     json.Number("0"),
+		"jsonPositive": json.Number("5"),
+	}
+
+	tests := []struct {
+		name string
+		key  string
+		want bool
+		ok   bool
+	}{
+		{name: "bool", key: "bool", want: true, ok: true},
+		{name: "string", key: "string", want: true, ok: true},
+		{name: "string invalid", key: "stringBad", want: false, ok: false},
+		{name: "float zero", key: "floatZero", want: false, ok: true},
+		{name: "float positive", key: "float", want: true, ok: true},
+		{name: "json zero", key: "jsonZero", want: false, ok: true},
+		{name: "json positive", key: "jsonPositive", want: true, ok: true},
+		{name: "missing", key: "missing", want: false, ok: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := getBool(m, tc.key)
+			if got != tc.want || ok != tc.ok {
+				t.Fatalf("getBool(%q) = (%v, %v), want (%v, %v)", tc.key, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestRRFromJSONFallback(t *testing.T) {
+	rr, err := rrFromJSON(RRJSON{
+		Name:  "fallback.example.",
+		Type:  "99",
+		Class: "IN",
+		TTL:   123,
+		Data: map[string]any{
+			"raw": "fallback.example. 0 IN TYPE99 \\# 0",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rr == nil {
+		t.Fatalf("expected rr, got nil")
+	}
+	hdr := rr.Header()
+	if hdr.Name != "fallback.example." {
+		t.Fatalf("unexpected name: %q", hdr.Name)
+	}
+	if hdr.Ttl != 123 {
+		t.Fatalf("ttl not restored from JSON header: got %d", hdr.Ttl)
+	}
+	if hdr.Class != ClassINET {
+		t.Fatalf("unexpected class: %d", hdr.Class)
+	}
+	if hdr.Rrtype != 99 {
+		t.Fatalf("unexpected type: %d", hdr.Rrtype)
+	}
+}
+
+func TestRRFromJSONErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input RRJSON
+		check func(*testing.T, error)
+	}{
+		{
+			name:  "unknown type",
+			input: RRJSON{Type: "definitely-unknown", Class: "IN"},
+			check: func(t *testing.T, err error) {
+				var ute *unknownTypeError
+				if !errors.As(err, &ute) {
+					t.Fatalf("expected unknownTypeError, got %T", err)
+				}
+			},
+		},
+		{
+			name:  "unknown class",
+			input: RRJSON{Type: "A", Class: "definitely-unknown", Data: map[string]any{"a": "192.0.2.1"}},
+			check: func(t *testing.T, err error) {
+				var uce *unknownClassError
+				if !errors.As(err, &uce) {
+					t.Fatalf("expected unknownClassError, got %T", err)
+				}
+			},
+		},
+		{
+			name:  "invalid ipv4",
+			input: RRJSON{Type: "A", Class: "IN", Data: map[string]any{"a": "not-an-ip"}},
+			check: func(t *testing.T, err error) {
+				if !strings.Contains(err.Error(), "ParseAddr") {
+					t.Fatalf("expected ParseAddr error, got %v", err)
+				}
+			},
+		},
+		{
+			name:  "txt invalid slice",
+			input: RRJSON{Type: "TXT", Class: "IN", Data: map[string]any{"txt": "not-a-slice"}},
+			check: func(t *testing.T, err error) {
+				if !errors.Is(err, ErrInvalidStringSlice) {
+					t.Fatalf("expected ErrInvalidStringSlice, got %v", err)
+				}
+			},
+		},
+		{
+			name:  "opt options not array",
+			input: RRJSON{Type: "OPT", Class: "IN", Data: map[string]any{"options": "not-an-array"}},
+			check: func(t *testing.T, err error) {
+				if !errors.Is(err, ErrEDNSOptionsNotArray) {
+					t.Fatalf("expected ErrEDNSOptionsNotArray, got %v", err)
+				}
+			},
+		},
+		{
+			name:  "opt option not object",
+			input: RRJSON{Type: "OPT", Class: "IN", Data: map[string]any{"options": []any{"not-an-object"}}},
+			check: func(t *testing.T, err error) {
+				if !errors.Is(err, ErrEDNSOptionEntry) {
+					t.Fatalf("expected ErrEDNSOptionEntry, got %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Helper()
+
+			rr, err := rrFromJSON(tc.input)
+			if err == nil {
+				t.Fatalf("expected error, got rr=%v", rr)
+			}
+			if rr != nil {
+				t.Fatalf("expected nil RR on error, got %T", rr)
+			}
+			tc.check(t, err)
+		})
+	}
+}
+
+func TestRRsFromJSONAggregatesErrors(t *testing.T) {
+	valid := RRJSON{
+		Name:  "valid.example.",
+		Type:  "A",
+		Class: "IN",
+		TTL:   60,
+		Data:  map[string]any{"a": "192.0.2.1"},
+	}
+	invalid := RRJSON{
+		Name:  "invalid.example.",
+		Type:  "A",
+		Class: "IN",
+		TTL:   60,
+		Data:  map[string]any{"a": "not-an-ip"},
+	}
+
+	got, err := rrsFromJSON([]RRJSON{valid, invalid})
+	if err == nil {
+		t.Fatal("expected aggregated error")
+	}
+	if !strings.Contains(err.Error(), "ParseAddr") {
+		t.Fatalf("unexpected error contents: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one successful RR, got %d", len(got))
+	}
+	if got[0].Header().Name != "valid.example." {
+		t.Fatalf("unexpected RR in output: %v", got[0])
+	}
+}
+
+func TestWrapError(t *testing.T) {
+	if got := wrapError(ErrInvalidJSON, nil); got != nil {
+		t.Fatalf("wrapError should return nil when err nil: got %v", got)
+	}
+
+	base := errors.New("boom")
+	err := wrapError(ErrInvalidJSON, base)
+	if !errors.Is(err, ErrInvalidJSON) {
+		t.Fatalf("expected errors.Is to match sentinel: %v", err)
+	}
+	if got := err.Error(); got != "invalid JSON: boom" {
+		t.Errorf("%q != %q", got, "invalid JSON: boom")
+	}
+	if errors.Unwrap(err) != base {
+		t.Fatalf("expected unwrap to yield original error, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestUnknownTypeErrorIs(t *testing.T) {
+	_, err := stringToType("definitely-unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown type")
+	}
+	if !errors.Is(err, ErrUnknownType) {
+		t.Fatalf("expected errors.Is to match ErrUnknownType: %v", err)
+	}
+	if errors.Is(err, ErrUnknownClass) {
+		t.Fatalf("unexpected match against ErrUnknownClass: %v", err)
+	}
+
+	var ute *unknownTypeError
+	if !errors.As(err, &ute) {
+		t.Fatalf("expected unknownTypeError, got %T", err)
+	}
+	if ute.Error() != "unknown type \"definitely-unknown\"" {
+		t.Fatalf("unexpected error string: %q", ute.Error())
+	}
+}
+
+func TestUnknownClassErrorIs(t *testing.T) {
+	_, err := stringToClass("definitely-unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown class")
+	}
+	if !errors.Is(err, ErrUnknownClass) {
+		t.Fatalf("expected errors.Is to match ErrUnknownClass: %v", err)
+	}
+	if errors.Is(err, ErrUnknownType) {
+		t.Fatalf("unexpected match against ErrUnknownType: %v", err)
+	}
+
+	var uce *unknownClassError
+	if !errors.As(err, &uce) {
+		t.Fatalf("expected unknownClassError, got %T", err)
+	}
+	if uce.Error() != "unknown class \"definitely-unknown\"" {
+		t.Fatalf("unexpected error string: %q", uce.Error())
+	}
+}
+
+func TestStringSliceErrorIs(t *testing.T) {
+	_, err := getStringSlice(map[string]any{"txt": "not-a-slice"}, "txt")
+	if err == nil {
+		t.Fatal("expected error for invalid string slice")
+	}
+	if !errors.Is(err, ErrInvalidStringSlice) {
+		t.Fatalf("expected errors.Is to match ErrInvalidStringSlice: %v", err)
+	}
+
+	var sse *stringSliceError
+	if !errors.As(err, &sse) {
+		t.Fatalf("expected stringSliceError, got %T", err)
+	}
+	if sse.Error() != "txt must be array of strings" {
+		t.Fatalf("unexpected error string: %q", sse.Error())
+	}
+}
+
+func TestStringToOptionCode(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCode  uint16
+		wantError bool
+	}{
+		{name: "known mnemonic", input: "NSID", wantCode: EDNS0NSID},
+		{name: "case insensitive", input: "subnet", wantCode: EDNS0SUBNET},
+		{name: "alias", input: "tcp_keepalive", wantCode: EDNS0TCPKEEPALIVE},
+		{name: "numeric", input: "65000", wantCode: 65000},
+		{name: "unknown", input: "definitely-unknown", wantError: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := stringToOptionCode(tc.input)
+			if tc.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.input)
+				}
+				var uoe *unknownOptionError
+				if !errors.As(err, &uoe) {
+					t.Fatalf("expected unknownOptionError, got %T", err)
+				}
+				if uoe.Error() != "unknown option code \""+tc.input+"\"" {
+					t.Fatalf("unexpected error string: %q", uoe.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.wantCode {
+				t.Fatalf("stringToOptionCode(%q) = %d, want %d", tc.input, got, tc.wantCode)
+			}
+		})
+	}
+}
+
+func TestOptOptionEntryError(t *testing.T) {
+	err := &optOptionEntryError{index: 3}
+	if got := err.Error(); got != "opt options[3] must be object" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+	if !errors.Is(err, ErrEDNSOptionEntry) {
+		t.Fatalf("expected errors.Is to match ErrEDNSOptionEntry, got %v", err)
+	}
+}
+
+func TestOptOptionCodeError(t *testing.T) {
+	err := &optOptionCodeError{code: "NSID"}
+	if got := err.Error(); got != "opt option NSID" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+	if !errors.Is(err, ErrEDNSOption) {
+		t.Fatalf("expected errors.Is to match ErrEDNSOption, got %v", err)
+	}
+
+	inner := errors.New("boom")
+	err = &optOptionCodeError{code: "NSID", err: inner}
+	if got := err.Error(); got != "opt option NSID: boom" {
+		t.Fatalf("unexpected wrapped error string: %q", got)
+	}
+	if !errors.Is(err, ErrEDNSOption) {
+		t.Fatalf("expected errors.Is to match ErrEDNSOption for wrapped error, got %v", err)
+	}
+	if !errors.Is(err, inner) {
+		t.Fatalf("expected errors.Is to match wrapped error, got %v", err)
+	}
+	if errors.Unwrap(err) != inner {
+		t.Fatalf("expected Unwrap to return inner error, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestEDNSOptionFromJSONErrors(t *testing.T) {
+	t.Run("missing code", func(t *testing.T) {
+		if opt, err := ednsOptionFromJSON(map[string]any{}); err == nil {
+			t.Fatalf("expected ErrEDNSOptionNoCode, got option=%v", opt)
+		} else if !errors.Is(err, ErrEDNSOptionNoCode) {
+			t.Fatalf("expected ErrEDNSOptionNoCode, got %v", err)
+		}
+	})
+
+	t.Run("unknown code", func(t *testing.T) {
+		if _, err := ednsOptionFromJSON(map[string]any{"code": "definitely-unknown"}); err == nil {
+			t.Fatal("expected error for unknown option code")
+		} else {
+			var uoe *unknownOptionError
+			if !errors.As(err, &uoe) {
+				t.Fatalf("expected unknownOptionError, got %T", err)
+			}
+		}
+	})
+
+	t.Run("invalid subnet payload", func(t *testing.T) {
+		if opt, err := ednsOptionFromJSON(map[string]any{"code": "SUBNET", "address": "not-an-ip"}); err == nil {
+			t.Fatalf("expected error, got option=%v", opt)
+		} else {
+			if !errors.Is(err, ErrEDNSOption) {
+				t.Fatalf("expected errors.Is to match ErrEDNSOption, got %v", err)
+			}
+			var optErr *optOptionCodeError
+			if !errors.As(err, &optErr) {
+				t.Fatalf("expected optOptionCodeError, got %T", err)
+			}
+			if optErr.code != "SUBNET" {
+				t.Fatalf("unexpected option code: %q", optErr.code)
+			}
+			if optErr.err == nil {
+				t.Fatal("expected wrapped error for invalid subnet payload")
+			}
+		}
+	})
+}
+
+func TestKeyArrayError(t *testing.T) {
+	err := &keyArrayError{key: "algs"}
+	if got := err.Error(); got != "algs must be array" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+	if !errors.Is(err, ErrUint8SliceType) {
+		t.Fatalf("expected errors.Is to match ErrUint8SliceType, got %v", err)
+	}
+}
+
+func TestKeyIndexError(t *testing.T) {
+	err := &keyIndexError{key: "algs", index: 1}
+	if got := err.Error(); got != "algs[1]" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+	if !errors.Is(err, ErrUint8SliceElement) {
+		t.Fatalf("expected errors.Is to match ErrUint8SliceElement, got %v", err)
+	}
+
+	inner := ErrInvalidNumberType
+	err = &keyIndexError{key: "algs", index: 2, err: inner}
+	if got := err.Error(); got != "algs[2]: invalid number type" {
+		t.Fatalf("unexpected wrapped error string: %q", got)
+	}
+	if !errors.Is(err, ErrUint8SliceElement) {
+		t.Fatalf("expected errors.Is to match ErrUint8SliceElement for wrapped error, got %v", err)
+	}
+	if !errors.Is(err, inner) {
+		t.Fatalf("expected errors.Is to match wrapped error, got %v", err)
+	}
+	if errors.Unwrap(err) != inner {
+		t.Fatalf("expected Unwrap to return inner error, got %v", errors.Unwrap(err))
+	}
+}
+
+func TestKeyIndexRangeError(t *testing.T) {
+	err := &keyIndexRangeError{key: "algs", index: 4}
+	if got := err.Error(); got != "algs[4]: value out of range" {
+		t.Fatalf("unexpected error string: %q", got)
+	}
+	if !errors.Is(err, ErrUint8SliceRange) {
+		t.Fatalf("expected errors.Is to match ErrUint8SliceRange, got %v", err)
+	}
+}
+
 const fallbackType = 65280
 
 func TestMsgJSONRoundTrip(t *testing.T) {
@@ -29,6 +695,7 @@ func TestMsgJSONRoundTrip(t *testing.T) {
 		TypeDNSKEY:   "DNSKEY",
 		TypeRRSIG:    "RRSIG",
 		TypeTLSA:     "TLSA",
+		TypeOPT:      "OPT",
 		fallbackType: "TYPE65280",
 	}
 
@@ -76,7 +743,6 @@ func TestMsgJSONRoundTrip(t *testing.T) {
 }
 
 func TestMsgMarshalNil(t *testing.T) {
-
 	var m *Msg
 	got, err := json.Marshal(m)
 	if err != nil {
@@ -88,7 +754,6 @@ func TestMsgMarshalNil(t *testing.T) {
 }
 
 func TestMsgUnmarshalNull(t *testing.T) {
-
 	var msg Msg
 	if err := json.Unmarshal([]byte("null"), &msg); err != nil {
 		t.Fatalf("Unmarshal null failed: %v", err)
@@ -113,6 +778,32 @@ func messageFixtures(t *testing.T) map[string]*Msg {
 	fallbackRR.Header().Class = ClassINET
 	fallbackRR.Header().Rrtype = fallbackType
 	fallbackRR.Header().Ttl = 3600
+
+	edns := new(OPT)
+	edns.Hdr.Name = "."
+	edns.Hdr.Rrtype = TypeOPT
+	edns.SetUDPSize(1232)
+	edns.SetExtendedRcode(0x5A << 4)
+	edns.SetVersion(1)
+	edns.SetDo(true)
+	edns.SetCo(true)
+	edns.SetZ(0x1234)
+	edns.Option = append(edns.Option,
+		&EDNS0_NSID{Code: EDNS0NSID, Nsid: "31323334"},
+		&EDNS0_SUBNET{Code: EDNS0SUBNET, Family: 1, SourceNetmask: 24, SourceScope: 0, Address: net.IPv4(198, 51, 100, 0)},
+		&EDNS0_COOKIE{Code: EDNS0COOKIE, Cookie: "00112233445566778899aabbccddeeff"},
+		&EDNS0_UL{Code: EDNS0UL, Lease: 3600, KeyLease: 7200},
+		&EDNS0_LLQ{Code: EDNS0LLQ, Version: 1, Opcode: 2, Error: 0, Id: 123456789, LeaseLife: 600},
+		&EDNS0_DAU{Code: EDNS0DAU, AlgCode: []uint8{8, 13}},
+		&EDNS0_DHU{Code: EDNS0DHU, AlgCode: []uint8{1, 2}},
+		&EDNS0_N3U{Code: EDNS0N3U, AlgCode: []uint8{1}},
+		&EDNS0_EXPIRE{Code: EDNS0EXPIRE, Expire: 86400, Empty: true},
+		&EDNS0_LOCAL{Code: EDNS0LOCALSTART + 1, Data: []byte{0xDE, 0xAD, 0xBE, 0xEF}},
+		&EDNS0_TCP_KEEPALIVE{Code: EDNS0TCPKEEPALIVE, Timeout: 10},
+		&EDNS0_PADDING{Padding: []byte{0x00, 0x01, 0x02, 0x03}},
+		&EDNS0_EDE{InfoCode: ExtendedErrorCodeBlocked, ExtraText: "blocked"},
+		&EDNS0_ESU{Code: EDNS0ESU, Uri: "sip:example.com"},
+	)
 
 	full := &Msg{
 		MsgHdr: MsgHdr{
@@ -198,6 +889,7 @@ func messageFixtures(t *testing.T) map[string]*Msg {
 				MatchingType: 1,
 				Certificate:  "abcdef1234567890",
 			},
+			edns,
 			fallbackRR,
 		},
 	}
@@ -218,316 +910,4 @@ func mustRR(t *testing.T, s string) RR {
 		t.Fatalf("failed to parse RR %q: %v", s, err)
 	}
 	return rr
-}
-
-func TestStringToType(t *testing.T) {
-
-	tests := []struct {
-		name    string
-		input   string
-		want    uint16
-		wantErr bool
-	}{
-		{name: "known mnemonic", input: "A", want: TypeA},
-		{name: "case insensitive", input: "a", want: TypeA},
-		{name: "numeric string", input: "15", want: TypeMX},
-		{name: "unknown", input: "definitely-unknown", wantErr: true},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-
-			got, err := stringToType(tc.input)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error for %q", tc.input)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error for %q: %v", tc.input, err)
-			}
-			if got != tc.want {
-				t.Fatalf("stringToType(%q) = %d, want %d", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestClassToString(t *testing.T) {
-
-	tests := []struct {
-		name string
-		in   uint16
-		want string
-	}{
-		{name: "known class", in: ClassINET, want: "IN"},
-		{name: "unknown class", in: 9999, want: "9999"},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-
-			if got := classToString(tc.in); got != tc.want {
-				t.Fatalf("classToString(%d) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestTypeToString(t *testing.T) {
-
-	tests := []struct {
-		name string
-		in   uint16
-		want string
-	}{
-		{name: "known type", in: TypeAAAA, want: "AAAA"},
-		{name: "unknown type", in: 9999, want: "9999"},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-
-			if got := typeToString(tc.in); got != tc.want {
-				t.Fatalf("typeToString(%d) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestStringToClass(t *testing.T) {
-
-	tests := []struct {
-		name    string
-		input   string
-		want    uint16
-		wantErr bool
-	}{
-		{name: "known mnemonic", input: "IN", want: ClassINET},
-		{name: "case insensitive", input: "in", want: ClassINET},
-		{name: "numeric string", input: "254", want: 254},
-		{name: "unknown", input: "definitely-unknown", wantErr: true},
-	}
-	for _, tc := range tests {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-
-			got, err := stringToClass(tc.input)
-			if tc.wantErr {
-				if err == nil {
-					t.Fatalf("expected error for %q", tc.input)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error for %q: %v", tc.input, err)
-			}
-			if got != tc.want {
-				t.Fatalf("stringToClass(%q) = %d, want %d", tc.input, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestGetUintHelpers(t *testing.T) {
-
-	m := map[string]any{
-		"u8":    float64(42),
-		"u16":   int(65535),
-		"u32n":  json.Number("123456"),
-		"u32s":  "789",
-		"int64": int64(65535),
-	}
-
-	if got := getUint8(m, "u8"); got != 42 {
-		t.Fatalf("getUint8 = %d, want 42", got)
-	}
-	if got := getUint16(m, "u16"); got != 65535 {
-		t.Fatalf("getUint16 = %d, want 65535", got)
-	}
-	if got := getUint32(m, "u32n"); got != 123456 {
-		t.Fatalf("getUint32(json.Number) = %d, want 123456", got)
-	}
-	if got := getUint32(m, "u32s"); got != 789 {
-		t.Fatalf("getUint32(string) = %d, want 789", got)
-	}
-	if got := getUint16(m, "missing"); got != 0 {
-		t.Fatalf("getUint16 missing key = %d, want 0", got)
-	}
-	if got := getUint32(m, "int64"); got != 65535 {
-		t.Fatalf("getUint32 = %d, want 65535", got)
-	}
-}
-
-func TestGetStringSlice(t *testing.T) {
-
-	m := map[string]any{"txt": []any{"chunk1", "chunk2"}}
-	got, err := getStringSlice(m, "txt")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	want := []string{"chunk1", "chunk2"}
-	if len(got) != len(want) {
-		t.Fatalf("len mismatch: got %d want %d", len(got), len(want))
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("getStringSlice mismatch at %d: got %q want %q", i, got[i], want[i])
-		}
-	}
-
-	_, err = getStringSlice(map[string]any{"txt": "not-a-slice"}, "txt")
-	if err == nil {
-		t.Fatal("expected error for non-slice input")
-	}
-
-	_, err = getStringSlice(map[string]any{"txt": []any{"ok", 123}}, "txt")
-	if err == nil {
-		t.Fatal("expected error for mixed slice")
-	}
-}
-
-func TestRRFromJSONFallback(t *testing.T) {
-
-	rr, err := rrFromJSON(RRJSON{
-		Name:  "fallback.example.",
-		Type:  "99",
-		Class: "IN",
-		TTL:   123,
-		Data: map[string]any{
-			"raw": "fallback.example. 0 IN TYPE99 \\# 0",
-		},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if rr == nil {
-		t.Fatalf("expected rr, got nil")
-	}
-	hdr := rr.Header()
-	if hdr.Name != "fallback.example." {
-		t.Fatalf("unexpected name: %q", hdr.Name)
-	}
-	if hdr.Ttl != 123 {
-		t.Fatalf("ttl not restored from JSON header: got %d", hdr.Ttl)
-	}
-	if hdr.Class != ClassINET {
-		t.Fatalf("unexpected class: %d", hdr.Class)
-	}
-	if hdr.Rrtype != 99 {
-		t.Fatalf("unexpected type: %d", hdr.Rrtype)
-	}
-}
-
-func TestRRsFromJSONAggregatesErrors(t *testing.T) {
-
-	valid := RRJSON{
-		Name:  "valid.example.",
-		Type:  "A",
-		Class: "IN",
-		TTL:   60,
-		Data:  map[string]any{"a": "192.0.2.1"},
-	}
-	invalid := RRJSON{
-		Name:  "invalid.example.",
-		Type:  "A",
-		Class: "IN",
-		TTL:   60,
-		Data:  map[string]any{"a": "not-an-ip"},
-	}
-
-	got, err := rrsFromJSON([]RRJSON{valid, invalid})
-	if err == nil {
-		t.Fatal("expected aggregated error")
-	}
-	if !strings.Contains(err.Error(), "ParseAddr") {
-		t.Fatalf("unexpected error contents: %v", err)
-	}
-	if len(got) != 1 {
-		t.Fatalf("expected one successful RR, got %d", len(got))
-	}
-	if got[0].Header().Name != "valid.example." {
-		t.Fatalf("unexpected RR in output: %v", got[0])
-	}
-}
-
-func TestWrapError(t *testing.T) {
-
-	if got := wrapError(ErrInvalidJSON, nil); got != nil {
-		t.Fatalf("wrapError should return nil when err nil: got %v", got)
-	}
-
-	base := errors.New("boom")
-	err := wrapError(ErrInvalidJSON, base)
-	if !errors.Is(err, ErrInvalidJSON) {
-		t.Fatalf("expected errors.Is to match sentinel: %v", err)
-	}
-	if got := err.Error(); got != "invalid JSON: boom" {
-		t.Errorf("%q != %q", got, "invalid JSON: boom")
-	}
-	if errors.Unwrap(err) != base {
-		t.Fatalf("expected unwrap to yield original error, got %v", errors.Unwrap(err))
-	}
-}
-
-func TestUnknownTypeErrorIs(t *testing.T) {
-
-	_, err := stringToType("definitely-unknown")
-	if err == nil {
-		t.Fatal("expected error for unknown type")
-	}
-	if !errors.Is(err, ErrUnknownType) {
-		t.Fatalf("expected errors.Is to match ErrUnknownType: %v", err)
-	}
-	if errors.Is(err, ErrUnknownClass) {
-		t.Fatalf("unexpected match against ErrUnknownClass: %v", err)
-	}
-
-	var ute *unknownTypeError
-	if !errors.As(err, &ute) {
-		t.Fatalf("expected unknownTypeError, got %T", err)
-	}
-	if ute.Error() != "unknown type \"definitely-unknown\"" {
-		t.Fatalf("unexpected error string: %q", ute.Error())
-	}
-}
-
-func TestUnknownClassErrorIs(t *testing.T) {
-	_, err := stringToClass("definitely-unknown")
-	if err == nil {
-		t.Fatal("expected error for unknown class")
-	}
-	if !errors.Is(err, ErrUnknownClass) {
-		t.Fatalf("expected errors.Is to match ErrUnknownClass: %v", err)
-	}
-	if errors.Is(err, ErrUnknownType) {
-		t.Fatalf("unexpected match against ErrUnknownType: %v", err)
-	}
-
-	var uce *unknownClassError
-	if !errors.As(err, &uce) {
-		t.Fatalf("expected unknownClassError, got %T", err)
-	}
-	if uce.Error() != "unknown class \"definitely-unknown\"" {
-		t.Fatalf("unexpected error string: %q", uce.Error())
-	}
-}
-
-func TestStringSliceErrorIs(t *testing.T) {
-	_, err := getStringSlice(map[string]any{"txt": "not-a-slice"}, "txt")
-	if err == nil {
-		t.Fatal("expected error for invalid string slice")
-	}
-	if !errors.Is(err, ErrInvalidStringSlice) {
-		t.Fatalf("expected errors.Is to match ErrInvalidStringSlice: %v", err)
-	}
-
-	var sse *stringSliceError
-	if !errors.As(err, &sse) {
-		t.Fatalf("expected stringSliceError, got %T", err)
-	}
-	if sse.Error() != "txt must be array of strings" {
-		t.Fatalf("unexpected error string: %q", sse.Error())
-	}
 }

--- a/json_test.go
+++ b/json_test.go
@@ -463,8 +463,8 @@ func TestWrapError(t *testing.T) {
 	if !errors.Is(err, ErrInvalidJSON) {
 		t.Fatalf("expected errors.Is to match sentinel: %v", err)
 	}
-	if got := err.Error(); got != "dnsjson: invalid JSON: boom" {
-		t.Errorf("%q != %q", got, "dnsjson: invalid JSON: boom")
+	if got := err.Error(); got != "invalid JSON: boom" {
+		t.Errorf("%q != %q", got, "invalid JSON: boom")
 	}
 	if errors.Unwrap(err) != base {
 		t.Fatalf("expected unwrap to yield original error, got %v", errors.Unwrap(err))


### PR DESCRIPTION
MarshalJSON generates JSON using an explicit, human-readable JSON schema.
Full test coverage is provided.

Schema overview (stable keys; rdata keys per RR type listed below):

```
	{
	  "id": 1234,
	  "msgHdr": {"qr":true, "opcode":"QUERY", "aa":false, "tc":false, "rd":true,
	              "ra":true, "z":0, "ad":false, "cd":false, "rcode":"NOERROR"},
	  "question": [{"name":"example.com.", "qtype":"A", "qclass":"IN"}],
	  "answer":  [ RRJSON, ... ],
	  "ns":      [ RRJSON, ... ],
	  "extra":   [ RRJSON, ... ]
	}
```

RRJSON (common fields) + per-type data (examples):

```json
	{
	  "name":"example.com.", "type":"A", "class":"IN", "ttl":300,
	  "data": { "a":"93.184.216.34" }
	}
```

```
AAAA: {"aaaa":"2001:db8::1"}
CNAME: {"target":"alias.example."}
NS: {"ns":"ns1.example."}
PTR: {"ptr":"host.example."}
TXT: {"txt":["chunk1","chunk2"]}
MX: {"preference":10, "mx":"mail.example."}
SRV: {"priority":0, "weight":5, "port":443, "target":"svc.example."}
SOA: {"ns":"ns1.", "mbox":"hostmaster.", "serial":1, "refresh":7200, "retry":900, "expire":1209600, "minttl":300}
CAA: {"flag":0, "tag":"issue", "value":"letsencrypt.org"}
NAPTR: {"order":100, "preference":50, "flags":"s", "services":"SIP+D2U", "regexp":"", "replacement":"_sip._udp.example."}
DS: {"key_tag":12345, "algorithm":8, "digest_type":2, "digest":"...hex..."}
DNSKEY: {"flags":257, "protocol":3, "algorithm":8, "public_key":"base64..."}
RRSIG: {"type_covered":"A", "algorithm":8, "labels":2, "original_ttl":300,
	"expiration": 1735689600, "inception": 1733097600, "key_tag":12345,
	"signer_name":"example.", "signature":"base64..."}
TLSA: {"usage":3, "selector":1, "matching_type":1, "cert_data":"hex or base64"}
```

Notes
  - Type/class use standard mnemonics (e.g., "A", "AAAA", "IN").
  - Unknown/less-common RR types are round-tripped via a best-effort map in "data"; if a
    type is not implemented below, Marshal will include {"raw": "<presentation>"} and
    Unmarshal will parse it using NewRR.
  - Times in RRSIG use UNIX seconds per miekg/dns conventions.
