### PR TITLE
Make PackDomainName return error if the root label doesn't fit

### DIFF
--- a/msg_test.go
+++ b/msg_test.go
@@ -243,34 +243,6 @@ func TestPackDomainNameCompressionMap(t *testing.T) {
 	}
 }
 
-func TestPackDomainNameBufferSize(t *testing.T) {
-	for _, tt := range []struct {
-		name      string
-		input     string
-		bufSize   int
-		expectOff int
-		expectErr bool
-	}{
-		{"generous_buffer", "example.com.", 255, 13, false},
-		{"exact_fit", "example.com.", 13, 13, false},
-		{"err_write_last_label", "example.com.", 10, 10, true},
-		{"err_write_root_label", "example.com.", 12, 12, true},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			msg := make([]byte, tt.bufSize)
-			off, err := PackDomainName(tt.input, msg, 0, nil, false)
-			if off != tt.expectOff {
-				t.Errorf("wrong offset: expected %d, got %d", tt.expectOff, off)
-			}
-			if tt.expectErr && err == nil {
-				t.Errorf("expected error, got none")
-			} else if !tt.expectErr && err != nil {
-				t.Errorf("expected sucess, got error (%s)", err)
-			}
-		})
-	}
-}
-
 func TestPackDomainNameNSECTypeBitmap(t *testing.T) {
 	ownername := "some-very-long-ownername.com."
 	msg := &Msg{


### PR DESCRIPTION
At the moment, if the buffer provided to PackDomainName doesn't fit the trailing root label for the name, the function will skip writing the root label however it will return an adjusted offset and no error.

I believe this is a bug and not intentional behavior because it would be really confusing.

Here is a small reproducer:

```go
wire := make([]byte, 4)
off, err := dns.PackDomainName("foo.", wire, 0, nil, false)

fmt.Printf("off = %d, err = %s\n", off, err) // off = 5, err = <nil>

_ = wire[:off] // panic: runtime error: slice bounds out of range [:5] with capacity 4
```

I'm providing a fix that will make the function return an error if the buffer doesn't fit the root label. A unit test is included as well.