### PR TITLE
fix: clarify cloneSlice comment to explain shallow vs deep copy semantics

### DIFF
--- a/types.go
+++ b/types.go
@@ -1673,7 +1673,10 @@ func euiToString(eui uint64, bits int) (hex string) {
 	return
 }
 
-// cloneSlice returns a shallow copy of s.
+// cloneSlice returns a copy of the slice s with a new backing array.
+// The elements themselves are not deep-copied, so this is a shallow
+// copy. For slices of value types (e.g. []byte), this is effectively
+// a deep copy.
 func cloneSlice[E any, S ~[]E](s S) S {
 	if s == nil {
 		return nil


### PR DESCRIPTION
## Summary

- Fixes #1709 — the `cloneSlice` comment said "shallow copy" which was confusing since it's used in `Copy()` which advertises deep-copy semantics
- Updated the comment to explain that while the slice elements are not deep-copied (shallow copy), for slices of value types (e.g. `[]byte` as used by `net.IP`), this effectively produces a deep copy
- No behavior change, comment-only fix

## Test plan
- No code changes, only a doc comment update
- Verified the new comment accurately describes the function's behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)