### PR TITLE
feat(edns0): Add zoneversion option from RFC9660

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ _all of them_
 - 9460 - SVCB and HTTPS Records
 - 9567 - DNS Error Reporting
 - 9606 - DNS Resolver Information
+- 9660 - DNS Zone Version (ZONEVERSION) Option
 - Draft - Compact Denial of Existence in DNSSEC
 
 ## Loosely Based Upon


### PR DESCRIPTION
This PR adds support for the DNS ZONEVERSION option as specified in [RFC 9660](https://www.ietf.org/archive/id/draft-ietf-dnsop-zoneversion-05.html). This option enables DNS clients to request, and authoritative DNS servers to provide, version information about the DNS zone used to generate the response.