### PR TITLE
provide a way to set socket options

### DIFF
--- a/server.go
+++ b/server.go
@@ -59,6 +59,12 @@ type ResponseWriter interface {
 	Hijack()
 }
 
+// Conner exposes the underlying connection and UDP session metadata when available.
+type Conner interface {
+	Conn() net.Conn
+	Session() *Session
+}
+
 // A ConnectionStater interface is used by a DNS Handler to access TLS connection state
 // when available.
 type ConnectionStater interface {
@@ -74,7 +80,7 @@ type response struct {
 	tsigProvider   TsigProvider
 	udp            net.PacketConn // i/o connection if UDP was used
 	tcp            net.Conn       // i/o connection if TCP was used
-	udpSession     *SessionUDP    // oob data to get egress interface right
+	udpSession     *Session       // oob data to get egress interface right
 	pcSession      net.Addr       // address to use when writing to a generic net.PacketConn
 	writer         Writer         // writer to output the raw DNS bits
 }
@@ -808,7 +814,7 @@ func (w *response) LocalAddr() net.Addr {
 func (w *response) RemoteAddr() net.Addr {
 	switch {
 	case w.udpSession != nil:
-		return w.udpSession.RemoteAddr()
+		return w.udpSession.Addr
 	case w.pcSession != nil:
 		return w.pcSession
 	case w.tcp != nil:
@@ -855,4 +861,20 @@ func (w *response) ConnectionState() *tls.ConnectionState {
 		return &t
 	}
 	return nil
+}
+
+// Conn exposes the underlying net.Conn when available. Callers should treat the returned
+// connection as read-only and must not close it.
+func (w *response) Conn() net.Conn {
+	if w.tcp != nil {
+		return w.tcp
+	}
+	if c, ok := w.udp.(net.Conn); ok {
+		return c
+	}
+	return nil
+}
+
+func (w *response) Session() *Session {
+	return w.udpSession
 }

--- a/session.go
+++ b/session.go
@@ -1,0 +1,12 @@
+package dns
+
+import "net"
+
+// Session captures per-packet metadata for UDP traffic handled by ResponseWriter.
+type Session struct {
+	Addr *net.UDPAddr
+	OOB  []byte
+}
+
+// SessionUDP is kept for backward compatibility with older code.
+type SessionUDP = Session

--- a/udp.go
+++ b/udp.go
@@ -26,31 +26,21 @@ var udpOOBSize = func() int {
 	return len(oob6)
 }()
 
-// SessionUDP holds the remote address and the associated
-// out-of-band data.
-type SessionUDP struct {
-	raddr   *net.UDPAddr
-	context []byte
-}
-
-// RemoteAddr returns the remote network address.
-func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
-
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
-func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
+func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *Session, error) {
 	oob := make([]byte, udpOOBSize)
 	n, oobn, _, raddr, err := conn.ReadMsgUDP(b, oob)
 	if err != nil {
 		return n, nil, err
 	}
-	return n, &SessionUDP{raddr, oob[:oobn]}, err
+	return n, &Session{Addr: raddr, OOB: oob[:oobn]}, err
 }
 
-// WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
-func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
-	oob := correctSource(session.context)
-	n, _, err := conn.WriteMsgUDP(b, oob, session.raddr)
+// WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *Session instead of a net.Addr.
+func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *Session) (int, error) {
+	oob := correctSource(session.OOB)
+	n, _, err := conn.WriteMsgUDP(b, oob, session.Addr)
 	return n, err
 }
 

--- a/udp_no_control.go
+++ b/udp_no_control.go
@@ -10,28 +10,20 @@ package dns
 
 import "net"
 
-// SessionUDP holds the remote address
-type SessionUDP struct {
-	raddr *net.UDPAddr
-}
-
-// RemoteAddr returns the remote network address.
-func (s *SessionUDP) RemoteAddr() net.Addr { return s.raddr }
-
 // ReadFromSessionUDP acts just like net.UDPConn.ReadFrom(), but returns a session object instead of a
 // net.UDPAddr.
-func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *SessionUDP, error) {
+func ReadFromSessionUDP(conn *net.UDPConn, b []byte) (int, *Session, error) {
 	n, raddr, err := conn.ReadFrom(b)
 	if err != nil {
 		return n, nil, err
 	}
-	return n, &SessionUDP{raddr.(*net.UDPAddr)}, err
+	return n, &Session{Addr: raddr.(*net.UDPAddr)}, err
 }
 
-// WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *SessionUDP instead of a net.Addr.
-func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *SessionUDP) (int, error) {
-	return conn.WriteTo(b, session.raddr)
+// WriteToSessionUDP acts just like net.UDPConn.WriteTo(), but uses a *Session instead of a net.Addr.
+func WriteToSessionUDP(conn *net.UDPConn, b []byte, session *Session) (int, error) {
+	return conn.WriteTo(b, session.Addr)
 }
 
 func setUDPSocketOptions(*net.UDPConn) error { return nil }
-func parseDstFromOOB([]byte, net.IP) net.IP  { return nil }
+func parseDstFromOOB([]byte) net.IP          { return nil }


### PR DESCRIPTION
## What

- ~~Allow 3rd parties to control socket options~~
- Provide a way to retrieve the OOB destination information
- Expose net.Conn, to be able to read unix.TCP_INFO

## How

- ~~Created a new listener param to set Control of net.ListenConfig~~
- ~~Exposed internal OOB state with a new `PacketConnState`~~
- Introduce parts of v2 dns that exposes a Session and Conn with the help of `Conner` interface

## Why

I need this change to allow my CoreDNS plugin to:
- ~~set the freebind socket option~~
- read the destination IP from OOB information when using freebind sockopts
- provide TCP RTT stats on linux by reading GetsockoptTCPInfo

If this gets accepted, I'll follow up with a PR in the CoreDNS repo for the socket control options 