### PR TITLE
MsgInvalidFunc: Make DefaultMsgInvalidFunc a variable.

### DIFF
--- a/server.go
+++ b/server.go
@@ -194,7 +194,9 @@ type DecorateWriter func(Writer) Writer
 // rejected (or ignored) by the MsgAcceptFunc, or passed to this function.
 type MsgInvalidFunc func(m []byte, err error)
 
-func DefaultMsgInvalidFunc(m []byte, err error) {}
+var DefaultMsgInvalidFunc MsgInvalidFunc = defaultMsgInvalidFunc
+
+func defaultMsgInvalidFunc(m []byte, err error) {}
 
 // A Server defines parameters for running an DNS server.
 type Server struct {


### PR DESCRIPTION
For parity with [DefaultMsgAcceptFunc](https://github.com/miekg/dns/blob/b39ef963336bc62108809fa7f08b734dd643b6fd/acceptfunc.go#L20) that is a variable.
