### PR TITLE
MD5: remove keytag calculation

### DIFF
--- a/dnssec.go
+++ b/dnssec.go
@@ -12,7 +12,6 @@ import (
 	_ "crypto/sha256" // need its init function
 	_ "crypto/sha512" // need its init function
 	"encoding/asn1"
-	"encoding/binary"
 	"encoding/hex"
 	"math/big"
 	"sort"
@@ -134,38 +133,27 @@ func (k *DNSKEY) KeyTag() uint16 {
 		return 0
 	}
 	var keytag int
-	switch k.Algorithm {
-	case RSAMD5:
-		// This algorithm has been deprecated, but keep this key-tag calculation.
-		// Look at the bottom two bytes of the modules, which the last item in the pubkey.
-		// See https://www.rfc-editor.org/errata/eid193 .
-		modulus, _ := fromBase64([]byte(k.PublicKey))
-		if len(modulus) > 1 {
-			x := binary.BigEndian.Uint16(modulus[len(modulus)-3:])
-			keytag = int(x)
-		}
-	default:
-		keywire := new(dnskeyWireFmt)
-		keywire.Flags = k.Flags
-		keywire.Protocol = k.Protocol
-		keywire.Algorithm = k.Algorithm
-		keywire.PublicKey = k.PublicKey
-		wire := make([]byte, DefaultMsgSize)
-		n, err := packKeyWire(keywire, wire)
-		if err != nil {
-			return 0
-		}
-		wire = wire[:n]
-		for i, v := range wire {
-			if i&1 != 0 {
-				keytag += int(v) // must be larger than uint32
-			} else {
-				keytag += int(v) << 8
-			}
-		}
-		keytag += keytag >> 16 & 0xFFFF
-		keytag &= 0xFFFF
+	keywire := new(dnskeyWireFmt)
+	keywire.Flags = k.Flags
+	keywire.Protocol = k.Protocol
+	keywire.Algorithm = k.Algorithm
+	keywire.PublicKey = k.PublicKey
+	wire := make([]byte, DefaultMsgSize)
+	n, err := packKeyWire(keywire, wire)
+	if err != nil {
+		return 0
 	}
+	wire = wire[:n]
+	for i, v := range wire {
+		if i&1 != 0 {
+			keytag += int(v) // must be larger than uint32
+		} else {
+			keytag += int(v) << 8
+		}
+	}
+	keytag += keytag >> 16 & 0xFFFF
+	keytag &= 0xFFFF
+
 	return uint16(keytag)
 }
 

--- a/dnssec_test.go
+++ b/dnssec_test.go
@@ -978,16 +978,3 @@ func TestParseKeyReadError(t *testing.T) {
 		t.Errorf("expected a nil map, but got %v", m)
 	}
 }
-
-func TestRSAMD5KeyTag(t *testing.T) {
-	rr1, _ := NewRR("test.  IN DNSKEY  257 3 1 AwEAAcntNdoMnY8pvyPcpDTAaiqHyAhf53XUBANq166won/fjBFvmuzhTuP5r4el/pV0tzEBL73zpoU48BqF66uiL+qRijXCySJiaBUvLNll5rpwuduAOoVpmwOmkC4fV6izHOAx/Uy8c+pYP0YR8+1P7GuTFxgnMmt9sUGtoe+la0X/ ;{id = 27461 (ksk), size = 1024b}")
-	rr2, _ := NewRR("test.  IN DNSKEY  257 3 1 AwEAAf0bKO/m45ylk5BlSLmQHQRBLx1m/ZUXvyPFB387bJXxnTk6so3ub97L1RQ+8bOoiRh3Qm5EaYihjco7J8b/W5WbS3tVsE79nY584RfTKT2zcZ9AoFP2XLChXxPIf/6l0H9n6sH0aBjsG8vabEIp8e06INM3CXVPiMRPPeGNa0Ub ;{id = 27461 (ksk), size = 1024b}")
-
-	exp := uint16(27461)
-	if x := rr1.(*DNSKEY).KeyTag(); x != exp {
-		t.Errorf("expected %d, got %d, as keytag for rr1", exp, x)
-	}
-	if x := rr2.(*DNSKEY).KeyTag(); x != exp { // yes, same key tag
-		t.Errorf("expected %d, got %d, as keytag for rr2", exp, x)
-	}
-}


### PR DESCRIPTION
Thanks for you pull request, do note the following:

- If your PR introduces backward incompatible changes it will very likely not be merged.

- We support the last two major Go versions, if your PR uses features from a too new Go version, it
  will not be merged.

- If this text is not replaced (deleted, or preferably replaced with something sensible), your PR will be closed.
