### PR TITLE
TXT: Fix incorrect estimated length of empty dns:"txt" fields

### DIFF
--- a/msg.go
+++ b/msg.go
@@ -457,7 +457,7 @@ func packTxt(txt []string, msg []byte, offset int) (int, error) {
 			return offset, ErrBuf
 		}
 		msg[offset] = 0
-		return offset, nil
+		return offset+1, nil
 	}
 	var err error
 	for _, s := range txt {

--- a/types_generate.go
+++ b/types_generate.go
@@ -182,6 +182,7 @@ func main() {
 				case `dns:"domain-name"`:
 					o("for _, x := range rr.%s { l += domainNameLen(x, off+l, compression, false) }\n")
 				case `dns:"txt"`:
+					o("if len(rr.%s) == 0 { l += 1 }\n")
 					o("for _, x := range rr.%s { l += len(x) + 1 }\n")
 				case `dns:"apl"`:
 					o("for _, x := range rr.%s { l += x.len() }\n")

--- a/ztypes.go
+++ b/ztypes.go
@@ -319,6 +319,9 @@ func (rr *APL) len(off int, compression map[string]struct{}) int {
 
 func (rr *AVC) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
+	if len(rr.Txt) == 0 {
+		l += 1
+	}
 	for _, x := range rr.Txt {
 		l += len(x) + 1
 	}
@@ -566,6 +569,9 @@ func (rr *NIMLOC) len(off int, compression map[string]struct{}) int {
 
 func (rr *NINFO) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
+	if len(rr.ZSData) == 0 {
+		l += 1
+	}
 	for _, x := range rr.ZSData {
 		l += len(x) + 1
 	}
@@ -627,6 +633,9 @@ func (rr *PX) len(off int, compression map[string]struct{}) int {
 
 func (rr *RESINFO) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
+	if len(rr.Txt) == 0 {
+		l += 1
+	}
 	for _, x := range rr.Txt {
 		l += len(x) + 1
 	}
@@ -699,6 +708,9 @@ func (rr *SOA) len(off int, compression map[string]struct{}) int {
 
 func (rr *SPF) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
+	if len(rr.Txt) == 0 {
+		l += 1
+	}
 	for _, x := range rr.Txt {
 		l += len(x) + 1
 	}
@@ -787,6 +799,9 @@ func (rr *TSIG) len(off int, compression map[string]struct{}) int {
 
 func (rr *TXT) len(off int, compression map[string]struct{}) int {
 	l := rr.Hdr.len(off, compression)
+	if len(rr.Txt) == 0 {
+		l += 1
+	}
 	for _, x := range rr.Txt {
 		l += len(x) + 1
 	}


### PR DESCRIPTION
As is `dns.Len` can incorrectly estimate length of RRs with dns:"txt" fields, such as TXT, because it does not take into account that `packTxt` writes `\x00' byte for empty strings:

https://github.com/miekg/dns/blob/d1539a788a12830620381c4cc6617762994f3fa1/msg.go#L455-L460