### PR TITLE
Fix fmt.Stringer for Question

### DIFF
--- a/types.go
+++ b/types.go
@@ -275,7 +275,7 @@ func (q *Question) len(off int, compression map[string]struct{}) int {
 	return l
 }
 
-func (q *Question) String() (s string) {
+func (q Question) String() (s string) {
 	// prefix with ; (as in dig)
 	s = ";" + sprintName(q.Name) + "\t"
 	s += Class(q.Qclass).String() + "\t"


### PR DESCRIPTION
Currently `fmt.Stringer` is implemented for `*dns.Question` but not `dns.Question`. This corrects `%v` formatting.