### PR TITLE
packDomainName: Avoid using forward compression pointers

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -299,7 +299,7 @@ loop:
 					// where we need to insert the pointer later
 
 					// If compress is true, we're allowed to compress this dname
-					if compress {
+					if compress && p < off {
 						pointer = p // Where to point to
 						break loop
 					}


### PR DESCRIPTION
If compression map is reused after failed packDomainName, another call to packDomainName may refer stale forward pointers. This both violates RFC and leads to data corruption.

> If your PR introduces backward incompatible changes it will very likely not be merged.

If some code relies on external compression map to contain stale pointers after failed `packDomainName` it seems like a bug, rather than a compatibility problem.
